### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,4 +1,6 @@
 name: Elixir
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/fancydrones/xmavlink/security/code-scanning/4](https://github.com/fancydrones/xmavlink/security/code-scanning/4)

To address the issue, you should add a `permissions` block to the workflow, to restrict the GITHUB_TOKEN to the least necessary privileges. Since the workflow shown only needs to check out code and does not appear to perform any write operations (to commits, pull requests, issues, etc.), the minimal required permission is `contents: read`. The permissions block can be added at the root level (affecting all jobs), or at the job level. For clarity and security, it is preferable to add this block at the root of the workflow (just below the `name:` line, before `on:`).

**Steps:**  
- Edit `.github/workflows/elixir.yml`
- Insert the following lines after `name: Elixir` (line 1):

```yaml
permissions:
  contents: read
```

- No other modifications are required; functionality is unchanged but security is improved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
