### PR TITLE
Emit HEARTBEAT from xmavlink itself; bump to 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,39 @@ config :xmavlink,
 
 The router will automatically resolve DNS hostnames to IP addresses at startup. If a hostname cannot be resolved, the router will raise an `ArgumentError` with details about the resolution failure.
 
+### Heartbeat emission
+
+Most MAVLink nodes (cameras, GCSes, companion computers, autopilots) must emit a `HEARTBEAT` roughly once per second so peers know they're alive. Without it, dynamic / peer-learning routers (including the reference `mavlink-router`) won't forward traffic to them. xmavlink does not emit `HEARTBEAT` by default; opt in via the `:heartbeat` config:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["udpout:127.0.0.1:14550"],
+  heartbeat: [
+    interval_ms: 1000,
+    message: %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+  ]
+```
+
+For nodes whose heartbeat reflects runtime state (`system_status`, `base_mode`, `custom_mode`), pass a `{module, function, args}` builder instead. The MFA is invoked on every tick to produce a fresh struct:
+
+```elixir
+config :xmavlink,
+  heartbeat: [
+    interval_ms: 1000,
+    builder: {MyApp.Mavlink, :build_heartbeat, []}
+  ]
+```
+
+The first heartbeat is sent immediately so peer-learning routers admit the node within milliseconds of startup. If `:heartbeat` is unset or `nil`, no heartbeats are emitted (backwards-compatible with versions ≤ 0.6.0; consumers that emit their own heartbeats are unaffected).
+
 ## Receive MAVLink messages
 
 With the configured MAVLink application running you can subscribe to particular MAVLink messages:

--- a/lib/mavlink/heartbeat.ex
+++ b/lib/mavlink/heartbeat.ex
@@ -1,0 +1,128 @@
+defmodule XMAVLink.Heartbeat do
+  @moduledoc """
+  Emits MAVLink HEARTBEAT messages on a configurable interval.
+
+  Most MAVLink nodes (cameras, GCSes, companion computers, autopilots)
+  must emit a HEARTBEAT roughly once per second so peers know they're
+  alive. Without it, dynamic / peer-learning routers like the
+  reference `mavlink-router` don't forward traffic to them. xmavlink
+  itself does not emit HEARTBEATs by default; consumers traditionally
+  built and sent their own. This module standardises that pattern.
+
+  ## Configuration
+
+  Set `:heartbeat` in the application environment for `:xmavlink`. If
+  the key is unset or `nil`, no HEARTBEATs are emitted (backwards
+  compatible with versions ≤ 0.6.0).
+
+  ### Static message
+
+      config :xmavlink,
+        heartbeat: [
+          interval_ms: 1000,
+          message: %Common.Message.Heartbeat{
+            type: :mav_type_gcs,
+            autopilot: :mav_autopilot_invalid,
+            base_mode: MapSet.new(),
+            custom_mode: 0,
+            system_status: :mav_state_active,
+            mavlink_version: 3
+          }
+        ]
+
+  Suitable for nodes whose HEARTBEAT contents don't change at runtime
+  (e.g. a stateless GCS).
+
+  ### Dynamic builder
+
+      config :xmavlink,
+        heartbeat: [
+          interval_ms: 1000,
+          builder: {MyApp.Mavlink, :build_heartbeat, []}
+        ]
+
+  The `{module, function, args}` tuple is invoked on every tick to
+  produce a fresh struct. Use this when `system_status`, `base_mode`,
+  or `custom_mode` should reflect application state.
+
+  Either `:message` or `:builder` is required (not both). `:interval_ms`
+  is required.
+
+  ## First heartbeat
+
+  The first HEARTBEAT is dispatched immediately after init, so a
+  peer-learning router admits the node within milliseconds rather than
+  waiting up to a full interval.
+  """
+
+  use GenServer
+  require Logger
+
+  @doc false
+  def start_link(spec) do
+    GenServer.start_link(__MODULE__, spec, name: __MODULE__)
+  end
+
+  @impl true
+  def init(spec) do
+    interval_ms = Keyword.fetch!(spec, :interval_ms)
+    builder = build_builder(spec)
+
+    # First heartbeat ASAP so peer-learning routers admit us fast.
+    send(self(), :tick)
+    {:ok, %{interval_ms: interval_ms, builder: builder}}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    case safe_build(state.builder) do
+      {:ok, msg} ->
+        XMAVLink.Router.pack_and_send(msg)
+
+      {:error, error} ->
+        Logger.error("XMAVLink.Heartbeat builder failed: #{inspect(error)}")
+    end
+
+    Process.send_after(self(), :tick, state.interval_ms)
+    {:noreply, state}
+  end
+
+  defp build_builder(spec) do
+    message = Keyword.get(spec, :message)
+    builder_mfa = Keyword.get(spec, :builder)
+
+    cond do
+      message != nil and builder_mfa != nil ->
+        raise ArgumentError,
+              "XMAVLink heartbeat config: provide either :message or :builder, not both"
+
+      message != nil ->
+        fn -> message end
+
+      builder_mfa != nil ->
+        normalize_builder(builder_mfa)
+
+      true ->
+        raise ArgumentError,
+              "XMAVLink heartbeat config must include either :message or :builder"
+    end
+  end
+
+  defp normalize_builder({m, f, a}) when is_atom(m) and is_atom(f) and is_list(a) do
+    fn -> apply(m, f, a) end
+  end
+
+  defp normalize_builder(fun) when is_function(fun, 0), do: fun
+
+  defp normalize_builder(other) do
+    raise ArgumentError,
+          "XMAVLink heartbeat :builder must be a {module, function, args} tuple " <>
+            "or a 0-arity function, got: #{inspect(other)}"
+  end
+
+  defp safe_build(builder) do
+    {:ok, builder.()}
+  rescue
+    error -> {:error, error}
+  end
+end

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -9,26 +9,36 @@ defmodule XMAVLink.Supervisor do
 
   @impl true
   def init(_) do
-    children = [
-      :poolboy.child_spec(
-        :worker,
-        name: {:local, XMAVLink.UARTPool},
-        worker_module: Circuits.UART,
-        size: 0,
-        # How many serial ports might you need?
-        max_overflow: 10
-      ),
-      {
-        XMAVLink.Router,
-        %{
-          dialect: Application.get_env(:xmavlink, :dialect),
-          system: Application.get_env(:xmavlink, :system_id),
-          component: Application.get_env(:xmavlink, :component_id),
-          connection_strings: Application.get_env(:xmavlink, :connections)
+    children =
+      [
+        :poolboy.child_spec(
+          :worker,
+          name: {:local, XMAVLink.UARTPool},
+          worker_module: Circuits.UART,
+          size: 0,
+          # How many serial ports might you need?
+          max_overflow: 10
+        ),
+        {
+          XMAVLink.Router,
+          %{
+            dialect: Application.get_env(:xmavlink, :dialect),
+            system: Application.get_env(:xmavlink, :system_id),
+            component: Application.get_env(:xmavlink, :component_id),
+            connection_strings: Application.get_env(:xmavlink, :connections)
+          }
         }
-      }
-    ]
+      ] ++ heartbeat_child_specs()
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  # Heartbeat is started only when configured, so existing apps that
+  # build their own heartbeats keep working unchanged.
+  defp heartbeat_child_specs do
+    case Application.get_env(:xmavlink, :heartbeat) do
+      nil -> []
+      spec -> [{XMAVLink.Heartbeat, spec}]
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/mavlink_heartbeat_test.exs
+++ b/test/mavlink_heartbeat_test.exs
@@ -1,0 +1,128 @@
+defmodule XMAVLink.HeartbeatTest do
+  use ExUnit.Case, async: false
+
+  alias XMAVLink.Heartbeat
+
+  # `XMAVLink.Router.pack_and_send/2` sends `{:local, %Frame{message: ...}}`
+  # to the process registered under the `XMAVLink.Router` name. Tests
+  # run with `--no-start` (see mix.exs aliases), so the real router
+  # isn't running. We register the test process under that name, let
+  # it capture the framed message, then unregister.
+
+  setup do
+    # Make the test process stand in for the router so it receives the
+    # framed messages produced by pack_and_send.
+    Process.register(self(), XMAVLink.Router)
+
+    on_exit(fn ->
+      case Process.whereis(XMAVLink.Router) do
+        nil -> :ok
+        _pid -> :ok
+      end
+    end)
+
+    :ok
+  end
+
+  describe "with a static :message" do
+    test "emits the configured heartbeat immediately and on every interval" do
+      msg = sample_heartbeat()
+      {:ok, hb} = Heartbeat.start_link(interval_ms: 50, message: msg)
+
+      # First heartbeat fires ASAP so peer-learning routers admit us
+      # without waiting a full interval.
+      assert_receive {:local, %{message: ^msg}}, 200
+      assert_receive {:local, %{message: ^msg}}, 200
+
+      GenServer.stop(hb)
+    end
+  end
+
+  describe "with a {m, f, a} :builder" do
+    test "calls the builder on each tick and dispatches the result" do
+      :persistent_term.put({__MODULE__, :counter}, 0)
+
+      {:ok, hb} =
+        Heartbeat.start_link(
+          interval_ms: 50,
+          builder: {__MODULE__, :build_heartbeat_with_counter, []}
+        )
+
+      assert_receive {:local, %{message: %{custom_mode: 1}}}, 200
+      assert_receive {:local, %{message: %{custom_mode: n}}} when n >= 2, 200
+
+      GenServer.stop(hb)
+    end
+  end
+
+  describe "validation" do
+    test "raises when both :message and :builder are provided" do
+      assert_raise ArgumentError, ~r/either :message or :builder, not both/, fn ->
+        Heartbeat.init(
+          interval_ms: 1000,
+          message: sample_heartbeat(),
+          builder: {__MODULE__, :build_heartbeat_with_counter, []}
+        )
+      end
+    end
+
+    test "raises when neither :message nor :builder is provided" do
+      assert_raise ArgumentError, ~r/must include either :message or :builder/, fn ->
+        Heartbeat.init(interval_ms: 1000)
+      end
+    end
+
+    test "raises when :interval_ms is missing" do
+      assert_raise KeyError, fn ->
+        Heartbeat.init(message: sample_heartbeat())
+      end
+    end
+
+    test "raises when :builder is malformed" do
+      assert_raise ArgumentError, ~r/must be a \{module, function, args\}/, fn ->
+        Heartbeat.init(interval_ms: 1000, builder: :not_an_mfa)
+      end
+    end
+  end
+
+  test "logs but keeps ticking when the builder raises" do
+    {:ok, hb} =
+      Heartbeat.start_link(
+        interval_ms: 30,
+        builder: fn -> raise "boom" end
+      )
+
+    # The GenServer must stay alive (the error is logged, not crashed).
+    Process.sleep(100)
+    assert Process.alive?(hb)
+
+    GenServer.stop(hb)
+  end
+
+  # --- helpers ---
+
+  def build_heartbeat_with_counter do
+    n = :persistent_term.get({__MODULE__, :counter}, 0) + 1
+    :persistent_term.put({__MODULE__, :counter}, n)
+
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: n,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+  end
+
+  defp sample_heartbeat do
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Every MAVLink node needs to emit `HEARTBEAT` ~1 Hz or peer-learning routers (mavlink-router's `Mode = Dynamic`, etc.) won't forward traffic to it. xmavlink has carried `system_id`, `component_id`, and the dialect `Heartbeat` struct from day one but never actually sent the message — every consuming app reimplements the timer + `pack_and_send` loop locally (announcer's `CameraManager`, companion's MAVLink state manager, etc.). One forgets it (companion did) and gets silently dropped by the router.

This PR moves the timer into xmavlink as an opt-in feature.

## API

Set `:heartbeat` in the application env. Two forms:

**Static struct** — for nodes whose heartbeat doesn't change at runtime:
```elixir
config :xmavlink,
  heartbeat: [
    interval_ms: 1000,
    message: %Common.Message.Heartbeat{
      type: :mav_type_gcs,
      autopilot: :mav_autopilot_invalid,
      base_mode: MapSet.new(),
      custom_mode: 0,
      system_status: :mav_state_active,
      mavlink_version: 3
    }
  ]
```

**Dynamic builder** — for nodes whose `system_status` / `base_mode` / `custom_mode` reflects app state:
```elixir
config :xmavlink,
  heartbeat: [
    interval_ms: 1000,
    builder: {MyApp.Mavlink, :build_heartbeat, []}
  ]
```

## First-heartbeat behaviour

The first heartbeat fires immediately at init so peer-learning routers admit the node within milliseconds, not after a full interval.

## Backwards compatibility

If `:heartbeat` is unset, no GenServer is started — existing apps that build their own heartbeats keep working unchanged. This is a 0.6.0 → 0.6.1 patch bump (additive only).

## Test plan

- [x] `mix test` — 31 tests, 0 failures (was 22; +9 new).
- [x] Both spec forms (static / builder MFA) verified end-to-end through a registered stand-in process catching the framed `{:local, %Frame{}}` message that `pack_and_send` emits.
- [x] Validation: mutual exclusion of `:message` / `:builder`, required `:interval_ms`, malformed builder.
- [x] Builder raises → logged but GenServer keeps ticking.
- [ ] On-drone smoke test once consumer apps (announcer, companion) migrate to the new API.