### PR TITLE
UDPOut: attribute reply traffic by socket, not source IP — fixes NAT echo loop (0.6.2)

### DIFF
--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -305,16 +305,32 @@ defmodule XMAVLink.Router do
       ) do
     {
       :noreply,
-      case connections[{socket, address, port}] do
-        connection = %UDPInConnection{} ->
-          UDPInConnection.handle_info(message, connection, dialect)
+      case connections[socket] do
+        # A `udpout:` connection is registered under the bare `socket` key
+        # (see UDPOutConnection.connect/2). Any UDP packet arriving on that
+        # socket is a reply to our outbound traffic — attribute it to the
+        # UDPOut regardless of source IP. This is required behind NAT /
+        # masquerade / kube-proxy DNAT, where the reply's source IP is the
+        # NAT gateway rather than the address we sent to. Without this,
+        # we'd file the reply as a brand-new UDPInConnection under
+        # `{socket, reply_ip, reply_port}` and the broadcast `route/1`
+        # clause would forward subsequent inbound frames back out the
+        # original UDPOut — i.e. echo the host's traffic back to itself.
+        udpout = %UDPOutConnection{} ->
+          UDPOutConnection.handle_info(message, udpout, dialect)
 
-        connection = %UDPOutConnection{} ->
-          UDPOutConnection.handle_info(message, connection, dialect)
+        _ ->
+          case connections[{socket, address, port}] do
+            connection = %UDPInConnection{} ->
+              UDPInConnection.handle_info(message, connection, dialect)
 
-        nil ->
-          # New previously unseen UDPIn client
-          UDPInConnection.handle_info(message, nil, dialect)
+            connection = %UDPOutConnection{} ->
+              UDPOutConnection.handle_info(message, connection, dialect)
+
+            nil ->
+              # New previously unseen UDPIn client
+              UDPInConnection.handle_info(message, nil, dialect)
+          end
       end
       |> update_route_info(state)
       |> route

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -31,22 +31,26 @@ defmodule XMAVLink.UDPOutConnection do
       :not_a_frame ->
         # Noise or malformed frame
         :ok = Logger.debug("UDPOutConnection.handle_info: Not a frame #{inspect(raw)}")
-        {:error, :not_a_frame, {socket, source_addr, source_port}, receiving_connection}
+        {:error, :not_a_frame, socket, receiving_connection}
 
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
         case validate_and_unpack(received_frame, dialect) do
           {:ok, valid_frame} ->
-            # Include address and port in connection key because multiple
-            # clients can connect to a UDP "in" port.
-            {:ok, {socket, source_addr, source_port}, receiving_connection, valid_frame}
+            # A udpout connection is single-target, single-socket. Key it by
+            # the bare `socket` so update_route_info/2 updates the existing
+            # connection entry rather than creating a sibling under
+            # `{socket, source_addr, source_port}` — which would cause the
+            # broadcast `route/1` clause to forward back out the same UDPOut
+            # (echo) when the reply's source IP differs from the configured
+            # target (NAT / masquerade / kube-proxy DNAT).
+            {:ok, socket, receiving_connection, valid_frame}
 
           :unknown_message ->
             # We re-broadcast valid frames with unknown messages
             :ok = Logger.debug("relaying unknown message with id #{received_frame.message_id}}")
 
-            {:ok, {socket, source_addr, source_port}, receiving_connection,
-             struct(received_frame, target: :broadcast)}
+            {:ok, socket, receiving_connection, struct(received_frame, target: :broadcast)}
 
           reason ->
             :ok =
@@ -55,7 +59,7 @@ defmodule XMAVLink.UDPOutConnection do
                   "#{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port} failed: #{Atom.to_string(reason)}"
               )
 
-            {:error, reason, {socket, source_addr, source_port}, receiving_connection}
+            {:error, reason, socket, receiving_connection}
         end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.6.1",
+      version: "0.6.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -132,6 +132,91 @@ defmodule XMAVLink.Test.Router do
     end
   end
 
+  describe "udpout reply handling" do
+    # Regression for the NAT-mismatch echo loop: when a `udpout:` connection's
+    # reply arrives from a source IP that differs from the configured target
+    # (because NAT, masquerade, kube-proxy DNAT, or multipath routing
+    # rewrote the reply's source), the router previously filed it as a
+    # brand-new UDPInConnection at `{socket, reply_ip, reply_port}`. The
+    # broadcast clause of `route/1` would then forward subsequent inbound
+    # frames back out the original UDPOut — i.e. echo the host's traffic
+    # back to itself, producing a sustained sub-millisecond loop with the
+    # peer. Fixed by always attributing inbound on a UDPOut's socket to
+    # that UDPOut, regardless of source IP.
+    test "reply from a NAT'd source IP is attributed to the existing UDPOut, not filed as a phantom UDPInConnection" do
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:14556"]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        if Process.whereis(XMAVLink.SubscriptionCache) do
+          Agent.update(XMAVLink.SubscriptionCache, fn _ -> [] end)
+        end
+      end)
+
+      # The UDPOut is added asynchronously by the spawned connect/2 process,
+      # so wait until it lands in `connections`.
+      socket = wait_for_udpout_socket(router_pid)
+
+      # Real HEARTBEAT bytes (msg_id 0) packed under Common: sysid=1,
+      # compid=100, custom_mode=0, mav_type_quadrotor, autopilot=invalid,
+      # mav_state_active. CRC validates under Common.
+      raw_heartbeat =
+        <<0xFD, 0x09, 0x00, 0x00, 0x0F, 0x01, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x1E, 0x00, 0x00, 0x03, 0x03, 0xC3, 0xBC>>
+
+      # Reply arrives with a source IP different from the configured
+      # target (127.0.0.1) — simulates NAT.
+      fake_reply_ip = {10, 42, 0, 1}
+      fake_reply_port = 14556
+
+      send(router_pid, {:udp, socket, fake_reply_ip, fake_reply_port, raw_heartbeat})
+
+      # `:sys.get_state/1` is synchronous — by the time it returns, the
+      # `:udp` message has been processed.
+      state = :sys.get_state(router_pid)
+
+      refute Map.has_key?(state.connections, {socket, fake_reply_ip, fake_reply_port}),
+             "router filed a phantom UDPInConnection for the NAT'd reply " <>
+               "(would cause echo loop in production)"
+
+      assert match?(%XMAVLink.UDPOutConnection{}, state.connections[socket]),
+             "expected the UDPOut to remain registered under the bare socket key"
+
+      GenServer.stop(router_pid)
+    end
+
+    defp wait_for_udpout_socket(router_pid, attempts \\ 50) do
+      state = :sys.get_state(router_pid)
+
+      udpout =
+        Enum.find(state.connections, fn
+          {key, %XMAVLink.UDPOutConnection{}} when is_port(key) -> true
+          _ -> false
+        end)
+
+      cond do
+        udpout != nil ->
+          {socket, _} = udpout
+          socket
+
+        attempts > 0 ->
+          Process.sleep(20)
+          wait_for_udpout_socket(router_pid, attempts - 1)
+
+        true ->
+          flunk("UDPOut connection didn't materialize within timeout")
+      end
+    end
+  end
+
   describe "subscribe/1" do
     test "is synchronous - subscription is committed when call returns" do
       {:ok, pid} =


### PR DESCRIPTION
Resolves #16.

## Summary

When a \`udpout:host:port\` connection's reply arrives with a source IP that differs from the configured target — because of NAT, masquerade, kube-proxy DNAT, or multipath routing — the router previously filed it as a brand-new \`UDPInConnection\` keyed by \`{socket, reply_ip, reply_port}\`. The broadcast clause of \`route/1\` would then forward subsequent inbound frames back out the original UDPOut — i.e. **echo the host's traffic back to itself**, producing a sub-millisecond ping-pong loop with the peer.

## Reproduction

Behind Kubernetes kube-proxy DNAT with \`hostNetwork: true\` on the receiving end, replies arrive from the cni0 gateway IP rather than the resolved ClusterIP. Two consumers on different router endpoints amplified each other's echoes into a sustained **~6000 pps flood** at the FMU on our drone (downstream issue: [fancydrones/x500-cm5#47](https://github.com/fancydrones/x500-cm5/issues/47), [#48](https://github.com/fancydrones/x500-cm5/issues/48)).

Outside Kubernetes, any setup where outbound and reply pass through a NAT / masquerade gateway, or where the peer binds to \`0.0.0.0\` and the kernel picks a different egress IP for the reply, would hit the same symptom.

## Fix

\`UDPOut\` sockets are single-target by design (\`UDPOutConnection.connect/2\` does \`:gen_udp.open(0, ...)\` and the connection is registered under the bare \`socket\` key). Anything inbound on such a socket is reply traffic to our outbound — there is no legitimate "new client" case. So:

1. **\`Router.handle_info({:udp, socket, address, port, _}, state)\`** — first checks \`connections[socket]\`. If that's a \`%UDPOutConnection{}\`, the packet is attributed to it regardless of source IP. Falls back to the existing 3-tuple-based UDPIn lookup otherwise.

2. **\`UDPOutConnection.handle_info/3\`** — now returns the bare \`socket\` as the connection key (matching how \`connect/2\` registers it). Without this, \`update_route_info/2\` would put a duplicate entry at \`{socket, source_addr, source_port}\`, causing the same UDPOut to be iterated twice in \`route/1\` (and the second iteration is no longer the "source", so it gets the frame — same echo path through a different door).

\`UDPIn\` behavior is unchanged: those sockets still admit per-\`(ip, port)\` clients keyed by 3-tuple, via the fallback branch.

## Test

Regression test in \`test/mavlink_router_test.exs\` (\`describe "udpout reply handling"\`):

- Starts a router with a \`udpout:127.0.0.1:14556\` connection.
- Captures the UDPOut's socket from \`:sys.get_state/1\`.
- Injects a synthetic \`{:udp, socket, {10, 42, 0, 1}, 14556, valid_heartbeat_bytes}\` (NAT'd reply IP).
- Asserts \`state.connections\` does **not** contain the \`{socket, 10.42.0.1, 14556}\` 3-tuple key.
- Asserts the original UDPOut entry under \`socket\` is still there.

Existing 31 tests still pass.

## Version bump

\`mix.exs\` → \`0.6.2\`. Patch-level: pure bug fix, no API surface changes, fully backwards-compatible for non-NAT topologies.

## Test plan

- [x] \`mix test\` passes (32 tests, 0 failures)
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix format\` applied
- [ ] Once published to Hex 0.6.2, verify on the affected drone deployment that the multi-hop flood collapses (see x500-cm5#47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)