### PR TITLE
Source-exclusion on the targeted route clause — fixes residual TIMESYNC echo (0.6.3)

### DIFF
--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -559,10 +559,18 @@ defmodule XMAVLink.Router do
     state
   end
 
-  # Only send targeted messages to observed system/components and local
+  # Only send targeted messages to observed system/components and local.
+  # Excludes the source connection so we never echo a frame back to the
+  # connection we received it from — symmetric with the broadcast clause
+  # above. Without this, a frame received via udpout from sysid=N gets
+  # the route `routes[{N, _}] = source_socket` registered, then any
+  # targeted frame with target_system=0 (wildcard) — e.g. TIMESYNC,
+  # which the dialect classifies as `:system_component` even with target
+  # fields set to 0 — would have the source-socket connection in
+  # recipients and forward back out the udpout.
   # Log warning if a message sent locally cannot reach its remote destination
   defp route(
-         {:ok, _,
+         {:ok, source_connection_key,
           frame = %Frame{
             source_system: source_system,
             source_component: source_component,
@@ -571,7 +579,9 @@ defmodule XMAVLink.Router do
             message: %{__struct__: message_type}
           }, state = %Router{connections: connections}}
        ) do
-    recipients = matching_system_components(target_system, target_component, state)
+    recipients =
+      matching_system_components(target_system, target_component, state)
+      |> Enum.reject(fn key -> key == source_connection_key end)
 
     if match?(
          {^recipients, ^source_system, ^source_component},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -193,6 +193,74 @@ defmodule XMAVLink.Test.Router do
       GenServer.stop(router_pid)
     end
 
+    # Regression for the secondary echo path: even after the broadcast-clause
+    # fix above, a frame whose dialect classification is `:system_component`
+    # (e.g. TIMESYNC, msg_id 111) goes through the *targeted* `route/1`
+    # clause. That clause computes recipients via `matching_system_components`
+    # which always includes `:local` and any connection in `routes` that
+    # matches the target. With `target_system=0` (wildcard, as PX4's
+    # TIMESYNC sends), every entry in `routes` matches — including the
+    # UDPOut socket the frame just arrived on (because we just registered
+    # `routes[{source_system, source_component}] = source_connection_key`).
+    # Without source-exclusion, the targeted clause would forward the frame
+    # back out the same UDPOut, producing the same echo as the broadcast
+    # path did before 0.6.2.
+    test "TIMESYNC reply is not echoed back via the udpout (regression: targeted route clause source-exclusion)" do
+      # A real UDP listener stands in for the peer the udpout would forward
+      # to. If the router echoes the frame, bytes arrive at this socket
+      # and we'll detect it via `assert_receive`/`refute_receive`.
+      {:ok, trap_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, trap_port} = :inet.port(trap_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:#{trap_port}"]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(trap_socket)
+
+        if Process.whereis(XMAVLink.SubscriptionCache) do
+          Agent.update(XMAVLink.SubscriptionCache, fn _ -> [] end)
+        end
+      end)
+
+      udpout_socket = wait_for_udpout_socket(router_pid)
+
+      # TIMESYNC v2 frame from sysid=1/compid=1 (PX4-style): msg_id 111,
+      # target_system=0, target_component=0. CRC validates under Common.
+      # Captured from a production xmavlink emitter.
+      raw_timesync =
+        <<0xFD, 0x0D, 0x00, 0x00, 0x37, 0x01, 0x01, 0x6F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0xF8, 0x17, 0xE4, 0x36, 0x1B, 0x14, 0x31>>
+
+      # Inject as if the reply arrived from a NAT'd source IP. The
+      # specific IP doesn't matter for the targeted-clause echo bug —
+      # what matters is that `routes[{1,1}]` ends up pointing at the
+      # udpout_socket, which it does as soon as we attribute the frame
+      # to the UDPOut.
+      fake_reply_ip = {10, 42, 0, 1}
+      send(router_pid, {:udp, udpout_socket, fake_reply_ip, trap_port, raw_timesync})
+
+      # Sync with the router process.
+      _state = :sys.get_state(router_pid)
+
+      # If the router echoes, the trap socket's controlling process
+      # (us) receives a `{:udp, _, _, _, _}` message. With the
+      # source-exclusion fix in place, no echo should fire.
+      refute_receive {:udp, ^trap_socket, _, _, _},
+                     100,
+                     "router echoed a :system_component-classified frame back via the udpout"
+
+      GenServer.stop(router_pid)
+    end
+
     defp wait_for_udpout_socket(router_pid, attempts \\ 50) do
       state = :sys.get_state(router_pid)
 


### PR DESCRIPTION
## Summary

0.6.2 fixed the **broadcast-clause** echo for frames the dialect classifies as \`:broadcast\` (HEARTBEAT, ATTITUDE, GLOBAL_POSITION_INT, etc.). But frames classified \`:system\`, \`:system_component\`, or \`:component\` (e.g. **TIMESYNC**, msg_id 111 — \`:system_component\` in xmavlink's Common dialect) go through the *targeted* clause of \`route/1\`, which has no source-exclusion. So they still echo.

This PR adds the same source-exclusion to the targeted clause and bumps to 0.6.3.

## How the residual echo manifests

\`matching_system_components/3\` always prepends \`:local\` and adds every \`routes\` entry whose \`{system, component}\` key matches the target. PX4's TIMESYNC arrives with \`target_system = 0\` (wildcard) — under that wildcard, every \`routes\` entry matches.

Just before \`route/1\` runs, \`update_route_info/2\` registered \`routes[{source_system, source_component}] = source_connection_key\` — i.e. the UDPOut socket the frame just arrived on. So:

\`\`\`
recipients = [:local, source_socket]
forward(connections[source_socket], frame)  # echoes back via UDPOut
\`\`\`

Captured in production after 0.6.2 deployed: companion + announcer (both behind kube-proxy DNAT, both pulling 0.6.2) emitted **identical TIMESYNC bytes** (seq=0x37, sysid=1, compid=1, msg_id=0x6f) to the router 87µs apart. They were each echoing PX4's TIMESYNC at PX4's send rate.

## Fix

Bind the source connection key in the targeted-clause head and \`Enum.reject\` it from \`recipients\`:

\`\`\`elixir
defp route(
       {:ok, source_connection_key,
        frame = %Frame{...}, state = %Router{connections: connections}}
     ) do
  recipients =
    matching_system_components(target_system, target_component, state)
    |> Enum.reject(fn key -> key == source_connection_key end)
  ...
end
\`\`\`

Symmetric with the broadcast clause's existing source-exclusion. \`pack_and_send\` from \`:local\` is unaffected — recipients drops \`:local\` and forwards to actual targets, which is the correct behavior (local subscribers already received the frame via the LocalConnection path).

## Test

\`describe "udpout reply handling"\` gets a second test:

- Sets up a real UDP listener on a free ephemeral port.
- Starts a router with a \`udpout:127.0.0.1:<trap_port>\` connection.
- Injects a \`{:udp, udpout_socket, {10, 42, 0, 1}, trap_port, real_timesync_bytes}\` (NAT'd reply, dialect-classified \`:system_component\`).
- \`refute_receive {:udp, ^trap_socket, _, _, _}, 100\` — if the router echoes via UDPOut, the trap listener receives a packet and the test fails.

\`mix test\` passes 33/33 (32 from 0.6.2, +1 for this regression).

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix test\` passes (33 tests, 0 failures)
- [x] \`mix format\` applied
- [ ] Once published to Hex 0.6.3 + consumer bump rolls out, verify on the affected drone deployment that the residual TIMESYNC echo collapses (downstream tracking: fancydrones/x500-cm5#47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)