### PR TITLE
Support per-message MAVLink source identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.7.0 - 2026-05-07
+
+- Added per-message `source_system` and `source_component` overrides to
+  `XMAVLink.Router.pack_and_send/3`.
+- Added heartbeat source identity options and `:heartbeats` supervisor config
+  for multiple local MAVLink identities sharing one router.
+- Fixed outbound local sequence tracking so each local source identity uses an
+  independent MAVLink sequence counter.
+- Preserved the existing default router identity behavior for callers that do
+  not pass source overrides.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ config :xmavlink,
 
 The first heartbeat is sent immediately so peer-learning routers admit the node within milliseconds of startup. If `:heartbeat` is unset or `nil`, no heartbeats are emitted (backwards-compatible with versions ≤ 0.6.0; consumers that emit their own heartbeats are unaffected).
 
+When multiple local MAVLink identities share one BEAM and one router, use
+`:heartbeats` and set an explicit source identity per emitter:
+
+```elixir
+config :xmavlink,
+  heartbeats: [
+    [
+      id: :camera_heartbeat,
+      source_system: 1,
+      source_component: 100,
+      interval_ms: 1000,
+      builder: {CameraApp.Mavlink, :heartbeat_message, []}
+    ],
+    [
+      id: :gcs_heartbeat,
+      source_system: 245,
+      source_component: 191,
+      interval_ms: 1000,
+      builder: {GcsApp.Mavlink, :heartbeat_message, []}
+    ]
+  ]
+```
+
 ## Receive MAVLink messages
 
 With the configured MAVLink application running you can subscribe to particular MAVLink messages:
@@ -171,6 +194,13 @@ MAV.pack_and_send(
     chan18_raw: 0
   }
 )
+```
+
+Pass `source_system` and `source_component` when a process needs to emit a
+message from an identity other than the router's configured default:
+
+```elixir
+MAV.pack_and_send(message, 2, source_system: 245, source_component: 191)
 ```
 
 ## Router Architecture

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.5.0"}
+     {:xmavlink, "~> 0.7.0"}
    ]
  end
  ```

--- a/lib/mavlink/heartbeat.ex
+++ b/lib/mavlink/heartbeat.ex
@@ -18,9 +18,11 @@ defmodule XMAVLink.Heartbeat do
   ### Static message
 
       config :xmavlink,
-        heartbeat: [
-          interval_ms: 1000,
-          message: %Common.Message.Heartbeat{
+      heartbeat: [
+        interval_ms: 1000,
+        source_system: 245,
+        source_component: 191,
+        message: %Common.Message.Heartbeat{
             type: :mav_type_gcs,
             autopilot: :mav_autopilot_invalid,
             base_mode: MapSet.new(),
@@ -36,10 +38,12 @@ defmodule XMAVLink.Heartbeat do
   ### Dynamic builder
 
       config :xmavlink,
-        heartbeat: [
-          interval_ms: 1000,
-          builder: {MyApp.Mavlink, :build_heartbeat, []}
-        ]
+      heartbeat: [
+        interval_ms: 1000,
+        source_system: 1,
+        source_component: 100,
+        builder: {MyApp.Mavlink, :build_heartbeat, []}
+      ]
 
   The `{module, function, args}` tuple is invoked on every tick to
   produce a fresh struct. Use this when `system_status`, `base_mode`,
@@ -60,24 +64,29 @@ defmodule XMAVLink.Heartbeat do
 
   @doc false
   def start_link(spec) do
-    GenServer.start_link(__MODULE__, spec, name: __MODULE__)
+    {name, spec} = Keyword.pop(spec, :name, __MODULE__)
+    opts = if name, do: [name: name], else: []
+
+    GenServer.start_link(__MODULE__, spec, opts)
   end
 
   @impl true
   def init(spec) do
     interval_ms = Keyword.fetch!(spec, :interval_ms)
     builder = build_builder(spec)
+    version = Keyword.get(spec, :version, 2)
+    send_opts = Keyword.take(spec, [:source_system, :source_component])
 
     # First heartbeat ASAP so peer-learning routers admit us fast.
     send(self(), :tick)
-    {:ok, %{interval_ms: interval_ms, builder: builder}}
+    {:ok, %{interval_ms: interval_ms, builder: builder, version: version, send_opts: send_opts}}
   end
 
   @impl true
   def handle_info(:tick, state) do
     case safe_build(state.builder) do
       {:ok, msg} ->
-        XMAVLink.Router.pack_and_send(msg)
+        XMAVLink.Router.pack_and_send(msg, state.version, state.send_opts)
 
       {:error, error} ->
         Logger.error("XMAVLink.Heartbeat builder failed: #{inspect(error)}")

--- a/lib/mavlink/heartbeat.ex
+++ b/lib/mavlink/heartbeat.ex
@@ -18,11 +18,11 @@ defmodule XMAVLink.Heartbeat do
   ### Static message
 
       config :xmavlink,
-      heartbeat: [
-        interval_ms: 1000,
-        source_system: 245,
-        source_component: 191,
-        message: %Common.Message.Heartbeat{
+        heartbeat: [
+          interval_ms: 1000,
+          source_system: 245,
+          source_component: 191,
+          message: %Common.Message.Heartbeat{
             type: :mav_type_gcs,
             autopilot: :mav_autopilot_invalid,
             base_mode: MapSet.new(),
@@ -38,12 +38,12 @@ defmodule XMAVLink.Heartbeat do
   ### Dynamic builder
 
       config :xmavlink,
-      heartbeat: [
-        interval_ms: 1000,
-        source_system: 1,
-        source_component: 100,
-        builder: {MyApp.Mavlink, :build_heartbeat, []}
-      ]
+        heartbeat: [
+          interval_ms: 1000,
+          source_system: 1,
+          source_component: 100,
+          builder: {MyApp.Mavlink, :build_heartbeat, []}
+        ]
 
   The `{module, function, args}` tuple is invoked on every tick to
   produce a fresh struct. Use this when `system_status`, `base_mode`,

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -123,7 +123,7 @@ defmodule XMAVLink.LocalConnection do
   end
 
   # Subscription request from subscriber
-  def subscribe(query, pid, local_connection) do
+  def subscribe(query, pid, local_connection = %LocalConnection{}) do
     :ok = Logger.debug("Subscribe #{inspect(pid)} to query #{inspect(query)}")
     # Monitor so that we can unsubscribe dead processes
     Process.monitor(pid)
@@ -137,7 +137,7 @@ defmodule XMAVLink.LocalConnection do
   end
 
   # Unsubscribe request from subscriber
-  def unsubscribe(pid, local_connection) do
+  def unsubscribe(pid, local_connection = %LocalConnection{}) do
     :ok = Logger.debug("Unsubscribe #{inspect(pid)}")
 
     %LocalConnection{
@@ -149,7 +149,7 @@ defmodule XMAVLink.LocalConnection do
   end
 
   # Automatically unsubscribe a dead subscriber process
-  def subscriber_down(pid, local_connection) do
+  def subscriber_down(pid, local_connection = %LocalConnection{}) do
     :ok = Logger.debug("Subscriber #{inspect(pid)} exited")
 
     %LocalConnection{

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -14,13 +14,15 @@ defmodule XMAVLink.LocalConnection do
   defstruct system: nil,
             component: nil,
             subscriptions: [],
-            sequence_number: 0
+            sequence_number: 0,
+            sequence_numbers: %{}
 
   @type t :: %LocalConnection{
           system: 1..255,
           component: 1..255,
           subscriptions: [],
-          sequence_number: 0..255
+          sequence_number: 0..255,
+          sequence_numbers: %{{1..255, 1..255} => 0..255}
         }
 
   # Handle message from Router.pack_and_send()
@@ -30,19 +32,22 @@ defmodule XMAVLink.LocalConnection do
         {:local, frame = %Frame{source_system: frame_system, source_component: frame_component}},
         receiving_connection = %LocalConnection{
           system: system,
-          component: component,
-          sequence_number: sequence_number
+          component: component
         },
         _dialect
       ) do
     # Fill in missing frame details source_system, source_component, sequence_number
     source_system = frame_system || system
     source_component = frame_component || component
+    source_identity = {source_system, source_component}
+
+    {sequence_number, updated_connection} =
+      next_sequence_number(receiving_connection, source_identity)
 
     {
       :ok,
       :local,
-      struct(receiving_connection, sequence_number: rem(sequence_number + 1, 255)),
+      updated_connection,
       struct(frame,
         source_system: source_system,
         source_component: source_component,
@@ -165,4 +170,47 @@ defmodule XMAVLink.LocalConnection do
     Agent.update(XMAVLink.SubscriptionCache, fn _ -> subscriptions end)
     subscriptions
   end
+
+  defp next_sequence_number(local_connection = %LocalConnection{}, source_identity) do
+    sequence_number =
+      Map.get(
+        local_connection.sequence_numbers,
+        source_identity,
+        initial_sequence_number(local_connection, source_identity)
+      )
+
+    next_sequence_number = rem(sequence_number + 1, 255)
+
+    updated_connection = %LocalConnection{
+      local_connection
+      | sequence_number:
+          default_sequence_number(local_connection, source_identity, next_sequence_number),
+        sequence_numbers:
+          Map.put(local_connection.sequence_numbers, source_identity, next_sequence_number)
+    }
+
+    {sequence_number, updated_connection}
+  end
+
+  defp initial_sequence_number(
+         %LocalConnection{system: system, component: component, sequence_number: sequence_number},
+         {system, component}
+       ),
+       do: sequence_number
+
+  defp initial_sequence_number(_local_connection, _source_identity), do: 0
+
+  defp default_sequence_number(
+         %LocalConnection{system: system, component: component},
+         {system, component},
+         next
+       ),
+       do: next
+
+  defp default_sequence_number(
+         %LocalConnection{sequence_number: sequence_number},
+         _source_identity,
+         _next
+       ),
+       do: sequence_number
 end

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -27,7 +27,7 @@ defmodule XMAVLink.LocalConnection do
   # We use handle_info instead of cast for symmetry
   # with the other connection types
   def handle_info(
-        {:local, frame},
+        {:local, frame = %Frame{source_system: frame_system, source_component: frame_component}},
         receiving_connection = %LocalConnection{
           system: system,
           component: component,
@@ -36,13 +36,16 @@ defmodule XMAVLink.LocalConnection do
         _dialect
       ) do
     # Fill in missing frame details source_system, source_component, sequence_number
+    source_system = frame_system || system
+    source_component = frame_component || component
+
     {
       :ok,
       :local,
       struct(receiving_connection, sequence_number: rem(sequence_number + 1, 255)),
       struct(frame,
-        source_system: system,
-        source_component: component,
+        source_system: source_system,
+        source_component: source_component,
         sequence_number: sequence_number
       )
       |> Frame.pack_frame()

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -187,6 +187,9 @@ defmodule XMAVLink.Router do
 
   - message: A MAVLink message structure from the installed dialect
   - version: Force sending using a specific MAVLink protocol (default 2)
+  - opts: Optional send settings:
+    - `:source_system` and `:source_component` override the router's
+      configured local identity for this message. Provide both or neither.
 
   ## Example
 
@@ -217,7 +220,15 @@ defmodule XMAVLink.Router do
     )
   ```
   """
-  def pack_and_send(message, version \\ 2) do
+  def pack_and_send(message, version_or_opts \\ 2)
+
+  def pack_and_send(message, opts) when is_list(opts), do: pack_and_send(message, 2, opts)
+
+  def pack_and_send(message, version), do: pack_and_send(message, version, [])
+
+  def pack_and_send(message, version, opts) do
+    source_identity = source_identity!(opts)
+
     # We can only pack payload at this point because we need router state to get source
     # system/component and sequence number for frame
     try do
@@ -240,6 +251,8 @@ defmodule XMAVLink.Router do
           struct(Frame,
             version: version,
             message_id: message_id,
+            source_system: source_identity[:source_system],
+            source_component: source_identity[:source_component],
             target_system: target_system,
             target_component: target_component,
             target: target,
@@ -258,6 +271,29 @@ defmodule XMAVLink.Router do
       # message definitions and regenerate the dialect module.
       Protocol.UndefinedError ->
         {:error, :protocol_undefined}
+    end
+  end
+
+  defp source_identity!(opts) do
+    source_system = Keyword.get(opts, :source_system)
+    source_component = Keyword.get(opts, :source_component)
+
+    case {source_system, source_component} do
+      {nil, nil} ->
+        []
+
+      {system, component} when system in 1..255 and component in 1..255 ->
+        [source_system: system, source_component: component]
+
+      {nil, _component} ->
+        raise ArgumentError, "source_system is required when source_component is set"
+
+      {_system, nil} ->
+        raise ArgumentError, "source_component is required when source_system is set"
+
+      _ ->
+        raise ArgumentError,
+              "source_system and source_component must be integers in the MAVLink range 1..255"
     end
   end
 

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -33,12 +33,33 @@ defmodule XMAVLink.Supervisor do
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  # Heartbeat is started only when configured, so existing apps that
-  # build their own heartbeats keep working unchanged.
   defp heartbeat_child_specs do
-    case Application.get_env(:xmavlink, :heartbeat) do
-      nil -> []
-      spec -> [{XMAVLink.Heartbeat, spec}]
-    end
+    specs = heartbeat_specs()
+    multi? = length(specs) > 1
+
+    specs
+    |> Enum.with_index()
+    |> Enum.map(fn {spec, index} ->
+      child_spec = if multi?, do: Keyword.put_new(spec, :name, nil), else: spec
+
+      %{
+        id: Keyword.get(spec, :id, {XMAVLink.Heartbeat, index}),
+        start: {XMAVLink.Heartbeat, :start_link, [child_spec]}
+      }
+    end)
+  end
+
+  # Heartbeats are started only when configured, so existing apps that
+  # build their own heartbeats keep working unchanged. `:heartbeat` keeps
+  # the original single-emitter contract; `:heartbeats` allows multiple
+  # local source identities to share one router.
+  defp heartbeat_specs do
+    legacy =
+      case Application.get_env(:xmavlink, :heartbeat) do
+        nil -> []
+        spec -> [spec]
+      end
+
+    legacy ++ (Application.get_env(:xmavlink, :heartbeats) || [])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.6.3",
+      version: "0.7.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -68,7 +68,7 @@ defmodule XMAVLink.Mixfile do
   defp package() do
     [
       name: "xmavlink",
-      files: ["lib", "priv", "mix.exs", "README.md", "LICENSE"],
+      files: ["lib", "priv", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE"],
       exclude_patterns: [".DS_Store"],
       licenses: ["MIT"],
       links: %{"Github" => "https://github.com/fancydrones/xmavlink"},

--- a/test/mavlink_heartbeat_test.exs
+++ b/test/mavlink_heartbeat_test.exs
@@ -36,6 +36,22 @@ defmodule XMAVLink.HeartbeatTest do
 
       GenServer.stop(hb)
     end
+
+    test "dispatches heartbeats with an explicit source identity" do
+      msg = sample_heartbeat()
+
+      {:ok, hb} =
+        Heartbeat.start_link(
+          interval_ms: 50,
+          message: msg,
+          source_system: 245,
+          source_component: 191
+        )
+
+      assert_receive {:local, %{message: ^msg, source_system: 245, source_component: 191}}, 200
+
+      GenServer.stop(hb)
+    end
   end
 
   describe "with a {m, f, a} :builder" do

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -324,4 +324,48 @@ defmodule XMAVLink.Test.Router do
       GenServer.stop(pid)
     end
   end
+
+  describe "pack_and_send/3" do
+    test "can override the local source identity for one message" do
+      {:ok, pid} =
+        Router.start_link(
+          %{
+            system: 1,
+            component: 100,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn ->
+        if Process.whereis(XMAVLink.SubscriptionCache) do
+          Agent.update(XMAVLink.SubscriptionCache, fn _ -> [] end)
+        end
+      end)
+
+      assert :ok = Router.subscribe(message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = %Common.Message.Heartbeat{
+        type: :mav_type_gcs,
+        autopilot: :mav_autopilot_invalid,
+        base_mode: MapSet.new(),
+        custom_mode: 0,
+        system_status: :mav_state_active,
+        mavlink_version: 3
+      }
+
+      assert :ok = Router.pack_and_send(msg, 2, source_system: 245, source_component: 191)
+
+      assert_receive %XMAVLink.Frame{
+                       message: ^msg,
+                       source_system: 245,
+                       source_component: 191
+                     },
+                     200
+
+      Router.unsubscribe()
+      GenServer.stop(pid)
+    end
+  end
 end

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -367,5 +367,113 @@ defmodule XMAVLink.Test.Router do
       Router.unsubscribe()
       GenServer.stop(pid)
     end
+
+    test "keeps independent sequence numbers per local source identity" do
+      {:ok, pid} =
+        Router.start_link(
+          %{
+            system: 1,
+            component: 100,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn ->
+        if Process.whereis(XMAVLink.SubscriptionCache) do
+          Agent.update(XMAVLink.SubscriptionCache, fn _ -> [] end)
+        end
+      end)
+
+      assert :ok = Router.subscribe(message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = sample_heartbeat()
+
+      assert :ok = Router.pack_and_send(msg)
+
+      assert_receive %XMAVLink.Frame{
+                       source_system: 1,
+                       source_component: 100,
+                       sequence_number: 0
+                     },
+                     200
+
+      assert :ok = Router.pack_and_send(msg, 2, source_system: 245, source_component: 191)
+
+      assert_receive %XMAVLink.Frame{
+                       source_system: 245,
+                       source_component: 191,
+                       sequence_number: 0
+                     },
+                     200
+
+      assert :ok = Router.pack_and_send(msg)
+
+      assert_receive %XMAVLink.Frame{
+                       source_system: 1,
+                       source_component: 100,
+                       sequence_number: 1
+                     },
+                     200
+
+      assert :ok = Router.pack_and_send(msg, 2, source_system: 245, source_component: 191)
+
+      assert_receive %XMAVLink.Frame{
+                       source_system: 245,
+                       source_component: 191,
+                       sequence_number: 1
+                     },
+                     200
+
+      Router.unsubscribe()
+      GenServer.stop(pid)
+    end
+
+    test "keeps the legacy version argument for pack_and_send/2" do
+      {:ok, pid} =
+        Router.start_link(
+          %{
+            system: 1,
+            component: 100,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn ->
+        if Process.whereis(XMAVLink.SubscriptionCache) do
+          Agent.update(XMAVLink.SubscriptionCache, fn _ -> [] end)
+        end
+      end)
+
+      assert :ok = Router.subscribe(message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = sample_heartbeat()
+
+      assert :ok = Router.pack_and_send(msg, 1)
+
+      assert_receive %XMAVLink.Frame{
+                       source_system: 1,
+                       source_component: 100,
+                       version: 1
+                     },
+                     200
+
+      Router.unsubscribe()
+      GenServer.stop(pid)
+    end
+  end
+
+  defp sample_heartbeat do
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
   end
 end


### PR DESCRIPTION
## Summary

- allow `XMAVLink.Router.pack_and_send/3` to override `source_system` and `source_component` per local message while keeping the existing default identity behavior
- allow `XMAVLink.Heartbeat` emitters to pass those source options through to the router
- add `:heartbeats` supervisor config so multiple heartbeat emitters can share one router in one BEAM
- document the multi-identity heartbeat and per-message source identity APIs

## Validation

- [x] `mise exec -- mix test`
- [x] `mise exec -- mix format --check-formatted lib/mavlink/router.ex lib/mavlink/local_connection.ex lib/mavlink/heartbeat.ex lib/mavlink/supervisor.ex test/mavlink_heartbeat_test.exs test/mavlink_router_test.exs`

Downstream use: fancydrones/x500-cm5#129.