### PR TITLE
Fix TCP forwarding and clean test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.1 - 2026-05-07
+
+- Fixed TCP outbound forwarding to send MAVLink frames over the TCP socket
+  instead of attempting to use UDP send calls.
+- Added TCP forwarding regression coverage for MAVLink 1 and MAVLink 2 frames.
+- Reduced expected test-suite noise from generated task output and runtime logs.
+
 ## 0.7.0 - 2026-05-07
 
 - Added per-message `source_system` and `source_component` overrides to

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.7.0"}
+     {:xmavlink, "~> 0.7.1"}
    ]
  end
  ```

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -101,13 +101,13 @@ defmodule XMAVLink.TCPOutConnection do
         %XMAVLink.TCPOutConnection{socket: socket},
         %Frame{version: 1, mavlink_1_raw: packet}
       ) do
-    :gen_udp.send(socket, packet)
+    :gen_tcp.send(socket, packet)
   end
 
   def forward(
         %XMAVLink.TCPOutConnection{socket: socket},
         %Frame{version: 2, mavlink_2_raw: packet}
       ) do
-    :gen_udp.send(socket, packet)
+    :gen_tcp.send(socket, packet)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.7.0",
+      version: "0.7.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -1,9 +1,34 @@
 defmodule XMAVLink.Util.CacheManager.Test do
   use ExUnit.Case
-  alias XMAVLink.Util.CacheManager
-  doctest CacheManager
 
-  test "greets the world" do
-    # assert CacheManager == :world
+  alias XMAVLink.Util.CacheManager
+
+  setup do
+    delete_table(:systems)
+    create_systems_table()
+
+    on_exit(fn ->
+      delete_table(:systems)
+    end)
+
+    :ok
+  end
+
+  test "mavs/0 returns visible system/component ids" do
+    :ets.insert(:systems, {{1, 1}, %{}})
+    :ets.insert(:systems, {{2, 1}, %{}})
+
+    assert {:ok, mavs} = CacheManager.mavs()
+    assert Enum.sort(mavs) == [{1, 1}, {2, 1}]
+  end
+
+  defp create_systems_table do
+    :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp delete_table(table) do
+    if :ets.info(table) != :undefined do
+      :ets.delete(table)
+    end
   end
 end

--- a/test/mavlink_heartbeat_test.exs
+++ b/test/mavlink_heartbeat_test.exs
@@ -27,7 +27,7 @@ defmodule XMAVLink.HeartbeatTest do
   describe "with a static :message" do
     test "emits the configured heartbeat immediately and on every interval" do
       msg = sample_heartbeat()
-      {:ok, hb} = Heartbeat.start_link(interval_ms: 50, message: msg)
+      {:ok, hb} = Heartbeat.start_link(interval_ms: 10, message: msg)
 
       # First heartbeat fires ASAP so peer-learning routers admit us
       # without waiting a full interval.
@@ -42,7 +42,7 @@ defmodule XMAVLink.HeartbeatTest do
 
       {:ok, hb} =
         Heartbeat.start_link(
-          interval_ms: 50,
+          interval_ms: 10,
           message: msg,
           source_system: 245,
           source_component: 191
@@ -60,7 +60,7 @@ defmodule XMAVLink.HeartbeatTest do
 
       {:ok, hb} =
         Heartbeat.start_link(
-          interval_ms: 50,
+          interval_ms: 10,
           builder: {__MODULE__, :build_heartbeat_with_counter, []}
         )
 
@@ -104,12 +104,12 @@ defmodule XMAVLink.HeartbeatTest do
   test "logs but keeps ticking when the builder raises" do
     {:ok, hb} =
       Heartbeat.start_link(
-        interval_ms: 30,
+        interval_ms: 10,
         builder: fn -> raise "boom" end
       )
 
     # The GenServer must stay alive (the error is logged, not crashed).
-    Process.sleep(100)
+    Process.sleep(30)
     assert Process.alive?(hb)
 
     GenServer.stop(hb)

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -36,33 +36,41 @@ defmodule XMAVLink.Test.Router do
     end
 
     test "accepts IP address in tcpout connection string" do
-      # TCP should also work with IP addresses
+      {listen_socket, acceptor, port} = open_tcp_listener()
+      on_exit(fn -> close_tcp_listener(listen_socket, acceptor) end)
+
       assert {:ok, pid} =
                Router.start_link(
                  %{
                    system: 1,
                    component: 1,
                    dialect: APM.Dialect,
-                   connection_strings: ["tcpout:127.0.0.1:14552"]
+                   connection_strings: ["tcpout:127.0.0.1:#{port}"]
                  },
                  []
                )
+
+      assert_receive :tcp_peer_accepted, 1_000
 
       GenServer.stop(pid)
     end
 
     test "accepts DNS hostname in tcpout connection string" do
-      # TCP should also work with DNS hostnames
+      {listen_socket, acceptor, port} = open_tcp_listener()
+      on_exit(fn -> close_tcp_listener(listen_socket, acceptor) end)
+
       assert {:ok, pid} =
                Router.start_link(
                  %{
                    system: 1,
                    component: 1,
                    dialect: APM.Dialect,
-                   connection_strings: ["tcpout:localhost:14553"]
+                   connection_strings: ["tcpout:localhost:#{port}"]
                  },
                  []
                )
+
+      assert_receive :tcp_peer_accepted, 1_000
 
       GenServer.stop(pid)
     end
@@ -255,7 +263,7 @@ defmodule XMAVLink.Test.Router do
       # (us) receives a `{:udp, _, _, _, _}` message. With the
       # source-exclusion fix in place, no echo should fire.
       refute_receive {:udp, ^trap_socket, _, _, _},
-                     100,
+                     50,
                      "router echoed a :system_component-classified frame back via the udpout"
 
       GenServer.stop(router_pid)
@@ -475,5 +483,46 @@ defmodule XMAVLink.Test.Router do
       system_status: :mav_state_active,
       mavlink_version: 3
     }
+  end
+
+  defp open_tcp_listener do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        active: false,
+        packet: :raw,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listen_socket)
+    parent = self()
+
+    acceptor =
+      spawn_link(fn ->
+        case :gen_tcp.accept(listen_socket, 1_000) do
+          {:ok, peer_socket} ->
+            send(parent, :tcp_peer_accepted)
+
+            receive do
+              :close_tcp_peer -> :ok
+            after
+              1_000 -> :ok
+            end
+
+            :gen_tcp.close(peer_socket)
+
+          other ->
+            other
+        end
+      end)
+
+    {listen_socket, acceptor, port}
+  end
+
+  defp close_tcp_listener(listen_socket, acceptor) do
+    send(acceptor, :close_tcp_peer)
+    :gen_tcp.close(listen_socket)
+    :ok
   end
 end

--- a/test/mavlink_task_test.exs
+++ b/test/mavlink_task_test.exs
@@ -1,25 +1,33 @@
 defmodule XMAVLink.Test.Tasks do
   use ExUnit.Case
+
+  import ExUnit.CaptureIO
   import Mix.Tasks.Xmavlink
 
   @input "#{File.cwd!()}/test/input/test_mavlink.xml"
-  @output_dir "#{File.cwd!()}/test/output"
+  @output_dir "#{Mix.Project.build_path()}/generated"
   @output "#{@output_dir}/test_mavlink.ex"
   @output_module "TestMavlink"
 
   test "generate" do
-    # Setup output directory
     File.mkdir_p(@output_dir)
     File.rm(@output)
 
-    # Run mix task
-    run([@input, @output, @output_module])
+    output =
+      capture_io(fn ->
+        assert :ok = run([@input, @output, @output_module])
+      end)
 
-    # Did it generate
+    assert output =~ "Generated #{@output_module}"
     assert File.exists?(@output)
 
     # We don't care if we redefine MAVLink modules while running the following test
+    previous_compiler_options = Code.compiler_options()
     Code.compiler_options(ignore_module_conflict: true)
+
+    on_exit(fn ->
+      Code.compiler_options(previous_compiler_options)
+    end)
 
     # Confirm the list of modules generated from common.xml and its includes
     pairs =

--- a/test/mavlink_tcp_out_connection_test.exs
+++ b/test/mavlink_tcp_out_connection_test.exs
@@ -35,26 +35,39 @@ defmodule XMAVLink.Test.TCPOutConnection do
 
     acceptor =
       Task.async(fn ->
-        {:ok, peer_socket} = :gen_tcp.accept(listen_socket)
-        send(parent, :tcp_peer_accepted)
+        case :gen_tcp.accept(listen_socket, 1_000) do
+          {:ok, peer_socket} ->
+            try do
+              send(parent, :tcp_peer_accepted)
+              :gen_tcp.recv(peer_socket, byte_size(expected_packet), 1_000)
+            after
+              :gen_tcp.close(peer_socket)
+            end
 
-        result = :gen_tcp.recv(peer_socket, byte_size(expected_packet), 1_000)
-        :gen_tcp.close(peer_socket)
-        result
+          other ->
+            other
+        end
       end)
 
-    {:ok, socket} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
-
     try do
-      assert_receive :tcp_peer_accepted, 1_000
+      {:ok, socket} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
 
-      assert :ok =
-               TCPOutConnection.forward(%TCPOutConnection{socket: socket}, frame)
+      try do
+        assert_receive :tcp_peer_accepted, 1_000
 
-      assert {:ok, expected_packet} == Task.await(acceptor, 1_000)
+        assert :ok =
+                 TCPOutConnection.forward(%TCPOutConnection{socket: socket}, frame)
+
+        assert {:ok, expected_packet} == Task.await(acceptor, 1_000)
+      after
+        :gen_tcp.close(socket)
+      end
     after
-      :gen_tcp.close(socket)
       :gen_tcp.close(listen_socket)
+
+      if Process.alive?(acceptor.pid) do
+        Task.shutdown(acceptor, :brutal_kill)
+      end
     end
   end
 end

--- a/test/mavlink_tcp_out_connection_test.exs
+++ b/test/mavlink_tcp_out_connection_test.exs
@@ -1,0 +1,60 @@
+defmodule XMAVLink.Test.TCPOutConnection do
+  use ExUnit.Case
+
+  alias XMAVLink.Frame
+  alias XMAVLink.TCPOutConnection
+
+  describe "forward/2" do
+    test "sends MAVLink v1 frames over the TCP socket" do
+      packet = <<0xFE, 0x00, 0x01, 0x01, 0x01, 0x00, 0x37, 0x92>>
+      frame = %Frame{version: 1, mavlink_1_raw: packet}
+
+      assert_forwarded_packet(frame, packet)
+    end
+
+    test "sends MAVLink v2 frames over the TCP socket" do
+      packet = <<0xFD, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0xF8, 0x1B>>
+      frame = %Frame{version: 2, mavlink_2_raw: packet}
+
+      assert_forwarded_packet(frame, packet)
+    end
+  end
+
+  defp assert_forwarded_packet(frame, expected_packet) do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        active: false,
+        packet: :raw,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listen_socket)
+    parent = self()
+
+    acceptor =
+      Task.async(fn ->
+        {:ok, peer_socket} = :gen_tcp.accept(listen_socket)
+        send(parent, :tcp_peer_accepted)
+
+        result = :gen_tcp.recv(peer_socket, byte_size(expected_packet), 1_000)
+        :gen_tcp.close(peer_socket)
+        result
+      end)
+
+    {:ok, socket} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+
+    try do
+      assert_receive :tcp_peer_accepted, 1_000
+
+      assert :ok =
+               TCPOutConnection.forward(%TCPOutConnection{socket: socket}, frame)
+
+      assert {:ok, expected_packet} == Task.await(acceptor, 1_000)
+    after
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen_socket)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
-ExUnit.start()
+Logger.configure(level: :warning)
+
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
## Summary

- Bump package metadata and README install snippet to `0.7.1` for this patch bugfix.
- Add a `0.7.1` changelog entry for the TCP forwarding fix and test hygiene cleanup.
- Fix `XMAVLink.TCPOutConnection.forward/2` to write outbound frames with `:gen_tcp.send/2` instead of UDP send calls.
- Add TCP forwarding regression tests for MAVLink v1 and v2 frames using a local TCP listener.
- Clean up test output by capturing expected logs and Mix task IO, moving generated task output under `_build/test`, replacing a placeholder CacheManager test, and avoiding closed-port TCP retry noise in router tests.
- Trim conservative heartbeat/router waits to keep the suite fast while preserving regression coverage.

## Why

TCP outbound forwarding was documented but broken: inbound TCP parsing worked, while outbound forwarding attempted to use `:gen_udp.send/2` on a TCP socket. The test suite also emitted expected warnings/logs during green runs, which made CI output harder to trust.

This is a patch-level bugfix, so the PR now bumps the package version from `0.7.0` to `0.7.1`.

Closes #21.

## Validation

- `mix format --check-formatted mix.exs`
- `mix format --check-formatted lib/mavlink/tcp_out_connection.ex test/test_helper.exs test/mavlink_task_test.exs test/cache_manager_test.exs test/mavlink_router_test.exs test/mavlink_heartbeat_test.exs test/mavlink_tcp_out_connection_test.exs`
- `git diff --cached --check`
- `mix test`
- `mix test --slowest 10`