### PR TITLE
Add router instance targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 - 2026-05-07
 
 - Added named router instance support while preserving the default
   `XMAVLink.Router` convenience process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Added named router instance support while preserving the default
+  `XMAVLink.Router` convenience process.
+- Added targetable `subscribe`, `unsubscribe`, and `pack_and_send` router APIs
+  for named or pid router instances.
+- Isolated local subscription restart caches per named router.
+
 ## 0.7.1 - 2026-05-07
 
 - Fixed TCP outbound forwarding to send MAVLink frames over the TCP socket

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.7.1"}
+     {:xmavlink, "~> 0.8.0"}
    ]
  end
  ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ The above config specifies the Common dialect we generated and connects to a a v
 UDP packets on 14550 and a SITL vehicle listening for TCP connections on 5760. Remember 'out' means client, 
 'in' means server.
 
+By default the application supervises one router registered as `XMAVLink.Router`.
+Set `:router_name` when the application-owned router should use another registered
+name:
+
+```elixir
+config :xmavlink,
+  router_name: MyApp.MAVRouter,
+  dialect: Common,
+  connections: []
+```
+
 ### Connection String Formats
 
 XMAVLink supports the following connection string formats:
@@ -209,6 +220,33 @@ The XMAVLink application is to Elixir/Erlang code what [MAVProxy](https://ardupi
 is to its Python modules: a router that sits alongside them and gives them access to other MAVLink
 systems over its connections. Unlike MAVProxy it is not responsible for starting/stopping/scheduling
 Elixir/Erlang code.
+
+### Router instance model
+
+`XMAVLink.Router` remains the default convenience router name. Applications that
+need multiple independent routers can supervise named router instances and pass
+the router name or pid as the first argument to the public API:
+
+```elixir
+children = [
+  {XMAVLink.Router,
+   %{
+     name: MyApp.VehicleRouter,
+     dialect: Common,
+     system: 245,
+     component: 191,
+     connections: ["udpout:127.0.0.1:14550"]
+   }}
+]
+
+XMAVLink.Router.subscribe(MyApp.VehicleRouter, message: Common.Message.Heartbeat)
+XMAVLink.Router.pack_and_send(MyApp.VehicleRouter, message)
+XMAVLink.Router.unsubscribe(MyApp.VehicleRouter)
+```
+
+Named routers keep separate connection state, route tables, local sequence
+numbers, and subscription restart caches. Passing no router target continues to
+use the default `XMAVLink.Router` process.
 
 The router is supervised. On a failure the configured connections and previous subscriptions are 
 restored immediately. If a connection fails or is not available at startup the router will attempt to

--- a/lib/mavlink/heartbeat.ex
+++ b/lib/mavlink/heartbeat.ex
@@ -50,7 +50,8 @@ defmodule XMAVLink.Heartbeat do
   or `custom_mode` should reflect application state.
 
   Either `:message` or `:builder` is required (not both). `:interval_ms`
-  is required.
+  is required. Pass `:router` when heartbeats should be emitted through a
+  named or pid router other than the default `XMAVLink.Router`.
 
   ## First heartbeat
 
@@ -75,18 +76,27 @@ defmodule XMAVLink.Heartbeat do
     interval_ms = Keyword.fetch!(spec, :interval_ms)
     builder = build_builder(spec)
     version = Keyword.get(spec, :version, 2)
+    router = Keyword.get(spec, :router, XMAVLink.Router)
     send_opts = Keyword.take(spec, [:source_system, :source_component])
 
     # First heartbeat ASAP so peer-learning routers admit us fast.
     send(self(), :tick)
-    {:ok, %{interval_ms: interval_ms, builder: builder, version: version, send_opts: send_opts}}
+
+    {:ok,
+     %{
+       interval_ms: interval_ms,
+       builder: builder,
+       router: router,
+       version: version,
+       send_opts: send_opts
+     }}
   end
 
   @impl true
   def handle_info(:tick, state) do
     case safe_build(state.builder) do
       {:ok, msg} ->
-        XMAVLink.Router.pack_and_send(msg, state.version, state.send_opts)
+        XMAVLink.Router.pack_and_send(state.router, msg, state.version, state.send_opts)
 
       {:error, error} ->
         Logger.error("XMAVLink.Heartbeat builder failed: #{inspect(error)}")

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -13,6 +13,7 @@ defmodule XMAVLink.LocalConnection do
 
   defstruct system: nil,
             component: nil,
+            subscription_cache: nil,
             subscriptions: [],
             sequence_number: 0,
             sequence_numbers: %{}
@@ -20,6 +21,7 @@ defmodule XMAVLink.LocalConnection do
   @type t :: %LocalConnection{
           system: 1..255,
           component: 1..255,
+          subscription_cache: GenServer.server() | nil,
           subscriptions: [],
           sequence_number: 0..255,
           sequence_numbers: %{{1..255, 1..255} => 0..255}
@@ -57,8 +59,13 @@ defmodule XMAVLink.LocalConnection do
     }
   end
 
-  def connect(:local, system, component) do
-    local_connection = struct(LocalConnection, system: system, component: component)
+  def connect(:local, system, component, subscription_cache \\ XMAVLink.SubscriptionCache) do
+    local_connection =
+      struct(LocalConnection,
+        system: system,
+        component: component,
+        subscription_cache: subscription_cache
+      )
 
     send(
       # Local connection guaranteed, so this connect() called directly from Router process
@@ -66,21 +73,7 @@ defmodule XMAVLink.LocalConnection do
       {
         :add_connection,
         :local,
-        case Agent.start(fn -> [] end, name: XMAVLink.SubscriptionCache) do
-          {:ok, _} ->
-            :ok = Logger.debug("Started Subscription Cache")
-            # No subscriptions to restore
-            local_connection
-
-          {:error, {:already_started, _}} ->
-            :ok = Logger.debug("Restoring subscriptions from Subscription Cache")
-
-            reduce(
-              Agent.get(XMAVLink.SubscriptionCache, fn subs -> subs end),
-              local_connection,
-              fn {query, pid}, lc -> subscribe(query, pid, lc) end
-            )
-        end
+        restore_subscriptions(local_connection)
       }
     )
   end
@@ -137,7 +130,7 @@ defmodule XMAVLink.LocalConnection do
       local_connection
       | subscriptions:
           Enum.uniq([{query, pid} | local_connection.subscriptions])
-          |> update_subscription_cache
+          |> update_subscription_cache(local_connection.subscription_cache)
     }
   end
 
@@ -149,7 +142,7 @@ defmodule XMAVLink.LocalConnection do
       local_connection
       | subscriptions:
           filter(local_connection.subscriptions, &(not match?({_, ^pid}, &1)))
-          |> update_subscription_cache
+          |> update_subscription_cache(local_connection.subscription_cache)
     }
   end
 
@@ -161,13 +154,42 @@ defmodule XMAVLink.LocalConnection do
       local_connection
       | subscriptions:
           filter(local_connection.subscriptions, &(not match?({_, ^pid}, &1)))
-          |> update_subscription_cache
+          |> update_subscription_cache(local_connection.subscription_cache)
     }
   end
 
-  defp update_subscription_cache(subscriptions) do
+  defp restore_subscriptions(local_connection = %LocalConnection{subscription_cache: nil}) do
+    local_connection
+  end
+
+  defp restore_subscriptions(
+         local_connection = %LocalConnection{subscription_cache: subscription_cache}
+       ) do
+    case Agent.start(fn -> [] end, name: subscription_cache) do
+      {:ok, _} ->
+        :ok = Logger.debug("Started Subscription Cache #{inspect(subscription_cache)}")
+        # No subscriptions to restore
+        local_connection
+
+      {:error, {:already_started, _}} ->
+        :ok =
+          Logger.debug(
+            "Restoring subscriptions from Subscription Cache #{inspect(subscription_cache)}"
+          )
+
+        reduce(
+          Agent.get(subscription_cache, fn subs -> subs end),
+          local_connection,
+          fn {query, pid}, lc -> subscribe(query, pid, lc) end
+        )
+    end
+  end
+
+  defp update_subscription_cache(subscriptions, nil), do: subscriptions
+
+  defp update_subscription_cache(subscriptions, subscription_cache) do
     :ok = Logger.debug("Update subscription cache: #{inspect(subscriptions)}")
-    Agent.update(XMAVLink.SubscriptionCache, fn _ -> subscriptions end)
+    Agent.update(subscription_cache, fn _ -> subscriptions end)
     subscriptions
   end
 

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -56,10 +56,14 @@ defmodule XMAVLink.Router do
                         system/component was last received on. Used to forward messages to that system/component.
   """
   defstruct [
+    # Registered router name, if any
+    name: nil,
     # Generated dialect module
     dialect: nil,
     # Connection descriptions from user
     connection_strings: [],
+    # Subscription cache name for restart restoration, if any
+    subscription_cache: nil,
     # %{socket|port|local: XMAVLink.*_Connection}
     connections: %{},
     # Connection and MAVLink version tuple keyed by MAVLink addresses
@@ -69,12 +73,24 @@ defmodule XMAVLink.Router do
   # Can't used qualified type as map key
   @type mavlink_address :: Types.mavlink_address()
   @type mavlink_connection :: Types.connection()
+  @type router_name :: atom | {:global, term} | {:via, module, term}
+  @type router_ref :: GenServer.server()
+  @type subscribe_query :: [
+          {:message, Message.t() | :unknown}
+          | {subscribe_query_id_key, 0..255}
+          | {:as_frame, boolean}
+        ]
   @type t :: %Router{
+          name: router_name | nil,
           dialect: module | nil,
           connection_strings: [String.t()],
+          subscription_cache: router_name | nil,
           connections: %{},
           routes: %{mavlink_address: {mavlink_connection, Types.version()}}
         }
+
+  defguardp is_router_ref(router)
+            when is_atom(router) or is_pid(router) or is_tuple(router)
 
   ##############
   # Router API #
@@ -97,18 +113,37 @@ defmodule XMAVLink.Router do
                         tcpout:<remote ip>:<remote port>
                         serial:<device>:<baud rate>
 
-  - opts:               Standard GenServer options
+  - opts:               Standard GenServer options. Pass `:name` to register
+                        a non-default router, or `name: nil` in the args map to
+                        start an unregistered router addressed by pid.
   """
   @spec start_link(
-          %{system: 1..255, component: 1..255, dialect: module, connection_strings: [String.t()]},
+          %{
+            required(:system) => 1..255,
+            required(:component) => 1..255,
+            required(:dialect) => module,
+            optional(:name) => router_name | nil,
+            optional(:connection_strings) => [String.t()],
+            optional(:connections) => [String.t()]
+          },
           [{atom, any}]
         ) :: {:ok, pid}
   def start_link(args, opts \\ []) do
-    GenServer.start_link(
-      __MODULE__,
-      args,
-      [{:name, __MODULE__} | opts]
-    )
+    args = normalize_start_args(args)
+    name = Keyword.get(opts, :name, Map.get(args, :name, __MODULE__))
+
+    GenServer.start_link(__MODULE__, Map.put(args, :name, name), start_options(opts, name))
+  end
+
+  @doc false
+  def child_spec(args) do
+    args = normalize_start_args(args)
+    name = Map.get(args, :name, __MODULE__)
+
+    %{
+      id: Map.get(args, :id, name || __MODULE__),
+      start: {__MODULE__, :start_link, [Map.delete(args, :id)]}
+    }
   end
 
   @doc """
@@ -116,6 +151,7 @@ defmodule XMAVLink.Router do
 
   ## Parameters
 
+  - router: Optional router name or pid. Defaults to `XMAVLink.Router`.
   - query:  Keyword list of zero or more of the following query keywords:
 
     message:          message_module | :unknown (use latter with as_frame)
@@ -133,18 +169,23 @@ defmodule XMAVLink.Router do
   """
   @type subscribe_query_id_key ::
           :source_system | :source_component | :target_system | :target_component
-  @spec subscribe([
-          {:message, Message.t()} | {subscribe_query_id_key, 0..255} | {:as_frame, boolean}
-        ]) :: :ok
-  def subscribe(query \\ []) do
+  @spec subscribe() :: :ok | {:error, :invalid_message}
+  def subscribe(), do: subscribe(__MODULE__, [])
+
+  @spec subscribe(router_ref | subscribe_query) :: :ok | {:error, :invalid_message}
+  def subscribe(router) when is_router_ref(router), do: subscribe(router, [])
+  def subscribe(query), do: subscribe(__MODULE__, query)
+
+  @spec subscribe(router_ref, subscribe_query) :: :ok | {:error, :invalid_message}
+  def subscribe(router, query) do
     with message <- Keyword.get(query, :message),
-         true <- message == nil or Code.ensure_loaded?(message) do
+         true <- message == nil or message == :unknown or Code.ensure_loaded?(message) do
       # Synchronous: returns only after the subscription is committed to the
       # Router state. This prevents a race where the caller sends an outbound
       # message that elicits a reply before the inbound subscription is in
       # place, causing the reply to be dropped.
       GenServer.call(
-        __MODULE__,
+        router,
         {
           :subscribe,
           [
@@ -176,7 +217,10 @@ defmodule XMAVLink.Router do
   ```
   """
   @spec unsubscribe() :: :ok
-  def unsubscribe(), do: GenServer.cast(__MODULE__, {:unsubscribe, self()})
+  def unsubscribe(), do: unsubscribe(__MODULE__)
+
+  @spec unsubscribe(router_ref) :: :ok
+  def unsubscribe(router), do: GenServer.cast(router, {:unsubscribe, self()})
 
   @doc """
   Send a MAVLink message to one or more recipients using available
@@ -185,6 +229,7 @@ defmodule XMAVLink.Router do
 
   ## Parameters
 
+  - router: Optional router name or pid. Defaults to `XMAVLink.Router`.
   - message: A MAVLink message structure from the installed dialect
   - version: Force sending using a specific MAVLink protocol (default 2)
   - opts: Optional send settings:
@@ -220,13 +265,35 @@ defmodule XMAVLink.Router do
     )
   ```
   """
-  def pack_and_send(message, version_or_opts \\ 2)
+  @spec pack_and_send(Message.t()) :: :ok | {:error, :protocol_undefined}
+  def pack_and_send(message), do: pack_and_send(__MODULE__, message, 2, [])
 
-  def pack_and_send(message, opts) when is_list(opts), do: pack_and_send(message, 2, opts)
+  @spec pack_and_send(router_ref, Message.t()) :: :ok | {:error, :protocol_undefined}
+  def pack_and_send(router, message) when is_router_ref(router) and is_map(message),
+    do: pack_and_send(router, message, 2, [])
 
-  def pack_and_send(message, version), do: pack_and_send(message, version, [])
+  @spec pack_and_send(Message.t(), Types.version() | keyword) ::
+          :ok | {:error, :protocol_undefined}
+  def pack_and_send(message, opts) when is_list(opts),
+    do: pack_and_send(__MODULE__, message, 2, opts)
 
-  def pack_and_send(message, version, opts) do
+  def pack_and_send(message, version), do: pack_and_send(__MODULE__, message, version, [])
+
+  @spec pack_and_send(router_ref, Message.t(), Types.version() | keyword) ::
+          :ok | {:error, :protocol_undefined}
+  def pack_and_send(router, message, opts) when is_router_ref(router) and is_list(opts),
+    do: pack_and_send(router, message, 2, opts)
+
+  def pack_and_send(router, message, version) when is_router_ref(router),
+    do: pack_and_send(router, message, version, [])
+
+  @spec pack_and_send(Message.t(), Types.version(), keyword) ::
+          :ok | {:error, :protocol_undefined}
+  def pack_and_send(message, version, opts), do: pack_and_send(__MODULE__, message, version, opts)
+
+  @spec pack_and_send(router_ref, Message.t(), Types.version(), keyword) ::
+          :ok | {:error, :protocol_undefined}
+  def pack_and_send(router, message, version, opts) do
     source_identity = source_identity!(opts)
 
     # We can only pack payload at this point because we need router state to get source
@@ -241,26 +308,23 @@ defmodule XMAVLink.Router do
           {0, 0}
         end
 
-      # Although Router is a GenServer we still use send for symmetry because this arrives as
-      # a vanilla message, just like messages from a udp/tcp/serial port, and is dealt with in
-      # a similar way using handle_info()
-      send(
-        __MODULE__,
-        {
-          :local,
-          struct(Frame,
-            version: version,
-            message_id: message_id,
-            source_system: source_identity[:source_system],
-            source_component: source_identity[:source_component],
-            target_system: target_system,
-            target_component: target_component,
-            target: target,
-            message: message,
-            payload: payload,
-            crc_extra: crc_extra
-          )
-        }
+      # Atom and pid targets still receive the same vanilla message as external
+      # connections. Global/via names need GenServer dispatch because Kernel.send/2
+      # cannot resolve those names.
+      dispatch_local(
+        router,
+        struct(Frame,
+          version: version,
+          message_id: message_id,
+          source_system: source_identity[:source_system],
+          source_component: source_identity[:source_component],
+          target_system: target_system,
+          target_component: target_component,
+          target: target,
+          message: message,
+          payload: payload,
+          crc_extra: crc_extra
+        )
       )
 
       :ok
@@ -272,6 +336,51 @@ defmodule XMAVLink.Router do
       Protocol.UndefinedError ->
         {:error, :protocol_undefined}
     end
+  end
+
+  defp dispatch_local({:global, _} = router, frame), do: GenServer.cast(router, {:local, frame})
+  defp dispatch_local({:via, _, _} = router, frame), do: GenServer.cast(router, {:local, frame})
+  defp dispatch_local(router, frame), do: send(router, {:local, frame})
+
+  defp normalize_start_args(args) do
+    args = Map.new(args)
+    connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
+
+    Map.put(args, :connection_strings, connection_strings)
+  end
+
+  defp start_options(opts, nil), do: Keyword.delete(opts, :name)
+
+  defp start_options(opts, name) do
+    opts
+    |> Keyword.delete(:name)
+    |> Keyword.put(:name, name)
+  end
+
+  defp subscription_cache_name(nil), do: nil
+  defp subscription_cache_name(__MODULE__), do: XMAVLink.SubscriptionCache
+
+  defp subscription_cache_name(name) when is_atom(name) do
+    name
+    |> Atom.to_string()
+    |> Kernel.<>(".SubscriptionCache")
+    |> String.to_atom()
+  end
+
+  defp subscription_cache_name({:global, name}) do
+    {:global, {__MODULE__, :subscription_cache, name}}
+  end
+
+  defp subscription_cache_name({:via, registry, name}) do
+    {:via, registry, {__MODULE__, :subscription_cache, name}}
+  end
+
+  defp subscription_cache_name(_name), do: nil
+
+  defp route_local(frame, state) do
+    LocalConnection.handle_info({:local, frame}, state.connections.local, state.dialect)
+    |> update_route_info(state)
+    |> route
   end
 
   defp source_identity!(opts) do
@@ -310,9 +419,18 @@ defmodule XMAVLink.Router do
   # Start connections (they will send :add_connection messages
   # to us if successful) and initialise Router state
   def init(args) do
-    LocalConnection.connect(:local, args.system, args.component)
+    subscription_cache = subscription_cache_name(args.name)
+
+    LocalConnection.connect(:local, args.system, args.component, subscription_cache)
     _ = map(args.connection_strings, &connect/1)
-    {:ok, %Router{dialect: args.dialect, connection_strings: args.connection_strings}}
+
+    {:ok,
+     %Router{
+       name: args.name,
+       dialect: args.dialect,
+       connection_strings: args.connection_strings,
+       subscription_cache: subscription_cache
+     }}
   end
 
   @impl true
@@ -331,6 +449,11 @@ defmodule XMAVLink.Router do
   def handle_cast({:unsubscribe, pid}, state) do
     {:noreply,
      update_in(state, [Access.key!(:connections), :local], &LocalConnection.unsubscribe(pid, &1))}
+  end
+
+  # A call to pack_and_send() targeting a non-local registered name.
+  def handle_cast({:local, frame}, state) do
+    {:noreply, route_local(frame, state)}
   end
 
   @impl true
@@ -427,12 +550,7 @@ defmodule XMAVLink.Router do
 
   # A call to pack_and_send() from a local Elixir process, sent as a vanilla message for symmetry with other connection types
   def handle_info({:local, frame}, state) do
-    {
-      :noreply,
-      LocalConnection.handle_info({:local, frame}, state.connections.local, state.dialect)
-      |> update_route_info(state)
-      |> route
-    }
+    {:noreply, route_local(frame, state)}
   end
 
   # A spawned *Connection.connect() call has successfully got a

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -90,7 +90,15 @@ defmodule XMAVLink.Router do
         }
 
   defguardp is_router_ref(router)
-            when is_atom(router) or is_pid(router) or is_tuple(router)
+            when is_pid(router) or
+                   (is_atom(router) and not is_nil(router)) or
+                   (is_tuple(router) and tuple_size(router) == 2 and
+                      elem(router, 0) == :global) or
+                   (is_tuple(router) and tuple_size(router) == 3 and
+                      elem(router, 0) == :via and is_atom(elem(router, 1))) or
+                   (is_tuple(router) and tuple_size(router) == 2 and
+                      is_atom(elem(router, 0)) and not is_nil(elem(router, 0)) and
+                      is_atom(elem(router, 1)) and not is_nil(elem(router, 1)))
 
   ##############
   # Router API #
@@ -141,7 +149,7 @@ defmodule XMAVLink.Router do
     name = Map.get(args, :name, __MODULE__)
 
     %{
-      id: Map.get(args, :id, name || __MODULE__),
+      id: child_id(args, name),
       start: {__MODULE__, :start_link, [Map.delete(args, :id)]}
     }
   end
@@ -174,12 +182,20 @@ defmodule XMAVLink.Router do
 
   @spec subscribe(router_ref | subscribe_query) :: :ok | {:error, :invalid_message}
   def subscribe(router) when is_router_ref(router), do: subscribe(router, [])
+  def subscribe(nil), do: invalid_router_ref!(nil)
+
+  def subscribe(invalid_router) when is_tuple(invalid_router),
+    do: invalid_router_ref!(invalid_router)
+
   def subscribe(query), do: subscribe(__MODULE__, query)
 
   @spec subscribe(router_ref, subscribe_query) :: :ok | {:error, :invalid_message}
-  def subscribe(router, query) do
+  def subscribe(router, query) when is_router_ref(router) do
+    query = normalize_subscribe_query(query)
+
     with message <- Keyword.get(query, :message),
-         true <- message == nil or message == :unknown or Code.ensure_loaded?(message) do
+         true <-
+           message == nil or message == XMAVLink.UnknownMessage or Code.ensure_loaded?(message) do
       # Synchronous: returns only after the subscription is committed to the
       # Router state. This prevents a race where the caller sends an outbound
       # message that elicits a reply before the inbound subscription is in
@@ -207,6 +223,8 @@ defmodule XMAVLink.Router do
     end
   end
 
+  def subscribe(invalid_router, _query), do: invalid_router_ref!(invalid_router)
+
   @doc """
   Un-subscribes calling process from all existing subscriptions
 
@@ -220,7 +238,10 @@ defmodule XMAVLink.Router do
   def unsubscribe(), do: unsubscribe(__MODULE__)
 
   @spec unsubscribe(router_ref) :: :ok
-  def unsubscribe(router), do: GenServer.cast(router, {:unsubscribe, self()})
+  def unsubscribe(router) when is_router_ref(router),
+    do: GenServer.cast(router, {:unsubscribe, self()})
+
+  def unsubscribe(invalid_router), do: invalid_router_ref!(invalid_router)
 
   @doc """
   Send a MAVLink message to one or more recipients using available
@@ -272,6 +293,9 @@ defmodule XMAVLink.Router do
   def pack_and_send(router, message) when is_router_ref(router) and is_map(message),
     do: pack_and_send(router, message, 2, [])
 
+  def pack_and_send(invalid_router, message) when is_map(message),
+    do: invalid_router_ref!(invalid_router)
+
   @spec pack_and_send(Message.t(), Types.version() | keyword) ::
           :ok | {:error, :protocol_undefined}
   def pack_and_send(message, opts) when is_list(opts),
@@ -287,13 +311,16 @@ defmodule XMAVLink.Router do
   def pack_and_send(router, message, version) when is_router_ref(router),
     do: pack_and_send(router, message, version, [])
 
+  def pack_and_send(invalid_router, message, _version) when is_map(message),
+    do: invalid_router_ref!(invalid_router)
+
   @spec pack_and_send(Message.t(), Types.version(), keyword) ::
           :ok | {:error, :protocol_undefined}
   def pack_and_send(message, version, opts), do: pack_and_send(__MODULE__, message, version, opts)
 
   @spec pack_and_send(router_ref, Message.t(), Types.version(), keyword) ::
           :ok | {:error, :protocol_undefined}
-  def pack_and_send(router, message, version, opts) do
+  def pack_and_send(router, message, version, opts) when is_router_ref(router) do
     source_identity = source_identity!(opts)
 
     # We can only pack payload at this point because we need router state to get source
@@ -308,9 +335,8 @@ defmodule XMAVLink.Router do
           {0, 0}
         end
 
-      # Atom and pid targets still receive the same vanilla message as external
-      # connections. Global/via names need GenServer dispatch because Kernel.send/2
-      # cannot resolve those names.
+      # Resolve all router target shapes before dispatch so missing global/via
+      # names fail fast instead of being silently dropped by GenServer.cast/2.
       dispatch_local(
         router,
         struct(Frame,
@@ -338,9 +364,22 @@ defmodule XMAVLink.Router do
     end
   end
 
-  defp dispatch_local({:global, _} = router, frame), do: GenServer.cast(router, {:local, frame})
-  defp dispatch_local({:via, _, _} = router, frame), do: GenServer.cast(router, {:local, frame})
-  defp dispatch_local(router, frame), do: send(router, {:local, frame})
+  def pack_and_send(invalid_router, _message, _version, _opts),
+    do: invalid_router_ref!(invalid_router)
+
+  defp dispatch_local(router, frame) do
+    case GenServer.whereis(router) do
+      nil -> router_not_running!(router)
+      pid -> send(pid, {:local, frame})
+    end
+  end
+
+  defp child_id(%{id: id}, _name) when not is_nil(id), do: id
+
+  defp child_id(_args, nil),
+    do: raise(ArgumentError, "router child_spec requires :id when :name is nil")
+
+  defp child_id(_args, name), do: name
 
   defp normalize_start_args(args) do
     args = Map.new(args)
@@ -360,22 +399,22 @@ defmodule XMAVLink.Router do
   defp subscription_cache_name(nil), do: nil
   defp subscription_cache_name(__MODULE__), do: XMAVLink.SubscriptionCache
 
-  defp subscription_cache_name(name) when is_atom(name) do
-    name
-    |> Atom.to_string()
-    |> Kernel.<>(".SubscriptionCache")
-    |> String.to_atom()
+  defp subscription_cache_name(name), do: {:global, {__MODULE__, :subscription_cache, name}}
+
+  defp normalize_subscribe_query(query) do
+    Keyword.update(query, :message, nil, fn
+      :unknown -> XMAVLink.UnknownMessage
+      message -> message
+    end)
   end
 
-  defp subscription_cache_name({:global, name}) do
-    {:global, {__MODULE__, :subscription_cache, name}}
+  defp invalid_router_ref!(router) do
+    raise ArgumentError, "invalid router target #{inspect(router)}"
   end
 
-  defp subscription_cache_name({:via, registry, name}) do
-    {:via, registry, {__MODULE__, :subscription_cache, name}}
+  defp router_not_running!(router) do
+    raise ArgumentError, "router target #{inspect(router)} is not running"
   end
-
-  defp subscription_cache_name(_name), do: nil
 
   defp route_local(frame, state) do
     LocalConnection.handle_info({:local, frame}, state.connections.local, state.dialect)

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -9,6 +9,8 @@ defmodule XMAVLink.Supervisor do
 
   @impl true
   def init(_) do
+    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router)
+
     children =
       [
         :poolboy.child_spec(
@@ -22,25 +24,29 @@ defmodule XMAVLink.Supervisor do
         {
           XMAVLink.Router,
           %{
+            name: router_name,
             dialect: Application.get_env(:xmavlink, :dialect),
             system: Application.get_env(:xmavlink, :system_id),
             component: Application.get_env(:xmavlink, :component_id),
             connection_strings: Application.get_env(:xmavlink, :connections)
           }
         }
-      ] ++ heartbeat_child_specs()
+      ] ++ heartbeat_child_specs(router_name)
 
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  defp heartbeat_child_specs do
+  defp heartbeat_child_specs(router_name) do
     specs = heartbeat_specs()
     multi? = length(specs) > 1
 
     specs
     |> Enum.with_index()
     |> Enum.map(fn {spec, index} ->
-      child_spec = if multi?, do: Keyword.put_new(spec, :name, nil), else: spec
+      child_spec =
+        spec
+        |> Keyword.put_new(:router, router_name)
+        |> maybe_unnamed_heartbeat(multi?)
 
       %{
         id: Keyword.get(spec, :id, {XMAVLink.Heartbeat, index}),
@@ -48,6 +54,9 @@ defmodule XMAVLink.Supervisor do
       }
     end)
   end
+
+  defp maybe_unnamed_heartbeat(spec, true), do: Keyword.put_new(spec, :name, nil)
+  defp maybe_unnamed_heartbeat(spec, false), do: spec
 
   # Heartbeats are started only when configured, so existing apps that
   # build their own heartbeats keep working unchanged. `:heartbeat` keeps

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -9,7 +9,7 @@ defmodule XMAVLink.Supervisor do
 
   @impl true
   def init(_) do
-    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router)
+    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
 
     children =
       [

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.7.1",
+      version: "0.8.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,8 @@ defmodule XMAVLink.Mixfile do
         system_id: 245,
         # Default to system control
         component_id: 250,
+        # Default registered router name
+        router_name: XMAVLink.Router,
         connections: []
       ],
       mod: {XMAVLink.Application, []},

--- a/test/mavlink_heartbeat_test.exs
+++ b/test/mavlink_heartbeat_test.exs
@@ -52,6 +52,21 @@ defmodule XMAVLink.HeartbeatTest do
 
       GenServer.stop(hb)
     end
+
+    test "dispatches through a configured router target" do
+      msg = sample_heartbeat()
+
+      {:ok, hb} =
+        Heartbeat.start_link(
+          interval_ms: 10,
+          message: msg,
+          router: self()
+        )
+
+      assert_receive {:local, %{message: ^msg}}, 200
+
+      GenServer.stop(hb)
+    end
   end
 
   describe "with a {m, f, a} :builder" do

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -144,6 +144,152 @@ defmodule XMAVLink.Test.Router do
     end
   end
 
+  describe "router instances" do
+    test "child specs use the configured router name as the child id" do
+      router_name = XMAVLink.Test.Router.ChildSpecRouter
+
+      assert %{
+               id: ^router_name,
+               start:
+                 {Router, :start_link,
+                  [
+                    %{
+                      name: ^router_name,
+                      system: 1,
+                      component: 1,
+                      dialect: Common,
+                      connections: [],
+                      connection_strings: []
+                    }
+                  ]}
+             } =
+               Router.child_spec(%{
+                 name: router_name,
+                 system: 1,
+                 component: 1,
+                 dialect: Common,
+                 connections: []
+               })
+    end
+
+    test "targets subscriptions and outbound sends to a named router" do
+      router_name = XMAVLink.Test.Router.NamedRouter
+
+      {:ok, router_pid} =
+        Router.start_link(%{
+          name: router_name,
+          system: 42,
+          component: 100,
+          dialect: Common,
+          connection_strings: []
+        })
+
+      on_exit(fn ->
+        stop_router(router_pid)
+        stop_subscription_cache(router_name)
+      end)
+
+      assert :ok =
+               Router.subscribe(router_name, message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = sample_heartbeat()
+      assert :ok = Router.pack_and_send(router_name, msg)
+
+      assert_receive %XMAVLink.Frame{
+                       message: ^msg,
+                       source_system: 42,
+                       source_component: 100
+                     },
+                     200
+
+      state = :sys.get_state(router_name)
+      assert state.name == router_name
+      assert state.subscription_cache == subscription_cache_name(router_name)
+
+      Router.unsubscribe(router_name)
+    end
+
+    test "keeps subscriptions isolated between named routers" do
+      router_a = XMAVLink.Test.Router.NamedRouterA
+      router_b = XMAVLink.Test.Router.NamedRouterB
+
+      {:ok, pid_a} =
+        Router.start_link(%{
+          name: router_a,
+          system: 1,
+          component: 100,
+          dialect: Common,
+          connection_strings: []
+        })
+
+      {:ok, pid_b} =
+        Router.start_link(%{
+          name: router_b,
+          system: 2,
+          component: 100,
+          dialect: Common,
+          connection_strings: []
+        })
+
+      on_exit(fn ->
+        stop_router(pid_a)
+        stop_router(pid_b)
+        stop_subscription_cache(router_a)
+        stop_subscription_cache(router_b)
+      end)
+
+      assert :ok = Router.subscribe(router_a, message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = sample_heartbeat()
+      assert :ok = Router.pack_and_send(router_b, msg)
+
+      refute_receive %XMAVLink.Frame{source_system: 2}, 50
+
+      assert :ok = Router.pack_and_send(router_a, msg)
+
+      assert_receive %XMAVLink.Frame{
+                       message: ^msg,
+                       source_system: 1,
+                       source_component: 100
+                     },
+                     200
+
+      Router.unsubscribe(router_a)
+    end
+
+    test "targets an unregistered router by pid" do
+      {:ok, router_pid} =
+        Router.start_link(%{
+          name: nil,
+          system: 3,
+          component: 100,
+          dialect: Common,
+          connection_strings: []
+        })
+
+      on_exit(fn -> stop_router(router_pid) end)
+
+      assert :ok =
+               Router.subscribe(router_pid, message: Common.Message.Heartbeat, as_frame: true)
+
+      msg = sample_heartbeat()
+      assert :ok = Router.pack_and_send(router_pid, msg)
+
+      assert_receive %XMAVLink.Frame{
+                       message: ^msg,
+                       source_system: 3,
+                       source_component: 100
+                     },
+                     200
+
+      state = :sys.get_state(router_pid)
+      assert state.name == nil
+      assert state.subscription_cache == nil
+
+      Router.unsubscribe(router_pid)
+    end
+  end
+
   describe "udpout reply handling" do
     # Regression for the NAT-mismatch echo loop: when a `udpout:` connection's
     # reply arrives from a source IP that differs from the configured target
@@ -542,5 +688,28 @@ defmodule XMAVLink.Test.Router do
     send(acceptor, :close_tcp_peer)
     :gen_tcp.close(listen_socket)
     :ok
+  end
+
+  defp subscription_cache_name(XMAVLink.Router), do: XMAVLink.SubscriptionCache
+
+  defp subscription_cache_name(router_name) when is_atom(router_name) do
+    router_name
+    |> Atom.to_string()
+    |> Kernel.<>(".SubscriptionCache")
+    |> String.to_atom()
+  end
+
+  defp stop_subscription_cache(router_name) do
+    router_name
+    |> subscription_cache_name()
+    |> Process.whereis()
+    |> case do
+      nil -> :ok
+      pid -> Agent.stop(pid)
+    end
+  end
+
+  defp stop_router(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid)
   end
 end

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -172,6 +172,31 @@ defmodule XMAVLink.Test.Router do
                })
     end
 
+    test "child specs require an explicit id for unnamed routers" do
+      assert_raise ArgumentError, ~r/requires :id when :name is nil/, fn ->
+        Router.child_spec(%{
+          name: nil,
+          system: 1,
+          component: 1,
+          dialect: Common,
+          connections: []
+        })
+      end
+
+      assert %{
+               id: :unnamed_router,
+               start: {Router, :start_link, [%{name: nil}]}
+             } =
+               Router.child_spec(%{
+                 id: :unnamed_router,
+                 name: nil,
+                 system: 1,
+                 component: 1,
+                 dialect: Common,
+                 connections: []
+               })
+    end
+
     test "targets subscriptions and outbound sends to a named router" do
       router_name = XMAVLink.Test.Router.NamedRouter
 
@@ -287,6 +312,62 @@ defmodule XMAVLink.Test.Router do
       assert state.subscription_cache == nil
 
       Router.unsubscribe(router_pid)
+    end
+
+    test "normalizes :unknown subscriptions to the downstream unknown-message sentinel" do
+      router_name = XMAVLink.Test.Router.UnknownMessageRouter
+
+      {:ok, router_pid} =
+        Router.start_link(%{
+          name: router_name,
+          system: 4,
+          component: 100,
+          dialect: Common,
+          connection_strings: []
+        })
+
+      on_exit(fn ->
+        stop_router(router_pid)
+        stop_subscription_cache(router_name)
+      end)
+
+      assert :ok = Router.subscribe(router_name, message: :unknown, as_frame: true)
+
+      subscriber = self()
+      state = :sys.get_state(router_name)
+      [{query, ^subscriber}] = state.connections.local.subscriptions
+      assert query.message == XMAVLink.UnknownMessage
+
+      XMAVLink.LocalConnection.forward(state.connections.local, %XMAVLink.Frame{
+        source_system: 1,
+        source_component: 1,
+        target_system: 0,
+        target_component: 0,
+        target: :broadcast,
+        message: nil
+      })
+
+      assert_receive %XMAVLink.Frame{message: %{__struct__: XMAVLink.UnknownMessage}}, 200
+
+      Router.unsubscribe(router_name)
+    end
+
+    test "rejects invalid router target shapes" do
+      assert_raise ArgumentError, ~r/invalid router target nil/, fn ->
+        Router.subscribe(nil, [])
+      end
+
+      assert_raise ArgumentError, ~r/invalid router target {:bad}/, fn ->
+        Router.pack_and_send({:bad}, sample_heartbeat())
+      end
+    end
+
+    test "raises when a named router target is not running" do
+      assert_raise ArgumentError,
+                   ~r/router target {:global, :missing_router} is not running/,
+                   fn ->
+                     Router.pack_and_send({:global, :missing_router}, sample_heartbeat())
+                   end
     end
   end
 
@@ -692,17 +773,13 @@ defmodule XMAVLink.Test.Router do
 
   defp subscription_cache_name(XMAVLink.Router), do: XMAVLink.SubscriptionCache
 
-  defp subscription_cache_name(router_name) when is_atom(router_name) do
-    router_name
-    |> Atom.to_string()
-    |> Kernel.<>(".SubscriptionCache")
-    |> String.to_atom()
-  end
+  defp subscription_cache_name(router_name),
+    do: {:global, {XMAVLink.Router, :subscription_cache, router_name}}
 
   defp stop_subscription_cache(router_name) do
     router_name
     |> subscription_cache_name()
-    |> Process.whereis()
+    |> GenServer.whereis()
     |> case do
       nil -> :ok
       pid -> Agent.stop(pid)

--- a/test/mavlink_supervisor_test.exs
+++ b/test/mavlink_supervisor_test.exs
@@ -1,0 +1,40 @@
+defmodule XMAVLink.SupervisorTest do
+  use ExUnit.Case, async: false
+
+  test "falls back to the default router name when app config sets router_name to nil" do
+    previous_router_name = Application.get_env(:xmavlink, :router_name)
+    previous_heartbeat = Application.get_env(:xmavlink, :heartbeat)
+
+    Application.put_env(:xmavlink, :router_name, nil)
+    Application.put_env(:xmavlink, :heartbeat, interval_ms: 1000, message: sample_heartbeat())
+
+    on_exit(fn ->
+      restore_env(:router_name, previous_router_name)
+      restore_env(:heartbeat, previous_heartbeat)
+    end)
+
+    assert {:ok, {_supervisor_flags, children}} = XMAVLink.Supervisor.init([])
+
+    assert %{start: {XMAVLink.Router, :start_link, [%{name: XMAVLink.Router}]}} =
+             Enum.find(children, &match?(%{id: XMAVLink.Router}, &1))
+
+    assert %{start: {XMAVLink.Heartbeat, :start_link, [heartbeat_spec]}} =
+             Enum.find(children, &match?(%{id: {XMAVLink.Heartbeat, 0}}, &1))
+
+    assert Keyword.fetch!(heartbeat_spec, :router) == XMAVLink.Router
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:xmavlink, key)
+  defp restore_env(key, value), do: Application.put_env(:xmavlink, key, value)
+
+  defp sample_heartbeat do
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- Add named and pid-targetable router APIs while preserving the default `XMAVLink.Router` convenience path.
- Add router child-spec/name support plus per-router local subscription caches.
- Route configured heartbeats through the application router name and document the router instance model.
- Add tests for child specs, named-router targeting/isolation, pid-targeted routers, and heartbeat router targets.

Closes #22.

## Validation

- `mix format --check-formatted lib/mavlink/router.ex lib/mavlink/local_connection.ex lib/mavlink/heartbeat.ex lib/mavlink/supervisor.ex test/mavlink_router_test.exs test/mavlink_heartbeat_test.exs mix.exs`
- `mix test test/mavlink_router_test.exs test/mavlink_heartbeat_test.exs`
- `mix test`
- `git diff --check`