### PR TITLE
Move configured connection lifecycle under supervision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.9.0 - 2026-05-07
 
 - Moved configured connection startup and reconnect behavior under supervised
   per-router connection workers with explicit retry delays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Moved configured connection startup and reconnect behavior under supervised
+  per-router connection workers with explicit retry delays.
+- Added documentation and coverage for connection worker retry/reconnect
+  behavior.
+
 ## 0.8.0 - 2026-05-07
 
 - Added named router instance support while preserving the default

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.8.0"}
+     {:xmavlink, "~> 0.9.0"}
    ]
  end
  ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ XMAVLink supports the following connection string formats:
 - **TCP Out (client)**: `tcpout:<address>:<port>` (e.g., `"tcpout:192.168.1.100:5760"`)
 - **TCP In (server)**: `tcpin:<address>:<port>` (e.g., `"tcpin:0.0.0.0:5760"`)
 
+### Configured Connection Lifecycle
+
+Configured serial, UDP, and TCP connections run under a per-router dynamic
+supervisor. Each connection has a worker process that owns its socket or UART
+resource, forwards inbound frames to the router, and reconnects after open
+failures or TCP/serial disconnects.
+
+By default, connection workers retry every 1000 ms. Override the retry delay
+with `:connection_retry_ms`:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["tcpout:127.0.0.1:5760"],
+  connection_retry_ms: 500
+```
+
 ### DNS Hostname Support
 
 As of version 0.4.2, XMAVLink supports DNS hostnames in addition to IP addresses for network connections. This is particularly useful in:

--- a/lib/mavlink/connection_supervisor.ex
+++ b/lib/mavlink/connection_supervisor.ex
@@ -1,0 +1,14 @@
+defmodule XMAVLink.ConnectionSupervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  def start_link(_opts \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, [])
+  end
+
+  @impl true
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/mavlink/connection_worker.ex
+++ b/lib/mavlink/connection_worker.ex
@@ -1,0 +1,228 @@
+defmodule XMAVLink.ConnectionWorker do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+
+  defstruct [
+    :router,
+    :transport,
+    :tokens,
+    :connection_key,
+    :connection,
+    retry_ms: 1_000,
+    retry_timer: nil,
+    status: :disconnected
+  ]
+
+  @type transport :: module
+
+  @type t :: %__MODULE__{
+          router: pid,
+          transport: transport,
+          tokens: [term],
+          connection_key: term | nil,
+          connection: term | nil,
+          retry_ms: non_neg_integer,
+          retry_timer: reference | nil,
+          status: :disconnected | :connecting | :connected
+        }
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, Map.new(args))
+  end
+
+  @doc false
+  def child_spec(args) do
+    args = Map.new(args)
+
+    %{
+      id: {__MODULE__, Map.fetch!(args, :tokens)},
+      start: {__MODULE__, :start_link, [args]},
+      restart: :permanent,
+      shutdown: 5_000,
+      type: :worker
+    }
+  end
+
+  @doc false
+  def reconnect(worker) when is_pid(worker) do
+    GenServer.cast(worker, :reconnect)
+  end
+
+  @doc false
+  def forward(worker, connection, frame) when is_pid(worker) do
+    GenServer.cast(worker, {:forward, connection, frame})
+  end
+
+  @doc false
+  def status(worker) when is_pid(worker) do
+    GenServer.call(worker, :status)
+  end
+
+  @impl true
+  def init(args) do
+    Process.flag(:trap_exit, true)
+
+    state = %__MODULE__{
+      router: Map.fetch!(args, :router),
+      transport: Map.fetch!(args, :transport),
+      tokens: Map.fetch!(args, :tokens),
+      retry_ms: Map.get(args, :retry_ms, 1_000)
+    }
+
+    {:ok, state, {:continue, :connect}}
+  end
+
+  @impl true
+  def handle_continue(:connect, state) do
+    {:noreply, connect(state)}
+  end
+
+  @impl true
+  def handle_call(:status, _from, state) do
+    {:reply,
+     %{
+       status: state.status,
+       connection_key: state.connection_key,
+       retry_timer: state.retry_timer
+     }, state}
+  end
+
+  @impl true
+  def handle_cast(:reconnect, state) do
+    state =
+      state
+      |> cancel_retry()
+      |> close_connection()
+
+    {:noreply, connect(%{state | connection_key: nil, connection: nil})}
+  end
+
+  def handle_cast({:forward, connection, frame}, state) do
+    _ = state.transport.forward(connection, frame)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:connect, state) do
+    {:noreply, connect(%{state | retry_timer: nil})}
+  end
+
+  def handle_info(message = {:udp, _socket, _address, _port, _raw}, state) do
+    send(state.router, {:connection_message, self(), message})
+    {:noreply, state}
+  end
+
+  def handle_info(message = {:tcp, _socket, _raw}, state) do
+    send(state.router, {:connection_message, self(), message})
+    {:noreply, state}
+  end
+
+  def handle_info({:tcp_closed, socket}, state) do
+    send(state.router, {:connection_closed, self(), socket})
+
+    state =
+      state
+      |> close_connection()
+      |> schedule_retry()
+
+    {:noreply, %{state | connection_key: nil, connection: nil}}
+  end
+
+  def handle_info({:tcp_error, socket, reason}, state) do
+    send(state.router, {:connection_closed, self(), socket})
+
+    state =
+      state
+      |> close_connection()
+      |> schedule_retry(reason)
+
+    {:noreply, %{state | connection_key: nil, connection: nil}}
+  end
+
+  def handle_info(message = {:circuits_uart, _port, raw}, state) when is_binary(raw) do
+    send(state.router, {:connection_message, self(), message})
+    {:noreply, state}
+  end
+
+  def handle_info({:circuits_uart, port, {:error, reason}}, state) do
+    send(state.router, {:connection_closed, self(), port})
+
+    state =
+      state
+      |> close_connection()
+      |> schedule_retry(reason)
+
+    {:noreply, %{state | connection_key: nil, connection: nil}}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    _ = close_connection(state)
+    :ok
+  end
+
+  defp connect(state) do
+    state = %{state | status: :connecting}
+
+    case state.transport.open(state.tokens, self()) do
+      {:ok, nil, connection} ->
+        %{state | status: :connected, connection: connection}
+
+      {:ok, connection_key, connection} ->
+        send(state.router, {:add_connection, connection_key, connection, self()})
+
+        %{
+          state
+          | status: :connected,
+            connection_key: connection_key,
+            connection: connection
+        }
+
+      {:error, reason} ->
+        schedule_retry(state, reason)
+    end
+  end
+
+  defp schedule_retry(state, reason \\ nil) do
+    if reason do
+      Logger.warning(
+        "Could not open #{connection_description(state.tokens)}: #{inspect(reason)}. " <>
+          "Retrying in #{state.retry_ms} ms"
+      )
+    end
+
+    %{
+      state
+      | status: :disconnected,
+        retry_timer: Process.send_after(self(), :connect, state.retry_ms)
+    }
+  end
+
+  defp cancel_retry(%{retry_timer: nil} = state), do: state
+
+  defp cancel_retry(%{retry_timer: retry_timer} = state) do
+    Process.cancel_timer(retry_timer)
+    %{state | retry_timer: nil}
+  end
+
+  defp close_connection(%{connection: nil} = state), do: state
+
+  defp close_connection(state) do
+    _ = state.transport.close(state.connection)
+    state
+  end
+
+  defp connection_description([protocol, address, port])
+       when is_tuple(address) and tuple_size(address) == 4 do
+    "#{protocol}:#{Enum.join(Tuple.to_list(address), ".")}:#{port}"
+  end
+
+  defp connection_description(["serial", port, baud]), do: "serial:#{port}:#{baud}"
+  defp connection_description(tokens), do: inspect(tokens)
+end

--- a/lib/mavlink/connection_worker.ex
+++ b/lib/mavlink/connection_worker.ex
@@ -24,7 +24,7 @@ defmodule XMAVLink.ConnectionWorker do
           connection_key: term | nil,
           connection: term | nil,
           retry_ms: non_neg_integer,
-          retry_timer: reference | nil,
+          retry_timer: {reference, reference} | nil,
           status: :disconnected | :connecting | :connected
         }
 
@@ -100,13 +100,17 @@ defmodule XMAVLink.ConnectionWorker do
   end
 
   def handle_cast({:forward, connection, frame}, state) do
-    _ = state.transport.forward(connection, frame)
+    _ = state.transport.forward(direct_connection(connection), frame)
     {:noreply, state}
   end
 
   @impl true
-  def handle_info(:connect, state) do
+  def handle_info({:connect, connect_ref}, %{retry_timer: {_timer_ref, connect_ref}} = state) do
     {:noreply, connect(%{state | retry_timer: nil})}
+  end
+
+  def handle_info({:connect, _stale_ref}, state) do
+    {:noreply, state}
   end
 
   def handle_info(message = {:udp, _socket, _address, _port, _raw}, state) do
@@ -200,13 +204,19 @@ defmodule XMAVLink.ConnectionWorker do
     %{
       state
       | status: :disconnected,
-        retry_timer: Process.send_after(self(), :connect, state.retry_ms)
+        retry_timer: schedule_connect(state.retry_ms)
     }
+  end
+
+  defp schedule_connect(retry_ms) do
+    connect_ref = make_ref()
+    timer_ref = Process.send_after(self(), {:connect, connect_ref}, retry_ms)
+    {timer_ref, connect_ref}
   end
 
   defp cancel_retry(%{retry_timer: nil} = state), do: state
 
-  defp cancel_retry(%{retry_timer: retry_timer} = state) do
+  defp cancel_retry(%{retry_timer: {retry_timer, _connect_ref}} = state) do
     Process.cancel_timer(retry_timer)
     %{state | retry_timer: nil}
   end
@@ -217,6 +227,12 @@ defmodule XMAVLink.ConnectionWorker do
     _ = state.transport.close(state.connection)
     state
   end
+
+  defp direct_connection(%{worker: _worker} = connection) do
+    %{connection | worker: nil}
+  end
+
+  defp direct_connection(connection), do: connection
 
   defp connection_description([protocol, address, port])
        when is_tuple(address) and tuple_size(address) == 4 do

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -71,13 +71,14 @@ defmodule XMAVLink.Router do
     connection_worker_monitors: %{},
     # %{socket|port|local: XMAVLink.*_Connection}
     connections: %{},
-    # Connection and MAVLink version tuple keyed by MAVLink addresses
+    # Connection key last observed for each MAVLink address
     routes: %{}
   ]
 
   # Can't used qualified type as map key
   @type mavlink_address :: Types.mavlink_address()
   @type mavlink_connection :: Types.connection()
+  @type connection_key :: :local | binary | port | {port, Types.net_address(), Types.net_port()}
   @type router_name :: atom | {:global, term} | {:via, module, term}
   @type router_ref :: GenServer.server()
   @type subscribe_query :: [
@@ -92,10 +93,10 @@ defmodule XMAVLink.Router do
           connection_retry_ms: non_neg_integer,
           subscription_cache: router_name | nil,
           connection_supervisor: pid | nil,
-          connection_workers: %{term => pid},
+          connection_workers: %{connection_key() => pid},
           connection_worker_monitors: %{reference => pid},
-          connections: %{},
-          routes: %{mavlink_address: {mavlink_connection, Types.version()}}
+          connections: %{connection_key() => mavlink_connection()},
+          routes: %{mavlink_address() => connection_key()}
         }
 
   defguardp is_router_ref(router)

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -17,9 +17,9 @@ defmodule XMAVLink.Router do
   require Logger
 
   import XMAVLink.Utils, only: [resolve_address: 1, parse_positive_integer: 1]
-  import Enum, only: [map: 2]
-
   alias XMAVLink.Types
+  alias XMAVLink.ConnectionSupervisor
+  alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
   alias XMAVLink.Message
   alias XMAVLink.Router
@@ -28,7 +28,6 @@ defmodule XMAVLink.Router do
   alias XMAVLink.TCPOutConnection
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
-  alias Circuits.UART
 
   @typedoc """
   Represents the state of the XMAVLink.Router. Initial values should be set in config.exs.
@@ -62,8 +61,14 @@ defmodule XMAVLink.Router do
     dialect: nil,
     # Connection descriptions from user
     connection_strings: [],
+    # Supervised connection retry delay
+    connection_retry_ms: 1_000,
     # Subscription cache name for restart restoration, if any
     subscription_cache: nil,
+    # Per-router supervised connection workers
+    connection_supervisor: nil,
+    connection_workers: %{},
+    connection_worker_monitors: %{},
     # %{socket|port|local: XMAVLink.*_Connection}
     connections: %{},
     # Connection and MAVLink version tuple keyed by MAVLink addresses
@@ -84,7 +89,11 @@ defmodule XMAVLink.Router do
           name: router_name | nil,
           dialect: module | nil,
           connection_strings: [String.t()],
+          connection_retry_ms: non_neg_integer,
           subscription_cache: router_name | nil,
+          connection_supervisor: pid | nil,
+          connection_workers: %{term => pid},
+          connection_worker_monitors: %{reference => pid},
           connections: %{},
           routes: %{mavlink_address: {mavlink_connection, Types.version()}}
         }
@@ -120,6 +129,10 @@ defmodule XMAVLink.Router do
                         udpout:<remote ip>:<remote port>
                         tcpout:<remote ip>:<remote port>
                         serial:<device>:<baud rate>
+  - connection_retry_ms:
+                        Retry delay for configured connection workers after
+                        open failures or TCP/serial disconnects. Defaults to
+                        1000 ms.
 
   - opts:               Standard GenServer options. Pass `:name` to register
                         a non-default router, or `name: nil` in the args map to
@@ -132,7 +145,8 @@ defmodule XMAVLink.Router do
             required(:dialect) => module,
             optional(:name) => router_name | nil,
             optional(:connection_strings) => [String.t()],
-            optional(:connections) => [String.t()]
+            optional(:connections) => [String.t()],
+            optional(:connection_retry_ms) => non_neg_integer
           },
           [{atom, any}]
         ) :: {:ok, pid}
@@ -384,8 +398,15 @@ defmodule XMAVLink.Router do
   defp normalize_start_args(args) do
     args = Map.new(args)
     connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
+    connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
 
-    Map.put(args, :connection_strings, connection_strings)
+    if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
+      raise ArgumentError, "connection_retry_ms must be a non-negative integer"
+    end
+
+    args
+    |> Map.put(:connection_strings, connection_strings)
+    |> Map.put(:connection_retry_ms, connection_retry_ms)
   end
 
   defp start_options(opts, nil), do: Keyword.delete(opts, :name)
@@ -459,15 +480,22 @@ defmodule XMAVLink.Router do
   # to us if successful) and initialise Router state
   def init(args) do
     subscription_cache = subscription_cache_name(args.name)
+    {:ok, connection_supervisor} = ConnectionSupervisor.start_link()
 
     LocalConnection.connect(:local, args.system, args.component, subscription_cache)
-    _ = map(args.connection_strings, &connect/1)
+    connection_specs = Enum.map(args.connection_strings, &connection_spec/1)
+
+    for connection_spec <- connection_specs do
+      start_connection_worker(connection_supervisor, connection_spec, args.connection_retry_ms)
+    end
 
     {:ok,
      %Router{
        name: args.name,
        dialect: args.dialect,
        connection_strings: args.connection_strings,
+       connection_retry_ms: args.connection_retry_ms,
+       connection_supervisor: connection_supervisor,
        subscription_cache: subscription_cache
      }}
   end
@@ -496,104 +524,80 @@ defmodule XMAVLink.Router do
   end
 
   @impl true
+  # Receive data from a supervised connection worker
+  def handle_info({:connection_message, worker, message = {:udp, _, _, _, _}}, state) do
+    handle_udp_message(message, worker, state)
+  end
+
   # Receive data on UDP connection
   def handle_info(
-        message = {:udp, socket, address, port, _},
-        state = %Router{connections: connections, dialect: dialect}
+        message = {:udp, _socket, _address, _port, _},
+        state
       ) do
-    {
-      :noreply,
-      case connections[socket] do
-        # A `udpout:` connection is registered under the bare `socket` key
-        # (see UDPOutConnection.connect/2). Any UDP packet arriving on that
-        # socket is a reply to our outbound traffic — attribute it to the
-        # UDPOut regardless of source IP. This is required behind NAT /
-        # masquerade / kube-proxy DNAT, where the reply's source IP is the
-        # NAT gateway rather than the address we sent to. Without this,
-        # we'd file the reply as a brand-new UDPInConnection under
-        # `{socket, reply_ip, reply_port}` and the broadcast `route/1`
-        # clause would forward subsequent inbound frames back out the
-        # original UDPOut — i.e. echo the host's traffic back to itself.
-        udpout = %UDPOutConnection{} ->
-          UDPOutConnection.handle_info(message, udpout, dialect)
+    handle_udp_message(message, nil, state)
+  end
 
-        _ ->
-          case connections[{socket, address, port}] do
-            connection = %UDPInConnection{} ->
-              UDPInConnection.handle_info(message, connection, dialect)
-
-            connection = %UDPOutConnection{} ->
-              UDPOutConnection.handle_info(message, connection, dialect)
-
-            nil ->
-              # New previously unseen UDPIn client
-              UDPInConnection.handle_info(message, nil, dialect)
-          end
-      end
-      |> update_route_info(state)
-      |> route
-    }
+  def handle_info({:connection_message, _worker, message = {:tcp, _, _}}, state) do
+    handle_tcp_message(message, state)
   end
 
   # Receive data on TCP connection
-  def handle_info(message = {:tcp, socket, _}, state) do
-    {
-      :noreply,
-      TCPOutConnection.handle_info(message, state.connections[socket], state.dialect)
-      |> update_route_info(state)
-      |> route
-    }
+  def handle_info(message = {:tcp, _socket, _}, state) do
+    handle_tcp_message(message, state)
+  end
+
+  def handle_info({:connection_closed, worker, connection_key}, state) do
+    {:noreply, remove_worker_connection(connection_key, worker, state)}
   end
 
   # Unlike UDP, TCP connections can close
   def handle_info({:tcp_closed, socket}, state) do
-    %TCPOutConnection{address: address, port: port} = state.connections[socket]
-    spawn(TCPOutConnection, :connect, [["tcpout", address, port], self()])
+    reconnect_worker(state.connection_workers[socket])
     {:noreply, remove_connection(socket, state)}
   end
 
+  def handle_info({:connection_message, _worker, message = {:circuits_uart, _, raw}}, state)
+      when is_binary(raw) do
+    handle_serial_message(message, state)
+  end
+
   # Received data on serial connection
-  def handle_info(message = {:circuits_uart, port, raw}, state) when is_binary(raw) do
-    {
-      :noreply,
-      SerialConnection.handle_info(message, state.connections[port], state.dialect)
-      |> update_route_info(state)
-      |> route
-    }
+  def handle_info(message = {:circuits_uart, _port, raw}, state) when is_binary(raw) do
+    handle_serial_message(message, state)
   end
 
   # Received error on serial connection
   def handle_info({:circuits_uart, port, {:error, _reason}}, state) do
-    %SerialConnection{baud: baud, uart: uart} = state.connections[port]
-
-    spawn(SerialConnection, :connect, [
-      ["serial", port, baud, :poolboy.checkout(XMAVLink.UARTPool)],
-      self()
-    ])
-
-    :ok = UART.close(uart)
-    # After checkout to make sure we get a fresh UART, this one might be reused later
-    :poolboy.checkin(XMAVLink.UARTPool, uart)
+    reconnect_worker(state.connection_workers[port])
     {:noreply, remove_connection(port, state)}
   end
 
-  # A local subscribing Elixir process has crashed, remove them from our subscriber list
-  def handle_info({:DOWN, _, :process, pid, _}, state),
-    do:
-      {:noreply,
-       update_in(
-         state,
-         [Access.key!(:connections), :local],
-         &LocalConnection.subscriber_down(pid, &1)
-       )}
+  # A local subscribing Elixir process or a supervised connection worker has crashed.
+  def handle_info({:DOWN, ref, :process, pid, _}, state) do
+    case Map.pop(state.connection_worker_monitors, ref) do
+      {nil, _worker_monitors} ->
+        {:noreply,
+         update_in(
+           state,
+           [Access.key!(:connections), :local],
+           &LocalConnection.subscriber_down(pid, &1)
+         )}
+
+      {worker, worker_monitors} ->
+        {:noreply,
+         state
+         |> struct(connection_worker_monitors: worker_monitors)
+         |> remove_connections_for_worker(worker)}
+    end
+  end
 
   # A call to pack_and_send() from a local Elixir process, sent as a vanilla message for symmetry with other connection types
   def handle_info({:local, frame}, state) do
     {:noreply, route_local(frame, state)}
   end
 
-  # A spawned *Connection.connect() call has successfully got a
-  # connection, and wants to add it to our connection list.
+  # A supervised connection worker has successfully opened a connection and
+  # wants to add it to our connection list.
   def handle_info(
         {:add_connection, connection_key, connection},
         state = %Router{connections: connections}
@@ -607,33 +611,129 @@ defmodule XMAVLink.Router do
     }
   end
 
+  def handle_info(
+        {:add_connection, connection_key, connection, worker},
+        state = %Router{connections: connections}
+      ) do
+    {
+      :noreply,
+      state
+      |> monitor_connection_worker(worker)
+      |> struct(
+        connections: Map.put(connections, connection_key, connection),
+        connection_workers: Map.put(state.connection_workers, connection_key, worker)
+      )
+    }
+  end
+
   # Ignore weird messages
   def handle_info(_msg, state) do
     {:noreply, state}
+  end
+
+  defp handle_udp_message(
+         message = {:udp, socket, address, port, _},
+         worker,
+         state = %Router{connections: connections, dialect: dialect}
+       ) do
+    {
+      :noreply,
+      case connections[socket] do
+        # A `udpout:` connection is registered under the bare `socket` key
+        # (see UDPOutConnection.open/2). Any UDP packet arriving on that
+        # socket is a reply to our outbound traffic - attribute it to the
+        # UDPOut regardless of source IP. This is required behind NAT /
+        # masquerade / kube-proxy DNAT, where the reply's source IP is the
+        # NAT gateway rather than the address we sent to. Without this,
+        # we'd file the reply as a brand-new UDPInConnection under
+        # `{socket, reply_ip, reply_port}` and the broadcast `route/1`
+        # clause would forward subsequent inbound frames back out the
+        # original UDPOut - i.e. echo the host's traffic back to itself.
+        udpout = %UDPOutConnection{} ->
+          UDPOutConnection.handle_info(message, udpout, dialect)
+
+        _ ->
+          case connections[{socket, address, port}] do
+            connection = %UDPInConnection{} ->
+              UDPInConnection.handle_info(message, connection, dialect)
+
+            connection = %UDPOutConnection{} ->
+              UDPOutConnection.handle_info(message, connection, dialect)
+
+            nil ->
+              # New previously unseen UDPIn client
+              UDPInConnection.handle_info(message, nil, dialect, worker)
+          end
+      end
+      |> update_route_info(state)
+      |> route
+    }
+  end
+
+  defp handle_tcp_message(message = {:tcp, socket, _}, state) do
+    case state.connections[socket] do
+      nil ->
+        {:noreply, state}
+
+      connection ->
+        {
+          :noreply,
+          TCPOutConnection.handle_info(message, connection, state.dialect)
+          |> update_route_info(state)
+          |> route
+        }
+    end
+  end
+
+  defp handle_serial_message(message = {:circuits_uart, port, _raw}, state) do
+    case state.connections[port] do
+      nil ->
+        {:noreply, state}
+
+      connection ->
+        {
+          :noreply,
+          SerialConnection.handle_info(message, connection, state.dialect)
+          |> update_route_info(state)
+          |> route
+        }
+    end
   end
 
   ####################
   # Helper Functions #
   ####################
 
-  # Handle user configured connections by spawning a process to try to connect. If successful they will send
-  # us an :add_connection message with the details. The local connection gets added automatically.
-  defp connect(connection_string) when is_binary(connection_string),
-    do: connect(String.split(connection_string, [":", ","]))
+  # Handle user configured connections with supervised workers. If
+  # successful they send us an :add_connection message with the details. The
+  # local connection gets added automatically.
+  defp start_connection_worker(connection_supervisor, connection_spec, retry_ms) do
+    DynamicSupervisor.start_child(
+      connection_supervisor,
+      {ConnectionWorker,
+       Map.merge(connection_spec, %{
+         router: self(),
+         retry_ms: retry_ms
+       })}
+    )
+  end
 
-  defp connect(tokens = ["udpin" | _]),
-    do: spawn(UDPInConnection, :connect, [validate_address_and_port(tokens), self()])
+  defp connection_spec(connection_string) when is_binary(connection_string),
+    do: connection_spec(String.split(connection_string, [":", ","]))
 
-  defp connect(tokens = ["udpout" | _]),
-    do: spawn(UDPOutConnection, :connect, [validate_address_and_port(tokens), self()])
+  defp connection_spec(tokens = ["udpin" | _]),
+    do: %{transport: UDPInConnection, tokens: validate_address_and_port(tokens)}
 
-  defp connect(tokens = ["tcpout" | _]),
-    do: spawn(TCPOutConnection, :connect, [validate_address_and_port(tokens), self()])
+  defp connection_spec(tokens = ["udpout" | _]),
+    do: %{transport: UDPOutConnection, tokens: validate_address_and_port(tokens)}
 
-  defp connect(tokens = ["serial" | _]),
-    do: spawn(SerialConnection, :connect, [validate_port_and_baud(tokens), self()])
+  defp connection_spec(tokens = ["tcpout" | _]),
+    do: %{transport: TCPOutConnection, tokens: validate_address_and_port(tokens)}
 
-  defp connect([invalid_protocol | _]),
+  defp connection_spec(tokens = ["serial" | _]),
+    do: %{transport: SerialConnection, tokens: validate_port_and_baud(tokens)}
+
+  defp connection_spec([invalid_protocol | _]),
     do: raise(ArgumentError, message: "invalid protocol #{invalid_protocol}")
 
   # Parse network connection strings
@@ -661,19 +761,61 @@ defmodule XMAVLink.Router do
         raise ArgumentError, message: "invalid baud rate #{baud}"
 
       {true, parsed_baud} ->
-        # Have to checkout from uart pool in main process because
-        # poolboy monitors the process that calls checkout, and
-        # returns the UART to the pool when the caller dies. This
-        # happens immediately to our spawned connect() calls so we
-        # can't do this there, which would otherwise be a logical
-        # place to do it.
-        ["serial", port, parsed_baud, :poolboy.checkout(XMAVLink.UARTPool)]
+        ["serial", port, parsed_baud]
     end
   end
 
+  defp reconnect_worker(nil), do: :ok
+  defp reconnect_worker(worker), do: ConnectionWorker.reconnect(worker)
+
+  defp monitor_connection_worker(state, worker) do
+    if worker in Map.values(state.connection_worker_monitors) do
+      state
+    else
+      ref = Process.monitor(worker)
+      put_in(state.connection_worker_monitors[ref], worker)
+    end
+  end
+
+  defp track_connection_worker(state, connection_key, %{worker: worker}) when is_pid(worker) do
+    state
+    |> monitor_connection_worker(worker)
+    |> struct(connection_workers: Map.put(state.connection_workers, connection_key, worker))
+  end
+
+  defp track_connection_worker(state, _connection_key, _connection), do: state
+
+  defp remove_worker_connection(connection_key, worker, state) do
+    if state.connection_workers[connection_key] == worker do
+      remove_connection(connection_key, state)
+    else
+      state
+    end
+  end
+
+  defp remove_connections_for_worker(state, worker) do
+    state.connection_workers
+    |> Enum.filter(fn {_connection_key, connection_worker} -> connection_worker == worker end)
+    |> Enum.reduce(state, fn {connection_key, _worker}, updated_state ->
+      remove_connection(connection_key, updated_state)
+    end)
+  end
+
   # A handle_info() received an error and wants us to forget the borked connection
-  defp remove_connection(connection_key, state = %Router{connections: connections}) do
-    struct(state, connections: Map.delete(connections, connection_key))
+  defp remove_connection(
+         connection_key,
+         state = %Router{connections: connections, routes: routes, connection_workers: workers}
+       ) do
+    struct(state,
+      connections: Map.delete(connections, connection_key),
+      connection_workers: Map.delete(workers, connection_key),
+      routes:
+        routes
+        |> Enum.reject(fn {_mavlink_address, route_connection_key} ->
+          route_connection_key == connection_key
+        end)
+        |> Map.new()
+    )
   end
 
   # Map system/component ids to connections on which they have been seen for targeted messages
@@ -690,8 +832,8 @@ defmodule XMAVLink.Router do
       :ok,
       source_connection_key,
       frame,
-      struct(
-        state,
+      state
+      |> struct(
         # Don't add system/components from local connection to routes because local
         # automatically matches everything in matching_system_components() and we
         # don't want to receive messages twice
@@ -714,6 +856,7 @@ defmodule XMAVLink.Router do
             source_connection
           )
       )
+      |> track_connection_worker(source_connection_key, source_connection)
     }
   end
 
@@ -725,8 +868,8 @@ defmodule XMAVLink.Router do
     {
       :error,
       reason,
-      struct(
-        state,
+      state
+      |> struct(
         connections:
           Map.put(
             connections,
@@ -734,6 +877,7 @@ defmodule XMAVLink.Router do
             connection
           )
       )
+      |> track_connection_worker(connection_key, connection)
     }
   end
 

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -7,6 +7,7 @@ defmodule XMAVLink.SerialConnection do
 
   require Logger
 
+  alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
   alias Circuits.UART
 
@@ -15,13 +16,15 @@ defmodule XMAVLink.SerialConnection do
   defstruct port: nil,
             baud: nil,
             uart: nil,
-            buffer: <<>>
+            buffer: <<>>,
+            worker: nil
 
   @type t :: %XMAVLink.SerialConnection{
           port: binary,
           baud: non_neg_integer,
           uart: pid,
-          buffer: binary
+          buffer: binary,
+          worker: pid | nil
         }
 
   def handle_info(
@@ -70,38 +73,45 @@ defmodule XMAVLink.SerialConnection do
     end
   end
 
-  def connect(["serial", port, baud, uart], controlling_process) do
+  def open(["serial", port, baud], controlling_process) do
     if Map.has_key?(UART.enumerate(), port) do
+      uart = :poolboy.checkout(XMAVLink.UARTPool)
+
       case UART.open(uart, port, speed: baud, active: true) do
         :ok ->
           :ok = Logger.info("Opened serial port #{port} at #{baud} baud")
 
-          send(
-            controlling_process,
-            {
-              :add_connection,
-              port,
-              struct(
-                XMAVLink.SerialConnection,
-                port: port,
-                baud: baud,
-                uart: uart
-              )
-            }
-          )
+          :ok = UART.controlling_process(uart, controlling_process)
 
-          UART.controlling_process(uart, controlling_process)
+          {:ok, port,
+           struct(
+             XMAVLink.SerialConnection,
+             port: port,
+             baud: baud,
+             uart: uart,
+             worker: controlling_process
+           )}
 
-        {:error, _} ->
-          :ok = Logger.warning("Could not open serial port #{port}. Retrying in 1 second")
-          :timer.sleep(1000)
-          connect(["serial", port, baud, uart], controlling_process)
+        {:error, reason} ->
+          :poolboy.checkin(XMAVLink.UARTPool, uart)
+          {:error, {:open_failed, reason}}
       end
     else
-      :ok = Logger.warning("Serial port #{port} not attached. Retrying in 1 second")
-      :timer.sleep(1000)
-      connect(["serial", port, baud, uart], controlling_process)
+      {:error, :not_attached}
     end
+  end
+
+  def close(%XMAVLink.SerialConnection{uart: uart}) do
+    _ = UART.close(uart)
+    :poolboy.checkin(XMAVLink.UARTPool, uart)
+  end
+
+  def forward(
+        connection = %XMAVLink.SerialConnection{worker: worker},
+        frame
+      )
+      when is_pid(worker) do
+    ConnectionWorker.forward(worker, connection, frame)
   end
 
   def forward(

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -28,7 +28,8 @@ defmodule XMAVLink.Supervisor do
             dialect: Application.get_env(:xmavlink, :dialect),
             system: Application.get_env(:xmavlink, :system_id),
             component: Application.get_env(:xmavlink, :component_id),
-            connection_strings: Application.get_env(:xmavlink, :connections)
+            connection_strings: Application.get_env(:xmavlink, :connections),
+            connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000)
           }
         }
       ] ++ heartbeat_child_specs(router_name)

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -7,17 +7,19 @@ defmodule XMAVLink.TCPOutConnection do
   @smallest_mavlink_message 8
 
   require Logger
+  alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
   import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
 
-  defstruct socket: nil, address: nil, port: nil, buffer: <<>>
+  defstruct socket: nil, address: nil, port: nil, buffer: <<>>, worker: nil
 
   @type t :: %XMAVLink.TCPOutConnection{
           socket: pid,
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
-          buffer: binary
+          buffer: binary,
+          worker: pid | nil
         }
 
   def handle_info(
@@ -65,36 +67,37 @@ defmodule XMAVLink.TCPOutConnection do
     end
   end
 
-  def connect(["tcpout", address, port], controlling_process) do
+  def open(["tcpout", address, port], controlling_process) do
     case :gen_tcp.connect(address, port, [:binary, active: true]) do
       {:ok, socket} ->
         :ok = Logger.debug("Opened tcpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
 
-        send(
-          controlling_process,
-          {
-            :add_connection,
-            socket,
-            struct(
-              XMAVLink.TCPOutConnection,
-              socket: socket,
-              address: address,
-              port: port
-            )
-          }
-        )
+        :ok = :gen_tcp.controlling_process(socket, controlling_process)
 
-        :gen_tcp.controlling_process(socket, controlling_process)
+        {:ok, socket,
+         struct(
+           XMAVLink.TCPOutConnection,
+           socket: socket,
+           address: address,
+           port: port,
+           worker: controlling_process
+         )}
 
       other ->
-        :ok =
-          Logger.debug(
-            "Could not open tcpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}: #{inspect(other)}. Retrying in 1 second"
-          )
-
-        :timer.sleep(1000)
-        connect(["tcpout", address, port], controlling_process)
+        {:error, other}
     end
+  end
+
+  def close(%XMAVLink.TCPOutConnection{socket: socket}) do
+    :gen_tcp.close(socket)
+  end
+
+  def forward(
+        connection = %XMAVLink.TCPOutConnection{worker: worker},
+        frame
+      )
+      when is_pid(worker) do
+    ConnectionWorker.forward(worker, connection, frame)
   end
 
   def forward(

--- a/lib/mavlink/types.ex
+++ b/lib/mavlink/types.ex
@@ -6,7 +6,7 @@ defmodule XMAVLink.Types do
   @typedoc "Connection delegate modules for XMAVLink.Router"
   @type connection ::
           XMAVLink.SerialConnection
-          | XMAVLink.TCPConnection
+          | XMAVLink.TCPOutConnection
           | XMAVLink.UDPInConnection
           | XMAVLink.UDPOutConnection
 

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -6,16 +6,19 @@ defmodule XMAVLink.UDPInConnection do
   require Logger
   import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
 
+  alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
   defstruct address: nil,
             port: nil,
-            socket: nil
+            socket: nil,
+            worker: nil
 
   @type t :: %XMAVLink.UDPInConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
-          socket: pid
+          socket: pid,
+          worker: pid | nil
         }
 
   # Create connection if this is the first time we've received on it
@@ -62,24 +65,58 @@ defmodule XMAVLink.UDPInConnection do
     end
   end
 
-  def connect(["udpin", address, port], controlling_process) do
+  def handle_info({:udp, socket, source_addr, source_port, raw}, nil, dialect, worker) do
+    handle_info(
+      {:udp, socket, source_addr, source_port, raw},
+      %XMAVLink.UDPInConnection{
+        address: source_addr,
+        port: source_port,
+        socket: socket,
+        worker: worker
+      },
+      dialect
+    )
+  end
+
+  def handle_info(message, receiving_connection, dialect, _worker) do
+    handle_info(message, receiving_connection, dialect)
+  end
+
+  def open(["udpin", address, port], controlling_process) do
     # Do not add to connections, we don't want to forward to ourselves
     # Router.update_route_info() will add connections for other parties that
     # connect to this socket
     case :gen_udp.open(port, [:binary, ip: address, active: true]) do
       {:ok, socket} ->
         :ok = Logger.info("Opened udpin:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
-        :gen_udp.controlling_process(socket, controlling_process)
+        :ok = :gen_udp.controlling_process(socket, controlling_process)
+
+        {:ok, nil,
+         struct(
+           XMAVLink.UDPInConnection,
+           socket: socket,
+           address: address,
+           port: port,
+           worker: controlling_process
+         )}
 
       other ->
-        :ok =
-          Logger.warning(
-            "Could not open udpin:#{Enum.join(Tuple.to_list(address), ".")}:#{port}: #{inspect(other)}. Retrying in 1 second"
-          )
-
-        :timer.sleep(1000)
-        connect(["udpin", address, port], controlling_process)
+        {:error, other}
     end
+  end
+
+  def close(%XMAVLink.UDPInConnection{socket: socket}) do
+    :gen_udp.close(socket)
+  end
+
+  def forward(
+        connection = %XMAVLink.UDPInConnection{
+          worker: worker
+        },
+        frame
+      )
+      when is_pid(worker) do
+    ConnectionWorker.forward(worker, connection, frame)
   end
 
   def forward(

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -5,16 +5,19 @@ defmodule XMAVLink.UDPOutConnection do
 
   require Logger
   import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
+  alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
   defstruct address: nil,
             port: nil,
-            socket: nil
+            socket: nil,
+            worker: nil
 
   @type t :: %XMAVLink.UDPOutConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
-          socket: pid
+          socket: pid,
+          worker: pid | nil
         }
 
   # Create connection if this is the first time we've received on it
@@ -64,36 +67,39 @@ defmodule XMAVLink.UDPOutConnection do
     end
   end
 
-  def connect(["udpout", address, port], controlling_process) do
+  def open(["udpout", address, port], controlling_process) do
     case :gen_udp.open(0, [:binary, active: true]) do
       {:ok, socket} ->
         :ok = Logger.info("Opened udpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
 
-        send(
-          controlling_process,
-          {
-            :add_connection,
-            socket,
-            struct(
-              XMAVLink.UDPOutConnection,
-              socket: socket,
-              address: address,
-              port: port
-            )
-          }
-        )
+        :ok = :gen_udp.controlling_process(socket, controlling_process)
 
-        :gen_udp.controlling_process(socket, controlling_process)
+        {:ok, socket,
+         struct(
+           XMAVLink.UDPOutConnection,
+           socket: socket,
+           address: address,
+           port: port,
+           worker: controlling_process
+         )}
 
       other ->
-        :ok =
-          Logger.debug(
-            "Could not open udpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}: #{inspect(other)}. Retrying in 1 second"
-          )
-
-        :timer.sleep(1000)
-        connect(["udpout", address, port], controlling_process)
+        {:error, other}
     end
+  end
+
+  def close(%XMAVLink.UDPOutConnection{socket: socket}) do
+    :gen_udp.close(socket)
+  end
+
+  def forward(
+        connection = %XMAVLink.UDPOutConnection{
+          worker: worker
+        },
+        frame
+      )
+      when is_pid(worker) do
+    ConnectionWorker.forward(worker, connection, frame)
   end
 
   def forward(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.8.0",
+      version: "0.9.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/mavlink_connection_worker_test.exs
+++ b/test/mavlink_connection_worker_test.exs
@@ -75,4 +75,27 @@ defmodule XMAVLink.Test.ConnectionWorker do
 
     GenServer.stop(worker)
   end
+
+  test "ignores stale retry timer messages after an explicit reconnect" do
+    {:ok, worker} =
+      ConnectionWorker.start_link(%{
+        router: self(),
+        transport: Transport,
+        tokens: [parent: self(), failures: 1],
+        retry_ms: 1_000
+      })
+
+    assert_receive {:open_attempt, 1}, 100
+    assert %{retry_timer: {_timer_ref, connect_ref}} = ConnectionWorker.status(worker)
+
+    ConnectionWorker.reconnect(worker)
+
+    assert_receive {:open_attempt, 2}, 100
+    assert_receive {:add_connection, :fake_connection, %Transport{attempt: 2}, ^worker}, 100
+
+    send(worker, {:connect, connect_ref})
+    refute_receive {:open_attempt, 3}, 50
+
+    GenServer.stop(worker)
+  end
 end

--- a/test/mavlink_connection_worker_test.exs
+++ b/test/mavlink_connection_worker_test.exs
@@ -1,0 +1,78 @@
+defmodule XMAVLink.Test.ConnectionWorker do
+  use ExUnit.Case, async: true
+
+  alias XMAVLink.ConnectionWorker
+
+  defmodule Transport do
+    defstruct [:worker, :parent, :attempt]
+
+    def open(tokens, worker) do
+      parent = Keyword.fetch!(tokens, :parent)
+      attempt = Process.get(:open_attempt, 0) + 1
+      Process.put(:open_attempt, attempt)
+      send(parent, {:open_attempt, attempt})
+
+      if attempt <= Keyword.get(tokens, :failures, 0) do
+        {:error, {:failed_attempt, attempt}}
+      else
+        {:ok, Keyword.get(tokens, :connection_key, :fake_connection),
+         %__MODULE__{worker: worker, parent: parent, attempt: attempt}}
+      end
+    end
+
+    def close(%__MODULE__{parent: parent, attempt: attempt}) do
+      send(parent, {:closed, attempt})
+      :ok
+    end
+
+    def forward(%__MODULE__{parent: parent, attempt: attempt}, frame) do
+      send(parent, {:forwarded, attempt, frame})
+      :ok
+    end
+  end
+
+  test "retries failed opens and announces the connection after success" do
+    {:ok, worker} =
+      ConnectionWorker.start_link(%{
+        router: self(),
+        transport: Transport,
+        tokens: [parent: self(), failures: 2],
+        retry_ms: 5
+      })
+
+    assert_receive {:open_attempt, 1}, 100
+    assert_receive {:open_attempt, 2}, 100
+    assert_receive {:open_attempt, 3}, 100
+
+    assert_receive {:add_connection, :fake_connection, %Transport{attempt: 3}, ^worker}, 100
+
+    assert %{status: :connected, connection_key: :fake_connection} =
+             ConnectionWorker.status(worker)
+
+    GenServer.stop(worker)
+  end
+
+  test "reconnect closes the current connection and opens another one" do
+    {:ok, worker} =
+      ConnectionWorker.start_link(%{
+        router: self(),
+        transport: Transport,
+        tokens: [parent: self(), failures: 0],
+        retry_ms: 5
+      })
+
+    assert_receive {:open_attempt, 1}, 100
+    assert_receive {:add_connection, :fake_connection, connection, ^worker}, 100
+
+    ConnectionWorker.forward(worker, connection, :frame)
+    assert_receive {:forwarded, 1, :frame}, 100
+
+    ConnectionWorker.reconnect(worker)
+
+    assert_receive {:closed, 1}, 100
+    assert_receive {:open_attempt, 2}, 100
+    assert_receive {:add_connection, :fake_connection, %Transport{attempt: 2}, ^worker}, 100
+
+    GenServer.stop(worker)
+  end
+end

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -191,6 +191,35 @@ defmodule XMAVLink.Test.Router do
       GenServer.stop(router_pid)
     end
 
+    test "forwards outbound frames through worker-owned sockets" do
+      {udp_socket, udp_port} = open_udp_socket()
+      :ok = :inet.setopts(udp_socket, active: true)
+      on_exit(fn -> :gen_udp.close(udp_socket) end)
+
+      assert {:ok, router_pid} =
+               Router.start_link(
+                 %{
+                   system: 1,
+                   component: 1,
+                   dialect: Common,
+                   connection_strings: ["udpout:127.0.0.1:#{udp_port}"],
+                   connection_retry_ms: 10
+                 },
+                 []
+               )
+
+      _socket = wait_for_udpout_socket(router_pid)
+
+      assert :ok = Router.pack_and_send(router_pid, sample_heartbeat())
+
+      assert_receive {:udp, ^udp_socket, {127, 0, 0, 1}, _source_port, <<magic, _rest::binary>>},
+                     500
+
+      assert magic in [0xFE, 0xFD]
+
+      GenServer.stop(router_pid)
+    end
+
     test "tcpout workers reconnect after the peer closes" do
       {listen_socket, acceptor, port} = open_tcp_reconnect_listener(2)
       on_exit(fn -> close_tcp_reconnect_listener(listen_socket, acceptor) end)

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -142,6 +142,76 @@ defmodule XMAVLink.Test.Router do
       assert {:error, {%ArgumentError{message: message}, _stacktrace}} = result
       assert message =~ "invalid port"
     end
+
+    test "rejects invalid connection retry delays" do
+      assert_raise ArgumentError, ~r/connection_retry_ms/, fn ->
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: APM.Dialect,
+            connection_strings: [],
+            connection_retry_ms: -1
+          },
+          []
+        )
+      end
+    end
+  end
+
+  describe "connection lifecycle" do
+    test "starts configured connections as supervised workers" do
+      {udp_socket, udp_port} = open_udp_socket()
+      on_exit(fn -> :gen_udp.close(udp_socket) end)
+
+      assert {:ok, router_pid} =
+               Router.start_link(
+                 %{
+                   system: 1,
+                   component: 1,
+                   dialect: APM.Dialect,
+                   connection_strings: ["udpout:127.0.0.1:#{udp_port}"],
+                   connection_retry_ms: 10
+                 },
+                 []
+               )
+
+      socket = wait_for_udpout_socket(router_pid)
+      state = :sys.get_state(router_pid)
+
+      assert Process.alive?(state.connection_supervisor)
+      assert worker = state.connection_workers[socket]
+      assert Process.alive?(worker)
+
+      assert Enum.any?(DynamicSupervisor.which_children(state.connection_supervisor), fn
+               {_id, ^worker, :worker, [XMAVLink.ConnectionWorker]} -> true
+               _ -> false
+             end)
+
+      GenServer.stop(router_pid)
+    end
+
+    test "tcpout workers reconnect after the peer closes" do
+      {listen_socket, acceptor, port} = open_tcp_reconnect_listener(2)
+      on_exit(fn -> close_tcp_reconnect_listener(listen_socket, acceptor) end)
+
+      assert {:ok, router_pid} =
+               Router.start_link(
+                 %{
+                   system: 1,
+                   component: 1,
+                   dialect: APM.Dialect,
+                   connection_strings: ["tcpout:127.0.0.1:#{port}"],
+                   connection_retry_ms: 10
+                 },
+                 []
+               )
+
+      assert_receive {:tcp_peer_accepted, 1}, 1_000
+      assert_receive {:tcp_peer_accepted, 2}, 1_000
+
+      GenServer.stop(router_pid)
+    end
   end
 
   describe "router instances" do
@@ -765,9 +835,45 @@ defmodule XMAVLink.Test.Router do
     {listen_socket, acceptor, port}
   end
 
+  defp open_tcp_reconnect_listener(accept_count) do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        active: false,
+        packet: :raw,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listen_socket)
+    parent = self()
+
+    acceptor =
+      spawn_link(fn ->
+        for index <- 1..accept_count do
+          case :gen_tcp.accept(listen_socket, 1_000) do
+            {:ok, peer_socket} ->
+              send(parent, {:tcp_peer_accepted, index})
+              :gen_tcp.close(peer_socket)
+
+            other ->
+              send(parent, {:tcp_accept_failed, index, other})
+          end
+        end
+      end)
+
+    {listen_socket, acceptor, port}
+  end
+
   defp close_tcp_listener(listen_socket, acceptor) do
     send(acceptor, :close_tcp_peer)
     :gen_tcp.close(listen_socket)
+    :ok
+  end
+
+  defp close_tcp_reconnect_listener(listen_socket, acceptor) do
+    :gen_tcp.close(listen_socket)
+    Process.exit(acceptor, :kill)
     :ok
   end
 

--- a/test/mavlink_supervisor_test.exs
+++ b/test/mavlink_supervisor_test.exs
@@ -4,18 +4,25 @@ defmodule XMAVLink.SupervisorTest do
   test "falls back to the default router name when app config sets router_name to nil" do
     previous_router_name = Application.get_env(:xmavlink, :router_name)
     previous_heartbeat = Application.get_env(:xmavlink, :heartbeat)
+    previous_connection_retry_ms = Application.get_env(:xmavlink, :connection_retry_ms)
 
     Application.put_env(:xmavlink, :router_name, nil)
+    Application.put_env(:xmavlink, :connection_retry_ms, 250)
     Application.put_env(:xmavlink, :heartbeat, interval_ms: 1000, message: sample_heartbeat())
 
     on_exit(fn ->
       restore_env(:router_name, previous_router_name)
       restore_env(:heartbeat, previous_heartbeat)
+      restore_env(:connection_retry_ms, previous_connection_retry_ms)
     end)
 
     assert {:ok, {_supervisor_flags, children}} = XMAVLink.Supervisor.init([])
 
-    assert %{start: {XMAVLink.Router, :start_link, [%{name: XMAVLink.Router}]}} =
+    assert %{
+             start:
+               {XMAVLink.Router, :start_link,
+                [%{name: XMAVLink.Router, connection_retry_ms: 250}]}
+           } =
              Enum.find(children, &match?(%{id: XMAVLink.Router}, &1))
 
     assert %{start: {XMAVLink.Heartbeat, :start_link, [heartbeat_spec]}} =


### PR DESCRIPTION
## Summary

- Add a per-router dynamic connection supervisor and supervised connection workers for configured serial, UDP, and TCP links.
- Move retry/reconnect loops out of the router and transport modules into `XMAVLink.ConnectionWorker` with explicit `connection_retry_ms` backoff.
- Make connection workers own socket/UART resources, forward inbound transport messages to the router, and handle TCP/serial reconnects.
- Document configured connection lifecycle behavior and add retry/reconnect coverage.
- Address review feedback by preventing worker forwarding loops, ignoring stale retry timer messages, and correcting route/connection typespecs.

Closes #23

## Validation

- `mix test test/mavlink_connection_worker_test.exs test/mavlink_router_test.exs test/mavlink_supervisor_test.exs test/mavlink_tcp_out_connection_test.exs`
- `mix test`
- `mix format --check-formatted lib/mavlink/router.ex lib/mavlink/connection_worker.ex lib/mavlink/connection_supervisor.ex lib/mavlink/udp_in_connection.ex lib/mavlink/udp_out_connection.ex lib/mavlink/tcp_out_connection.ex lib/mavlink/serial_connection.ex lib/mavlink/supervisor.ex lib/mavlink/types.ex test/mavlink_connection_worker_test.exs test/mavlink_router_test.exs test/mavlink_supervisor_test.exs test/mavlink_tcp_out_connection_test.exs`
- `git diff --check`

Note: full-project `mix format --check-formatted` still reports pre-existing generated/unrelated files (`lib/common.ex`, `lib/mavlink_util/*`) as unformatted, so validation used the edited file set.