### PR TITLE
Strengthen CI release gate

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,10 @@
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  # lib/common.ex is checked-in generated dialect output. Keep it out of the
+  # formatter gate until the generator emits deterministic, formatted code.
+  inputs: [
+    "mix.exs",
+    "config/**/*.{ex,exs}",
+    "lib/{mavlink,mavlink_util,mix}/**/*.{ex,exs}",
+    "test/**/*.{ex,exs}"
+  ]
 ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,28 +1,67 @@
 name: Elixir
+
 permissions:
   contents: read
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  MIX_ENV: test
 
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
 
-    container:
-      image: elixir:1.18.4-slim
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: 1.18.4
+            otp: 27.3.4.3
+          - elixir: 1.19.4
+            otp: 28.4.2
 
     steps:
       - uses: actions/checkout@v6
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y ca-certificates make build-essential
 
-      - name: Install Dependencies
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Cache Mix dependencies and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
+
+      - name: Install Mix tools and dependencies
         run: |
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
-      - name: Run Tests
-        run: mix test
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Compile with warnings as errors
+        run: mix compile --warnings-as-errors
+
+      - name: Check compile-time dependency cycles
+        run: mix xref graph --label compile-connected --fail-above 0
+
+      - name: Run tests
+        run: mix test --warnings-as-errors

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ on MAVLink see https://mavlink.io.
 
 ## Installation
 
+XMAVLink currently supports Elixir 1.18 and later on Erlang/OTP 27 and later.
+CI tests the pinned repository toolchain in `.tool-versions` and a newer
+Elixir/OTP line.
+
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 by adding `xmavlink` to your list of dependencies in `mix.exs`:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,18 @@
+# QA checks
+
+The release gate in CI runs these checks across the supported Elixir/OTP matrix:
+
+```bash
+mix format --check-formatted
+mix compile --warnings-as-errors
+mix xref graph --label compile-connected --fail-above 0
+mix test --warnings-as-errors
+```
+
+`mix dialyzer` is not part of the required CI gate yet because the current code
+base still has a known warning tracked by v1.0.0 readiness issue #31. Add it to
+CI once that warning is resolved or formally excluded.
+
 # Testing locally with Ardupilot, MavProxy, SITL and X-Plane
 
 It's possible to use SITL with X-Plane:

--- a/lib/mavlink_util/param_request.ex
+++ b/lib/mavlink_util/param_request.ex
@@ -8,7 +8,6 @@ defmodule XMAVLink.Util.ParamRequest do
   alias XMAVLink.Router, as: MAV
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
-
   def param_request_list() do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
       Logger.info("Waiting to receive first parameter from vehicle #{system_id}.#{component_id}")
@@ -17,23 +16,34 @@ defmodule XMAVLink.Util.ParamRequest do
   end
 
   def param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded \\ 0) do
-    with [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <- :ets.lookup(@systems, {system_id, component_id}),
+    with [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <-
+           :ets.lookup(@systems, {system_id, component_id}),
          retry <- param_count_loaded == last_param_count_loaded,
          complete <- param_count_loaded == param_count and param_count > 0 do
       if complete do
-        Logger.info("All #{param_count} parameters loaded for vehicle #{system_id}.#{component_id}")
+        Logger.info(
+          "All #{param_count} parameters loaded for vehicle #{system_id}.#{component_id}"
+        )
       else
         if param_count > 0 do
-          Logger.info("Loaded #{param_count_loaded}/#{param_count} parameters for vehicle #{system_id}.#{component_id}")
+          Logger.info(
+            "Loaded #{param_count_loaded}/#{param_count} parameters for vehicle #{system_id}.#{component_id}"
+          )
         end
+
         if retry do
-          MAV.pack_and_send(%Common.Message.ParamRequestList{
-            target_system: system_id, target_component: component_id}, mavlink_version)
+          MAV.pack_and_send(
+            %Common.Message.ParamRequestList{
+              target_system: system_id,
+              target_component: component_id
+            },
+            mavlink_version
+          )
         end
+
         Process.sleep(@param_retry_interval)
         param_request_list(system_id, component_id, mavlink_version, param_count_loaded)
       end
     end
   end
-
 end

--- a/lib/mavlink_util/param_set.ex
+++ b/lib/mavlink_util/param_set.ex
@@ -10,39 +10,49 @@ defmodule XMAVLink.Util.ParamSet do
   alias Common.Message.ParamSet
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
-
   def param_set(param, new_value) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
       param_set(system_id, component_id, mavlink_version, param, new_value)
     end
   end
 
-  def param_set(system_id, component_id, mavlink_version, param, new_value) when is_atom(param)do
-    param_set(system_id, component_id, mavlink_version,  param |> Atom.to_string() |> String.upcase(), new_value)
+  def param_set(system_id, component_id, mavlink_version, param, new_value) when is_atom(param) do
+    param_set(
+      system_id,
+      component_id,
+      mavlink_version,
+      param |> Atom.to_string() |> String.upcase(),
+      new_value
+    )
   end
 
   def param_set(system_id, component_id, mavlink_version, param, new_value) do
-    with [{{^system_id, ^component_id, ^param}, {_time, %ParamValue{param_type: param_type}}}]
-         <- :ets.lookup(@params, {system_id, component_id, param}) do
-      MAV.subscribe message: ParamValue, source_system: system_id
+    with [{{^system_id, ^component_id, ^param}, {_time, %ParamValue{param_type: param_type}}}] <-
+           :ets.lookup(@params, {system_id, component_id, param}) do
+      MAV.subscribe(message: ParamValue, source_system: system_id)
 
-      MAV.pack_and_send(%ParamSet{
-        target_system: system_id,
-        target_component: component_id,
-        param_id: param,
-        param_value: new_value,
-        param_type: param_type,
-      }, mavlink_version)
+      MAV.pack_and_send(
+        %ParamSet{
+          target_system: system_id,
+          target_component: component_id,
+          param_id: param,
+          param_value: new_value,
+          param_type: param_type
+        },
+        mavlink_version
+      )
 
       receive do
         %ParamValue{param_id: ^param, param_value: ^new_value} ->
           MAV.unsubscribe()
-          Logger.info("Set #{param |> String.downcase()} to #{inspect new_value} for vehicle #{system_id}.#{component_id}")
+
+          Logger.info(
+            "Set #{param |> String.downcase()} to #{inspect(new_value)} for vehicle #{system_id}.#{component_id}"
+          )
       after
-          @param_retry_interval ->
-            param_set(system_id, component_id, mavlink_version, param, new_value)
+        @param_retry_interval ->
+          param_set(system_id, component_id, mavlink_version, param, new_value)
       end
     end
   end
-
 end

--- a/lib/mavlink_util/supervisor.ex
+++ b/lib/mavlink_util/supervisor.ex
@@ -13,6 +13,7 @@ defmodule XMAVLink.Util.Supervisor do
       {XMAVLink.Util.CacheManager, %{}},
       {XMAVLink.Util.FocusManager, %{}}
     ]
+
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule XMAVLink.Mixfile do
     [
       app: :xmavlink,
       version: "0.9.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),


### PR DESCRIPTION
## Summary

- Replace the single-container test workflow with a supported Elixir/OTP matrix.
- Gate formatting, compile warnings, compile-time dependency cycles, and tests with warnings as errors.
- Exclude checked-in generated dialect output from formatter inputs until the generator emits deterministic formatted code.
- Raise the declared Elixir floor to 1.18 and document the CI/Dialyzer policy.
- Format the hand-written utility files required for the formatter gate.

Closes #29

## Verification

- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`