### PR TITLE
Align docs with supported transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # XMAVLink
 
-This library includes a mix task that generates code from a MAVLink xml
+This library includes a mix task that generates code from MAVLink XML
 definition files and an application that enables communication with other
-systems using the MAVLink 1.0 or 2.0 protocol over serial, UDP and TCP
-connections.
+systems using MAVLink 1 frames and unsigned MAVLink 2 frames over serial,
+UDP, and outbound TCP connections.
 
-MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk, 
-Ardupilot and other leading autopilot platforms. For more information
+MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk,
+ArduPilot and other leading autopilot platforms. For more information
 on MAVLink see https://mavlink.io.
 
 ## Installation
@@ -31,6 +31,12 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
 This library is not officially recognised or supported by MAVLink at this
 time.
 
+XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames that
+do not set incompatible flags. MAVLink 2 signing is not implemented; inbound
+MAVLink 2 frames with incompatible flags are discarded. Supported configured
+transports are serial, UDP client (`udpout`), UDP server (`udpin`), and TCP
+client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
+
 ## Generating MAVLink Dialect Modules
 
 MAVLink message definition files for popular dialects can be found [here](https://github.com/mavlink/mavlink/tree/master/message_definitions/v1.0).
@@ -52,9 +58,12 @@ and list the connections to other vehicles in `config.exs`:
 config :xmavlink, dialect: Common, connections: ["serial:/dev/cu.usbserial-A603KH3Y:57600", "udpout:127.0.0.1:14550", "tcpout:127.0.0.1:5760"]
 ```
 
-The above config specifies the Common dialect we generated and connects to a a vehicle on a radio modem, a ground station listening for 
-UDP packets on 14550 and a SITL vehicle listening for TCP connections on 5760. Remember 'out' means client, 
-'in' means server.
+The above config specifies the Common dialect we generated and connects to a
+vehicle on a radio modem, a UDP peer listening on port 14550, and a SITL vehicle
+listening for TCP connections on port 5760. For configured network transports,
+`out` means XMAVLink connects or sends to a remote endpoint. `udpin` means
+XMAVLink opens a local UDP socket and receives packets from peers. TCP server
+mode is not currently supported.
 
 By default the application supervises one router registered as `XMAVLink.Router`.
 Set `:router_name` when the application-owned router should use another registered
@@ -75,7 +84,9 @@ XMAVLink supports the following connection string formats:
 - **UDP Out (client)**: `udpout:<address>:<port>` (e.g., `"udpout:192.168.1.100:14550"`)
 - **UDP In (server)**: `udpin:<address>:<port>` (e.g., `"udpin:0.0.0.0:14550"`)
 - **TCP Out (client)**: `tcpout:<address>:<port>` (e.g., `"tcpout:192.168.1.100:5760"`)
-- **TCP In (server)**: `tcpin:<address>:<port>` (e.g., `"tcpin:0.0.0.0:5760"`)
+
+There is no `tcpin` connection string. TCP is currently supported only as an
+outbound client connection, primarily for SITL endpoints.
 
 ### Configured Connection Lifecycle
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,93 +13,83 @@ mix test --warnings-as-errors
 base still has a known warning tracked by v1.0.0 readiness issue #31. Add it to
 CI once that warning is resolved or formally excluded.
 
-# Testing locally with Ardupilot, MavProxy, SITL and X-Plane
+# Testing locally with ArduPilot, MAVProxy, SITL, and X-Plane
+
+Use the upstream ArduPilot documentation as the source of truth for installing
+and running SITL and MAVProxy:
+
+- https://ardupilot.org/dev/docs/SITL-setup-landingpage.html
+- https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html
+- https://ardupilot.org/mavproxy/docs/getting_started/download_and_installation.html
+
+The old local instructions used Python 2 and global `sudo pip` installs. Do not
+use those for new setup. Current ArduPilot tooling is Python 3 based; prefer the
+platform-specific upstream setup, a virtual environment, or user-local install.
+
+For a local XMAVLink smoke test, start SITL through `sim_vehicle.py` and add or
+verify a MAVProxy UDP output to the port XMAVLink will use. On a typical local
+SITL session, MAVProxy already exposes UDP outputs on `127.0.0.1:14550` and
+`127.0.0.1:14551`; confirm with:
+
+```
+output
+```
+
+If needed, add an output explicitly from the MAVProxy prompt:
+
+```
+output add 127.0.0.1:14550
+```
+
+Then configure XMAVLink with a matching UDP listener:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["udpin:0.0.0.0:14550"]
+```
+
+or run a script that starts a router with the same connection string.
+
+For TCP-based SITL, connect XMAVLink as a TCP client:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["tcpout:127.0.0.1:5760"]
+```
+
+XMAVLink does not currently provide a TCP server (`tcpin`) transport.
+
+## X-Plane
 
 It's possible to use SITL with X-Plane:
 
-http://ardupilot.org/dev/docs/sitl-with-xplane.html
+https://ardupilot.org/dev/docs/sitl-with-xplane.html
 
-### Install dependencies:
-
-```
-brew install python@2.7
-```
-
-Verify with: `python --version`.
-
-Remove this incompatible library:
+Start X-Plane and set up the data export settings per the upstream page, then
+run ArduPlane and MAVProxy. A MAVProxy output can forward frames to an XMAVLink
+UDP listener:
 
 ```
-sudo pip uninstall python-dateutil
-```
-
-### Install MavProxy
-
-```
-sudo pip install wxPython
-sudo pip install gnureadline
-sudo pip install billiard
-sudo pip install numpy pyparsing
-sudo pip install MAVProxy
-```
-
-### Ardupilot
-
-Install Ardupilot dependencies:
-
-```
-brew tap ardupilot/homebrew-px4
-brew install genromfs
-brew install gcc-arm-none-eabi
-brew install gawk
-```
-
-Download Ardupilot:
-
-```bash
-git clone git@github.com:ArduPilot/ardupilot.git
-```
-
-Build Ardupilot for macOS:
-
-```bash
-cd ardupilot && ./Tools/environment_install/install-prereqs-mac.sh
-```
-
-Add the following to your shell:
-
-```
-export PATH=/Path/To/ardupilot/Tools/autotest:$PATH
-```
-
-Configure Ardupilot for SITL:
-
-```
-cd ardupilot
-./waf configure --board sitl
-cd ArduCopter
-sim_vehicle.py -w
-```
-
-After initialisation Ctl C and run the following:
-
-```
-sim_vehicle.py --console
-```
-
-Start X-Plane and set up the data export settings per web page, then run arduplane and mavproxy
-
 mavproxy.py --master=tcp:127.0.0.1:5760 --out 127.0.0.1:14550
+```
 
-Then
+Then run an XMAVLink script or application configured with:
+
+```elixir
+connections: ["udpin:0.0.0.0:14550"]
+```
+
+For example:
 
 ```bash
 mix run scripts/listen.exs
 ```
 
-will receive messages
+will receive messages if the script starts a matching listener.
 
-## to kill emlid noise bug in mavproxy:
+## MAVProxy noise setting
 
 ```
 set shownoise False
@@ -113,7 +103,7 @@ In another directory (like `..`):
 
 ```bash
 git clone git@github.com:mavlink/mavlink.git
-cd elixir-mavlink
+cd mavlink
 ```
 
 The message definitions live in:
@@ -127,7 +117,7 @@ To generate a protocol file for APM:
 ```bash
 mkdir message_definitions
 cp ../mavlink/message_definitions/v1.0/* message_definitions
-mix mavlink message_definitions/ardupilotmega.xml output/apm.ex APM
+mix xmavlink message_definitions/ardupilotmega.xml output/apm.ex APM
 ```
 
 ## Example usage

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule XMAVLink.Mixfile do
   config :xmavlink, dialect: Common
   config :xmavlink, system_id: 1
   config :xmavlink, component_id: 1
-  config :xmavlink, connections: ["udp:192.168.0.10:14550"]
+  config :xmavlink, connections: ["udpout:192.168.0.10:14550"]
   """
   def application do
     [


### PR DESCRIPTION
## Summary

- Document the actual protocol support: MAVLink 1 and unsigned MAVLink 2 frames without incompatible flags/signing.
- Remove the advertised `tcpin` connection string and clarify that TCP is currently client-only.
- Fix the `mix.exs` config example from unsupported `udp:` to `udpout:`.
- Replace stale Python 2 / global `sudo pip` SITL setup notes with upstream ArduPilot/MAVProxy links and current XMAVLink connection examples.
- Fix stale testing-guide commands for the MAVLink repo path and `mix xmavlink` task name.

Closes #30

## Verification

- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`