### PR TITLE
Add Dialyzer release gate

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -65,3 +65,41 @@ jobs:
 
       - name: Run tests
         run: mix test --warnings-as-errors
+
+  dialyzer:
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: dev
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: 1.18.4
+          otp-version: 27.3.4.3
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Cache Dialyzer PLTs and Mix build
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-dialyzer-1.18.4-27.3.4.3-${{ hashFiles('mix.exs', 'mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-dialyzer-1.18.4-27.3.4.3-
+
+      - name: Install Mix tools and dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+
+      - name: Run Dialyzer
+        run: mix dialyzer

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,11 +7,11 @@ mix format --check-formatted
 mix compile --warnings-as-errors
 mix xref graph --label compile-connected --fail-above 0
 mix test --warnings-as-errors
+mix dialyzer
 ```
 
-`mix dialyzer` is not part of the required CI gate yet because the current code
-base still has a known warning tracked by v1.0.0 readiness issue #31. Add it to
-CI once that warning is resolved or formally excluded.
+Dialyzer runs on the pinned baseline Elixir/OTP toolchain and uses CI caching
+for PLTs and Mix build artifacts.
 
 # Testing locally with ArduPilot, MAVProxy, SITL, and X-Plane
 

--- a/lib/mavlink_util/arm.ex
+++ b/lib/mavlink_util/arm.ex
@@ -61,7 +61,7 @@ defmodule XMAVLink.Util.Arm do
           arm(system_id, component_id, mavlink_version)
       end
     else
-      %Heartbeat{system_status: invalid_system_status} ->
+      {:ok, _, %Heartbeat{system_status: invalid_system_status}} ->
         Logger.warning(
           "Cannot arm vehicle #{system_id}.#{component_id}: #{Common.describe(invalid_system_status)}"
         )

--- a/lib/mavlink_util/focus_manager.ex
+++ b/lib/mavlink_util/focus_manager.ex
@@ -41,8 +41,7 @@ defmodule XMAVLink.Util.FocusManager do
     {:ok, {system_id, component_id, _}} =
       GenServer.call(XMAVLink.Util.FocusManager, {:focus, {system_id, component_id}})
 
-    # Only works for single IEx session
-    IEx.configure(default_prompt: "iex(%counter) vehicle #{system_id}.#{component_id}>")
+    configure_iex_prompt(system_id, component_id)
   end
 
   @impl true
@@ -80,6 +79,16 @@ defmodule XMAVLink.Util.FocusManager do
   end
 
   # TODO handle DOWN messages
+
+  defp configure_iex_prompt(system_id, component_id) do
+    if Code.ensure_loaded?(IEx) and function_exported?(IEx, :configure, 1) do
+      apply(IEx, :configure, [
+        [default_prompt: "iex(%counter) vehicle #{system_id}.#{component_id}>"]
+      ])
+    end
+
+    :ok
+  end
 
   defp format({s, c, _}), do: format({s, c})
   defp format({s, c}), do: "#{s}.#{c}"


### PR DESCRIPTION
## Summary

- Make `FocusManager`'s IEx prompt update optional so supported modules are Dialyzer-clean without a hard IEx dependency.
- Fix `Arm.arm/3`'s invalid-heartbeat match so it handles the actual `CacheManager.msg/1` return shape.
- Add a required Dialyzer workflow job on the pinned baseline Elixir/OTP toolchain with cached PLTs/build artifacts.
- Update `TESTING.md` so the documented QA gate includes `mix dialyzer`.

Closes #31

## Verification

- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix dialyzer`