### PR TITLE
Fix utility process lifecycle

### DIFF
--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -26,7 +26,9 @@ defmodule XMAVLink.Util.CacheManager do
   @five_second_loop :five_second_loop
   @ten_second_loop :ten_second_loop
 
-  defstruct []
+  defstruct one_second_interval_ms: 1_000,
+            five_second_interval_ms: 5_000,
+            ten_second_interval_ms: 10_000
 
   # API
 
@@ -132,19 +134,21 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   @impl true
-  def init(_opts) do
+  def init(opts) do
     :ets.new(@messages, [:named_table, :protected, {:read_concurrency, true}, :set])
     :ets.new(@systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
     :ets.new(@params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
 
     MAV.subscribe(as_frame: true)
 
+    state = struct(__MODULE__, opts)
+
     {
       :ok,
-      %XMAVLink.Util.CacheManager{}
-      |> one_second_loop
-      |> five_second_loop
-      |> ten_second_loop
+      state
+      |> schedule_one_second_loop()
+      |> schedule_five_second_loop()
+      |> schedule_ten_second_loop()
     }
   end
 
@@ -195,17 +199,17 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   def handle_info(@one_second_loop, state) do
-    :timer.send_after(1_000, @one_second_loop)
+    schedule_one_second_loop(state)
     {:noreply, one_second_loop(state)}
   end
 
   def handle_info(@five_second_loop, state) do
-    :timer.send_after(5_000, @one_second_loop)
+    schedule_five_second_loop(state)
     {:noreply, five_second_loop(state)}
   end
 
   def handle_info(@ten_second_loop, state) do
-    :timer.send_after(10_000, @one_second_loop)
+    schedule_ten_second_loop(state)
     {:noreply, ten_second_loop(state)}
   end
 
@@ -292,6 +296,21 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   defp ten_second_loop(state) do
+    state
+  end
+
+  defp schedule_one_second_loop(state) do
+    :timer.send_after(state.one_second_interval_ms, @one_second_loop)
+    state
+  end
+
+  defp schedule_five_second_loop(state) do
+    :timer.send_after(state.five_second_interval_ms, @five_second_loop)
+    state
+  end
+
+  defp schedule_ten_second_loop(state) do
+    :timer.send_after(state.ten_second_interval_ms, @ten_second_loop)
     state
   end
 

--- a/lib/mavlink_util/focus_manager.ex
+++ b/lib/mavlink_util/focus_manager.ex
@@ -12,6 +12,8 @@ defmodule XMAVLink.Util.FocusManager do
   @sessions :sessions
   @systems :systems
 
+  defstruct monitors: %{}, sessions: %{}
+
   # API
   def start_link(state, opts \\ []) do
     GenServer.start_link(__MODULE__, state, [{:name, __MODULE__} | opts])
@@ -45,9 +47,9 @@ defmodule XMAVLink.Util.FocusManager do
   end
 
   @impl true
-  def init(_opts) do
+  def init(opts) do
     :ets.new(@sessions, [:named_table, :protected, {:read_concurrency, true}, :set])
-    {:ok, %{}}
+    {:ok, struct(__MODULE__, opts)}
   end
 
   @impl true
@@ -65,8 +67,9 @@ defmodule XMAVLink.Util.FocusManager do
              @systems
            ) do
       if mavlink_major_version > 0 do
-        :ets.insert(@sessions, {caller_pid, {system_id, component_id, mavlink_major_version}})
-        Process.monitor(caller_pid)
+        state =
+          put_focus_session(state, caller_pid, {system_id, component_id, mavlink_major_version})
+
         Logger.info("Set focus to #{format(scid)}")
         {:reply, {:ok, {system_id, component_id, mavlink_major_version}}, state}
       else
@@ -78,16 +81,61 @@ defmodule XMAVLink.Util.FocusManager do
     end
   end
 
-  # TODO handle DOWN messages
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case Map.pop(state.monitors, ref) do
+      {nil, _monitors} ->
+        {:noreply, state}
+
+      {monitored_pid, monitors} ->
+        :ets.delete(@sessions, monitored_pid)
+
+        {:noreply,
+         %{
+           state
+           | monitors: monitors,
+             sessions: Map.delete(state.sessions, monitored_pid)
+         }}
+    end
+  end
 
   defp configure_iex_prompt(system_id, component_id) do
-    if Code.ensure_loaded?(IEx) and function_exported?(IEx, :configure, 1) do
+    if Code.ensure_loaded?(IEx) and function_exported?(IEx, :configure, 1) and
+         Process.whereis(IEx.Config) do
       apply(IEx, :configure, [
         [default_prompt: "iex(%counter) vehicle #{system_id}.#{component_id}>"]
       ])
     end
 
     :ok
+  end
+
+  defp put_focus_session(state, pid, scid) do
+    state = drop_focus_monitor(state, pid)
+    ref = Process.monitor(pid)
+    :ets.insert(@sessions, {pid, scid})
+
+    %{
+      state
+      | monitors: Map.put(state.monitors, ref, pid),
+        sessions: Map.put(state.sessions, pid, ref)
+    }
+  end
+
+  defp drop_focus_monitor(state, pid) do
+    case Map.pop(state.sessions, pid) do
+      {nil, _sessions} ->
+        state
+
+      {ref, sessions} ->
+        Process.demonitor(ref, [:flush])
+
+        %{
+          state
+          | monitors: Map.delete(state.monitors, ref),
+            sessions: sessions
+        }
+    end
   end
 
   defp format({s, c, _}), do: format({s, c})

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -22,6 +22,29 @@ defmodule XMAVLink.Util.CacheManager.Test do
     assert Enum.sort(mavs) == [{1, 1}, {2, 1}]
   end
 
+  test "one second loop reschedules one second loop" do
+    state = %CacheManager{one_second_interval_ms: 1}
+
+    assert {:noreply, ^state} = CacheManager.handle_info(:one_second_loop, state)
+    assert_receive :one_second_loop, 50
+  end
+
+  test "five second loop reschedules five second loop" do
+    state = %CacheManager{five_second_interval_ms: 1}
+
+    assert {:noreply, ^state} = CacheManager.handle_info(:five_second_loop, state)
+    assert_receive :five_second_loop, 50
+    refute_received :one_second_loop
+  end
+
+  test "ten second loop reschedules ten second loop" do
+    state = %CacheManager{ten_second_interval_ms: 1}
+
+    assert {:noreply, ^state} = CacheManager.handle_info(:ten_second_loop, state)
+    assert_receive :ten_second_loop, 50
+    refute_received :one_second_loop
+  end
+
   defp create_systems_table do
     :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
   end

--- a/test/focus_manager_test.exs
+++ b/test/focus_manager_test.exs
@@ -1,0 +1,76 @@
+defmodule XMAVLink.Util.FocusManager.Test do
+  use ExUnit.Case
+
+  alias XMAVLink.Util.FocusManager
+
+  setup do
+    delete_table(:sessions)
+    delete_table(:systems)
+    create_systems_table()
+    start_supervised!(FocusManager)
+
+    on_exit(fn ->
+      delete_table(:sessions)
+      delete_table(:systems)
+    end)
+
+    :ok
+  end
+
+  test "focus/2 stores focus for caller" do
+    :ets.insert(:systems, {{1, 1}, %{mavlink_major_version: 2}})
+
+    assert :ok = FocusManager.focus(1, 1)
+    assert {:ok, {1, 1, 2}} = FocusManager.focus()
+  end
+
+  test "focus sessions are removed when the owner process exits" do
+    :ets.insert(:systems, {{1, 1}, %{mavlink_major_version: 2}})
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        send(parent, {:focused, self(), FocusManager.focus(1, 1)})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:focused, ^pid, :ok}
+    assert {:ok, {1, 1, 2}} = FocusManager.focus(pid)
+
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+
+    assert_focus_cleared(pid)
+  end
+
+  defp assert_focus_cleared(pid, attempts \\ 20)
+
+  defp assert_focus_cleared(pid, attempts) when attempts > 0 do
+    case FocusManager.focus(pid) do
+      {:error, :not_focussed} ->
+        :ok
+
+      {:ok, _} ->
+        Process.sleep(10)
+        assert_focus_cleared(pid, attempts - 1)
+    end
+  end
+
+  defp assert_focus_cleared(pid, 0) do
+    flunk("expected focus session for #{inspect(pid)} to be removed")
+  end
+
+  defp create_systems_table do
+    :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp delete_table(table) do
+    if :ets.info(table) != :undefined do
+      :ets.delete(table)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix `CacheManager` periodic rescheduling so five-second and ten-second loops reschedule their own messages.
- Make cache loop intervals part of state so rescheduling behavior can be tested quickly and deterministically.
- Track `FocusManager` process monitors and remove stale focus sessions when owner processes exit.
- Add focused tests for cache loop rescheduling and focus-session cleanup.

I reviewed the parameter utility retry loops while working this issue. They remain synchronous utility command behavior in this patch; duplicate router subscriptions are idempotent for the same pid/query, and the concrete process-lifecycle defects addressed here were the timer rescheduling bug and stale focus-session monitors.

Closes #32

## Verification

- `mise exec -- mix test test/cache_manager_test.exs test/focus_manager_test.exs --warnings-as-errors`
- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix dialyzer`