### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.1 - 2026-05-07
+
+- Strengthened CI release gates with formatting, warnings-as-errors, xref,
+  tests, and Dialyzer coverage across the supported toolchain checks.
+- Clarified supported transports and MAVLink 2 limitations in public docs.
+- Fixed utility process lifecycle issues in `CacheManager` and `FocusManager`.
+
 ## 0.9.0 - 2026-05-07
 
 - Moved configured connection startup and reconnect behavior under supervised

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.9.0"}
+     {:xmavlink, "~> 0.9.1"}
    ]
  end
  ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Bump package version from `0.9.0` to `0.9.1`.
- Update the README dependency example to `~> 0.9.1`.
- Add a changelog entry covering the CI, documentation, and utility lifecycle hardening intended for drone testing before v1.0.0.

## Verification

- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix dialyzer`