### PR TITLE
Tighten release hygiene checks

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,7 @@
 [
-  # lib/common.ex is checked-in generated dialect output. Keep it out of the
-  # formatter gate until the generator emits deterministic, formatted code.
+  # lib/common.ex is checked-in generated Common dialect output. Keep generated
+  # dialect modules out of the formatter gate; regenerate them from MAVLink XML
+  # instead of hand-formatting or hand-editing generated code.
   inputs: [
     "mix.exs",
     "config/**/*.{ex,exs}",

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -54,6 +54,9 @@ jobs:
           mix local.hex --force
           mix deps.get
 
+      - name: Check dependency lock hygiene
+        run: mix deps.unlock --check-unused
+
       - name: Check formatting
         run: mix format --check-formatted
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Generated APM in 'lib/apm.ex'.
 >
 ```
 
+The repository includes `lib/common.ex` as checked-in generated output for the
+MAVLink Common dialect. Treat generated dialect modules as build artifacts:
+change the generator or XML input and regenerate them rather than editing or
+formatting generated files by hand.
+
 ## Configuring the XMAVLink Application
 
 Add `XMAVLink.Application` with no start arguments to your `mix.exs`. You need to point the application at the dialect you just generated 

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,9 +17,9 @@ for PLTs and Mix build artifacts.
 ## Generated dialect output
 
 `lib/common.ex` is checked-in generated MAVLink dialect output. It is excluded
-from the formatter gate because the current generator does not emit stable,
-formatter-compatible code. Treat large formatting or timestamp churn in this
-file as generator work, not manual cleanup.
+from the formatter gate intentionally. Treat generated dialect modules as build
+artifacts: update the generator or XML input and regenerate them instead of
+hand-editing, hand-formatting, or reviewing large formatting-only diffs.
 
 # Testing locally with ArduPilot, MAVProxy, SITL, and X-Plane
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,6 +3,7 @@
 The release gate in CI runs these checks across the supported Elixir/OTP matrix:
 
 ```bash
+mix deps.unlock --check-unused
 mix format --check-formatted
 mix compile --warnings-as-errors
 mix xref graph --label compile-connected --fail-above 0
@@ -12,6 +13,13 @@ mix dialyzer
 
 Dialyzer runs on the pinned baseline Elixir/OTP toolchain and uses CI caching
 for PLTs and Mix build artifacts.
+
+## Generated dialect output
+
+`lib/common.ex` is checked-in generated MAVLink dialect output. It is excluded
+from the formatter gate because the current generator does not emit stable,
+formatter-compatible code. Treat large formatting or timestamp churn in this
+file as generator work, not manual cleanup.
 
 # Testing locally with ArduPilot, MAVProxy, SITL, and X-Plane
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,6 @@
 %{
   "circuits_uart": {:hex, :circuits_uart, "1.5.5", "0cb6df39ab66bf712dd854d1da8fe9cdbe2fee245661bf6aef49031b43acdbf6", [:mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "e688282b271d66cfe10c26e19fe3592202524532aaaebb3849ea26770ea52f5d"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},
-  "dialyzex": {:hex, :dialyzex, "1.3.0", "3687f38182751cf6c4444cb0ada036a608567b44eb539e198c9fd4a391fa0088", [:mix], [], "hexpm", "9835208ea3314ef1ec55def3b3d80e5d71c09d29ce2791b7ba6bcf275d92cdae"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.44", "f20830dd6b5c77afe2b063777ddbbff09f9759396500cdbe7523efd58d7a339c", [:mix], [], "hexpm", "4778ac752b4701a5599215f7030989c989ffdc4f6df457c5f36938cc2d2a2750"},
   "elixir_make": {:hex, :elixir_make, "0.9.0", "6484b3cd8c0cee58f09f05ecaf1a140a8c97670671a6a0e7ab4dc326c3109726", [:mix], [], "hexpm", "db23d4fd8b757462ad02f8aa73431a426fe6671c80b200d9710caf3d1dd0ffdb"},
   "erlex": {:hex, :erlex, "0.2.8", "cd8116f20f3c0afe376d1e8d1f0ae2452337729f68be016ea544a72f767d9c12", [:mix], [], "hexpm", "9d66ff9fedf69e49dc3fd12831e12a8a37b76f8651dd21cd45fcf5561a8a7590"},
@@ -12,5 +10,4 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},
-  "serial": {:hex, :serial, "0.1.2", "8c0959331417372bf58f259dbc106c59bb7ed482cb3f63f3765150c02cf14b88", [:make, :mix], [], "hexpm"},
 }


### PR DESCRIPTION
## Summary

- Remove unused `mix.lock` entries for `dialyzex`, `earmark`, and `serial`.
- Add `mix deps.unlock --check-unused` to the CI quality gate.
- Document the generated `lib/common.ex` policy in `.formatter.exs`, `README.md`, and `TESTING.md`.
- Keep generated dialect modules intentionally excluded from formatting while making regeneration, not manual edits, the expected workflow.

Follow-up: #39 tracks making generated dialect output deterministic and formatter-compatible in the future.

## Verification

- `mise exec -- mix deps.unlock --check-unused`
- `mise exec -- mix format --check-formatted`
- `mise exec -- env MIX_ENV=test mix compile --warnings-as-errors`
- `mise exec -- env MIX_ENV=test mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix dialyzer`