### PR TITLE
Mature utility API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.10.0 - 2026-05-07
+
+- Made utility supervision opt-in and documented how to start utilities for
+  the configured router or an explicitly supervised named router.
+- Clarified that the current utility layer is scoped to one selected router per
+  VM while the core router API remains the multi-router integration surface.
+- Changed utility focus and cache helpers to return normal `{:error, reason}`
+  results when utility state or MAV data is missing.
+- Added bounded retry behavior and cleanup for arm/disarm, parameter request,
+  and parameter set helpers.
+- Changed parameter query results to use MAVLink parameter names as string keys
+  instead of creating atoms from vehicle-provided input.
+- Added configurable SITL RC forwarding destination addresses.
+
 ## 0.9.1 - 2026-05-07
 
 - Strengthened CI release gates with formatting, warnings-as-errors, xref,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.9.1"}
+     {:xmavlink, "~> 0.10.0"}
    ]
  end
  ```
@@ -300,7 +300,41 @@ As of version 0.5.0, XMAVLink includes utility modules (previously in the separa
 - **Parameter Management**: Request and set vehicle parameters
 - **SITL Support**: Forward RC channels for Software-In-The-Loop simulation
 
-See the included `.iex.exs` file for convenient helper imports to use in IEx sessions, providing an interactive experience similar to MAVProxy.
+The utility layer is opt-in because `CacheManager` subscribes to MAVLink traffic
+and requests vehicle parameter lists when vehicles appear. Enable it for the
+configured application router with:
+
+```elixir
+config :xmavlink,
+  utilities: true
+```
+
+or supervise it explicitly when using a named router:
+
+```elixir
+children = [
+  {XMAVLink.Router,
+   %{
+     name: MyApp.VehicleRouter,
+     system: 245,
+     component: 250,
+     dialect: Common,
+     connection_strings: ["udpout:127.0.0.1:14550"]
+   }},
+  {XMAVLink.Util.Supervisor, router: MyApp.VehicleRouter}
+]
+```
+
+The current utility API is scoped to one configured router per VM. It uses
+global process names and ETS tables for IEx-friendly helpers, so applications
+that need multiple independent routers should use the core `XMAVLink.Router`
+API directly or keep utility usage limited to one selected router.
+
+Command helpers such as arm/disarm and parameter setting use bounded retry
+loops by default. Pass `:retries`, `:retry_interval_ms`, or `:router` in the
+options when a helper needs different behavior. Parameter queries return maps
+keyed by MAVLink parameter names as strings. `XMAVLink.Util.SITL.forward_rc/2`
+also accepts `:destination_address` when the SITL RC input is not on loopback.
 
 ## Roadmap
 

--- a/lib/mavlink/application.ex
+++ b/lib/mavlink/application.ex
@@ -4,7 +4,19 @@ defmodule XMAVLink.Application do
   use Application
 
   def start(_, _) do
-    children = [XMAVLink.Supervisor]
+    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+
+    children =
+      [XMAVLink.Supervisor] ++
+        utility_child_specs(router_name)
+
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp utility_child_specs(router_name) do
+    case Application.get_env(:xmavlink, :utilities, false) do
+      true -> [{XMAVLink.Util.Supervisor, router: router_name}]
+      _ -> []
+    end
   end
 end

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -59,7 +59,7 @@ defmodule XMAVLink.LocalConnection do
     }
   end
 
-  def connect(:local, system, component, subscription_cache \\ XMAVLink.SubscriptionCache) do
+  def new(system, component, subscription_cache \\ XMAVLink.SubscriptionCache) do
     local_connection =
       struct(LocalConnection,
         system: system,
@@ -67,13 +67,19 @@ defmodule XMAVLink.LocalConnection do
         subscription_cache: subscription_cache
       )
 
+    restore_subscriptions(local_connection)
+  end
+
+  def connect(:local, system, component, subscription_cache \\ XMAVLink.SubscriptionCache) do
+    local_connection = new(system, component, subscription_cache)
+
     send(
       # Local connection guaranteed, so this connect() called directly from Router process
       self(),
       {
         :add_connection,
         :local,
-        restore_subscriptions(local_connection)
+        local_connection
       }
     )
   end

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -483,7 +483,7 @@ defmodule XMAVLink.Router do
     subscription_cache = subscription_cache_name(args.name)
     {:ok, connection_supervisor} = ConnectionSupervisor.start_link()
 
-    LocalConnection.connect(:local, args.system, args.component, subscription_cache)
+    local_connection = LocalConnection.new(args.system, args.component, subscription_cache)
     connection_specs = Enum.map(args.connection_strings, &connection_spec/1)
 
     for connection_spec <- connection_specs do
@@ -497,7 +497,8 @@ defmodule XMAVLink.Router do
        connection_strings: args.connection_strings,
        connection_retry_ms: args.connection_retry_ms,
        connection_supervisor: connection_supervisor,
-       subscription_cache: subscription_cache
+       subscription_cache: subscription_cache,
+       connections: %{local: local_connection}
      }}
   end
 

--- a/lib/mavlink_util/application.ex
+++ b/lib/mavlink_util/application.ex
@@ -4,7 +4,9 @@ defmodule XMAVLink.Util.Application do
   use Application
 
   def start(_, _) do
-    children = [XMAVLink.Util.Supervisor]
+    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+    children = [{XMAVLink.Util.Supervisor, router: router_name}]
+
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/lib/mavlink_util/arm.ex
+++ b/lib/mavlink_util/arm.ex
@@ -1,22 +1,32 @@
 defmodule XMAVLink.Util.Arm do
-  @moduledoc false
+  @moduledoc """
+  Convenience helpers for arming and disarming a focused or explicit vehicle.
+
+  The helpers are intended for the utility layer's selected router and return
+  `:ok` or `{:error, reason}`. Retries are bounded by default; pass
+  `:retries`, `:retry_interval_ms`, or `:router` in the options to override the
+  defaults.
+  """
 
   @arm_retry_interval 3000
+  @arm_retries 5
 
   require Logger
   alias Common.Message.CommandLong
   alias Common.Message.Heartbeat
-  alias XMAVLink.Router, as: MAV
-  import XMAVLink.Util.CacheManager, only: [msg: 1]
+  alias XMAVLink.Util.CacheManager
+  import XMAVLink.Util.CacheManager, only: [msg: 2]
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
-  def arm() do
+  def arm(opts \\ []) when is_list(opts) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
-      arm(system_id, component_id, mavlink_version)
+      arm(system_id, component_id, mavlink_version, opts)
     end
   end
 
-  def arm(system_id, component_id, mavlink_version) do
+  def arm(system_id, component_id, mavlink_version, opts \\ []) do
+    opts = command_opts(opts, @arm_retry_interval, @arm_retries)
+
     with {:ok, _, %Heartbeat{system_status: system_status}}
          when system_status in [
                 :mav_state_standby,
@@ -24,41 +34,13 @@ defmodule XMAVLink.Util.Arm do
                 :mav_state_critical,
                 :mav_state_emergency
               ] <-
-           msg(Heartbeat) do
-      MAV.subscribe(message: Heartbeat, source_system: system_id)
-
-      MAV.pack_and_send(
-        %CommandLong{
-          command: :mav_cmd_component_arm_disarm,
-          confirmation: 1,
-          # Arm
-          param1: 1.0,
-          param2: 0.0,
-          param3: 0.0,
-          param4: 0.0,
-          param5: 0.0,
-          param6: 0.0,
-          param7: 0.0,
-          target_component: component_id,
-          target_system: system_id
-        },
-        mavlink_version
-      )
-
-      receive do
-        %Heartbeat{base_mode: base_mode} ->
-          cond do
-            :mav_mode_flag_safety_armed in base_mode ->
-              MAV.unsubscribe()
-              Logger.info("Armed vehicle #{system_id}.#{component_id}")
-              :ok
-
-            true ->
-              arm(system_id, component_id, mavlink_version)
-          end
+           msg({system_id, component_id, mavlink_version}, Heartbeat),
+         :ok <-
+           XMAVLink.Router.subscribe(opts.router, message: Heartbeat, source_system: system_id) do
+      try do
+        do_arm(system_id, component_id, mavlink_version, opts, opts.attempts)
       after
-        @arm_retry_interval ->
-          arm(system_id, component_id, mavlink_version)
+        XMAVLink.Router.unsubscribe(opts.router)
       end
     else
       {:ok, _, %Heartbeat{system_status: invalid_system_status}} ->
@@ -77,47 +59,102 @@ defmodule XMAVLink.Util.Arm do
     end
   end
 
-  def disarm() do
+  def disarm(opts \\ []) when is_list(opts) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
-      disarm(system_id, component_id, mavlink_version)
+      disarm(system_id, component_id, mavlink_version, opts)
     end
   end
 
-  def disarm(system_id, component_id, mavlink_version) do
-    MAV.subscribe(message: Heartbeat, source_system: system_id)
+  def disarm(system_id, component_id, mavlink_version, opts \\ []) do
+    opts = command_opts(opts, @arm_retry_interval, @arm_retries)
 
-    MAV.pack_and_send(
-      %CommandLong{
-        command: :mav_cmd_component_arm_disarm,
-        confirmation: 1,
-        # Disarm
-        param1: 0.0,
-        param2: 0.0,
-        param3: 0.0,
-        param4: 0.0,
-        param5: 0.0,
-        param6: 0.0,
-        param7: 0.0,
-        target_component: component_id,
-        target_system: system_id
-      },
-      mavlink_version
-    )
+    with :ok <-
+           XMAVLink.Router.subscribe(opts.router, message: Heartbeat, source_system: system_id) do
+      try do
+        do_disarm(system_id, component_id, mavlink_version, opts, opts.attempts)
+      after
+        XMAVLink.Router.unsubscribe(opts.router)
+      end
+    end
+  end
 
-    receive do
-      %Heartbeat{base_mode: base_mode} ->
-        cond do
-          :mav_mode_flag_safety_armed not in base_mode ->
-            MAV.unsubscribe()
+  defp do_arm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
+
+  defp do_arm(system_id, component_id, mavlink_version, opts, attempts) do
+    with :ok <-
+           XMAVLink.Router.pack_and_send(
+             opts.router,
+             arm_command(system_id, component_id, 1.0),
+             mavlink_version
+           ) do
+      receive do
+        %Heartbeat{base_mode: base_mode} ->
+          if :mav_mode_flag_safety_armed in base_mode do
+            Logger.info("Armed vehicle #{system_id}.#{component_id}")
+            :ok
+          else
+            do_arm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+          end
+      after
+        opts.retry_interval_ms ->
+          do_arm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+      end
+    end
+  end
+
+  defp do_disarm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
+
+  defp do_disarm(system_id, component_id, mavlink_version, opts, attempts) do
+    with :ok <-
+           XMAVLink.Router.pack_and_send(
+             opts.router,
+             arm_command(system_id, component_id, 0.0),
+             mavlink_version
+           ) do
+      receive do
+        %Heartbeat{base_mode: base_mode} ->
+          if :mav_mode_flag_safety_armed not in base_mode do
             Logger.info("Disarmed vehicle #{system_id}.#{component_id}")
             :ok
-
-          true ->
-            disarm(system_id, component_id, mavlink_version)
-        end
-    after
-      @arm_retry_interval ->
-        disarm(system_id, component_id, mavlink_version)
+          else
+            do_disarm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+          end
+      after
+        opts.retry_interval_ms ->
+          do_disarm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+      end
     end
   end
+
+  defp arm_command(system_id, component_id, arm) do
+    %CommandLong{
+      command: :mav_cmd_component_arm_disarm,
+      confirmation: 1,
+      param1: arm,
+      param2: 0.0,
+      param3: 0.0,
+      param4: 0.0,
+      param5: 0.0,
+      param6: 0.0,
+      param7: 0.0,
+      target_component: component_id,
+      target_system: system_id
+    }
+  end
+
+  defp command_opts(opts, retry_interval_ms, retries) do
+    retries = Keyword.get(opts, :retries, retries)
+
+    %{
+      router: Keyword.get(opts, :router, CacheManager.router()),
+      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, retry_interval_ms),
+      attempts: attempts(retries)
+    }
+  end
+
+  defp attempts(:infinity), do: :infinity
+  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
+
+  defp next_attempts(:infinity), do: :infinity
+  defp next_attempts(attempts), do: attempts - 1
 end

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -13,7 +13,6 @@ defmodule XMAVLink.Util.CacheManager do
 
   use GenServer
   require Logger
-  alias XMAVLink.Router, as: MAV
   alias XMAVLink.Util.ParamRequest
   alias Common.Message.Heartbeat
   alias Common.Message.ParamValue
@@ -28,18 +27,31 @@ defmodule XMAVLink.Util.CacheManager do
 
   defstruct one_second_interval_ms: 1_000,
             five_second_interval_ms: 5_000,
-            ten_second_interval_ms: 10_000
+            ten_second_interval_ms: 10_000,
+            router: nil
 
   # API
 
   def start_link(state, opts \\ []) do
-    GenServer.start_link(__MODULE__, state, [{:name, __MODULE__} | opts])
+    GenServer.start_link(__MODULE__, state, Keyword.put_new(opts, :name, __MODULE__))
   end
 
   def mavs() do
-    scids = :ets.foldl(fn {scid, _}, acc -> [scid | acc] end, [], @systems)
-    Logger.info("Listing #{length(scids)} visible vehicles")
-    {:ok, scids}
+    with :ok <- require_table(@systems) do
+      scids = :ets.foldl(fn {scid, _}, acc -> [scid | acc] end, [], @systems)
+      Logger.info("Listing #{length(scids)} visible vehicles")
+      {:ok, scids}
+    end
+  end
+
+  def router() do
+    case GenServer.whereis(__MODULE__) do
+      nil ->
+        Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+
+      pid ->
+        GenServer.call(pid, :router)
+    end
   end
 
   def msg() do
@@ -49,20 +61,22 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   def msg({system_id, component_id, _}) do
-    {
-      :ok,
-      :ets.foldl(
-        fn
-          {{^system_id, ^component_id, msg_type}, {received, msg}}, acc ->
-            Enum.into([{msg_type, {now() - received, msg}}], acc)
+    with :ok <- require_table(@messages) do
+      {
+        :ok,
+        :ets.foldl(
+          fn
+            {{^system_id, ^component_id, msg_type}, {received, msg}}, acc ->
+              Enum.into([{msg_type, {now() - received, msg}}], acc)
 
-          _, acc ->
-            acc
-        end,
-        %{},
-        @messages
-      )
-    }
+            _, acc ->
+              acc
+          end,
+          %{},
+          @messages
+        )
+      }
+    end
   end
 
   def msg(name) do
@@ -72,7 +86,8 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   def msg({system_id, component_id, _}, msg_type) when is_atom(msg_type) do
-    with [{_key, {received, message}}] <-
+    with :ok <- require_table(@messages),
+         [{_key, {received, message}}] <-
            :ets.lookup(@messages, {system_id, component_id, msg_type}) do
       Logger.info("Most recent \"#{dequalify_msg_type(msg_type)}\" message")
       {:ok, now() - received, message}
@@ -103,17 +118,15 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   def params({system_id, component_id, _mavlink_version}, match) when is_binary(match) do
-    with match_upcase <- String.upcase(match),
+    with :ok <- require_table(@params),
+         match_upcase <- String.upcase(match),
          param_map when is_map(param_map) <-
            :ets.foldl(
              fn
                {{^system_id, ^component_id, param_id}, {_, %ParamValue{param_value: param_value}}},
                acc ->
                  if String.contains?(param_id, match_upcase) do
-                   Enum.into(
-                     [{param_id |> String.downcase() |> String.to_atom(), param_value}],
-                     acc
-                   )
+                   Enum.into([{param_id, param_value}], acc)
                  else
                    acc
                  end
@@ -139,9 +152,8 @@ defmodule XMAVLink.Util.CacheManager do
     :ets.new(@systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
     :ets.new(@params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
 
-    MAV.subscribe(as_frame: true)
-
-    state = struct(__MODULE__, opts)
+    state = __MODULE__ |> struct(opts) |> normalize_router()
+    XMAVLink.Router.subscribe(state.router, as_frame: true)
 
     {
       :ok,
@@ -153,6 +165,10 @@ defmodule XMAVLink.Util.CacheManager do
   end
 
   @impl true
+  def handle_call(:router, _caller, state) do
+    {:reply, state.router, state}
+  end
+
   def handle_call(_msg, _caller, state) do
     {:reply, :ok, state}
   end
@@ -243,7 +259,8 @@ defmodule XMAVLink.Util.CacheManager do
     spawn_link(ParamRequest, :param_request_list, [
       source_system_id,
       source_component_id,
-      mavlink_major_version
+      mavlink_major_version,
+      [router: state.router]
     ])
 
     state
@@ -321,4 +338,20 @@ defmodule XMAVLink.Util.CacheManager do
     |> String.split(".")
     |> (fn parts -> parts |> Enum.reverse() |> List.first() end).()
   end
+
+  defp require_table(table) do
+    case :ets.info(table) do
+      :undefined -> {:error, :not_started}
+      _ -> :ok
+    end
+  end
+
+  defp normalize_router(state = %{router: nil}) do
+    %{
+      state
+      | router: Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+    }
+  end
+
+  defp normalize_router(state), do: state
 end

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -92,6 +92,9 @@ defmodule XMAVLink.Util.CacheManager do
       Logger.info("Most recent \"#{dequalify_msg_type(msg_type)}\" message")
       {:ok, now() - received, message}
     else
+      {:error, :not_started} ->
+        {:error, :not_started}
+
       _ ->
         Logger.warning(
           "Error attempting to retrieve message of type \"#{dequalify_msg_type(msg_type)}\""
@@ -140,6 +143,9 @@ defmodule XMAVLink.Util.CacheManager do
       Logger.info("Listing #{param_map |> Map.keys() |> length} parameters matching \"#{match}\"")
       {:ok, param_map}
     else
+      {:error, :not_started} ->
+        {:error, :not_started}
+
       _ ->
         Logger.warning("Error attempting to query params matching \"#{match}\"")
         {:error, :query_failed}

--- a/lib/mavlink_util/focus_manager.ex
+++ b/lib/mavlink_util/focus_manager.ex
@@ -16,7 +16,7 @@ defmodule XMAVLink.Util.FocusManager do
 
   # API
   def start_link(state, opts \\ []) do
-    GenServer.start_link(__MODULE__, state, [{:name, __MODULE__} | opts])
+    GenServer.start_link(__MODULE__, state, Keyword.put_new(opts, :name, __MODULE__))
   end
 
   def focus() do
@@ -24,7 +24,8 @@ defmodule XMAVLink.Util.FocusManager do
   end
 
   def focus(pid) when is_pid(pid) do
-    with [{^pid, scid}] <- :ets.lookup(@sessions, pid) do
+    with :ok <- require_table(@sessions),
+         [{^pid, scid}] <- :ets.lookup(@sessions, pid) do
       if pid == self() do
         Logger.info("Vehicle #{format(scid)}")
       else
@@ -33,6 +34,9 @@ defmodule XMAVLink.Util.FocusManager do
 
       {:ok, scid}
     else
+      {:error, reason} ->
+        {:error, reason}
+
       _ ->
         Logger.warning("#{inspect(pid)} has no vehicle focus")
         {:error, :not_focussed}
@@ -40,10 +44,14 @@ defmodule XMAVLink.Util.FocusManager do
   end
 
   def focus(system_id, component_id \\ 1) do
-    {:ok, {system_id, component_id, _}} =
-      GenServer.call(XMAVLink.Util.FocusManager, {:focus, {system_id, component_id}})
-
-    configure_iex_prompt(system_id, component_id)
+    with pid when is_pid(pid) <- GenServer.whereis(__MODULE__),
+         {:ok, {system_id, component_id, _}} <-
+           GenServer.call(pid, {:focus, {system_id, component_id}}) do
+      configure_iex_prompt(system_id, component_id)
+    else
+      nil -> {:error, :not_started}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @impl true
@@ -54,7 +62,8 @@ defmodule XMAVLink.Util.FocusManager do
 
   @impl true
   def handle_call({:focus, scid = {system_id, component_id}}, {caller_pid, _}, state) do
-    with mavlink_major_version when is_number(mavlink_major_version) <-
+    with :ok <- require_table(@systems),
+         mavlink_major_version when is_number(mavlink_major_version) <-
            :ets.foldl(
              fn {next_scid, %{mavlink_major_version: mmv}}, acc ->
                if next_scid == scid do
@@ -77,6 +86,7 @@ defmodule XMAVLink.Util.FocusManager do
         {:reply, {:error, :no_such_mav}, state}
       end
     else
+      {:error, reason} -> {:reply, {:error, reason}, state}
       _ -> {:reply, {:error, :no_mav_data}, state}
     end
   end
@@ -140,4 +150,11 @@ defmodule XMAVLink.Util.FocusManager do
 
   defp format({s, c, _}), do: format({s, c})
   defp format({s, c}), do: "#{s}.#{c}"
+
+  defp require_table(table) do
+    case :ets.info(table) do
+      :undefined -> {:error, :not_started}
+      _ -> :ok
+    end
+  end
 end

--- a/lib/mavlink_util/param_request.ex
+++ b/lib/mavlink_util/param_request.ex
@@ -1,49 +1,133 @@
 defmodule XMAVLink.Util.ParamRequest do
-  @moduledoc false
+  @moduledoc """
+  Convenience helper for requesting a vehicle's full parameter list.
+
+  The helper watches `XMAVLink.Util.CacheManager` state and resends
+  `PARAM_REQUEST_LIST` while the cached parameter count is not progressing.
+  Retries are bounded by default; pass `:retries`, `:retry_interval_ms`, or
+  `:router` in the options to override the defaults.
+  """
 
   @systems :systems
   @param_retry_interval 3000
+  @param_retries 10
 
   require Logger
-  alias XMAVLink.Router, as: MAV
+  alias XMAVLink.Util.CacheManager
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
-  def param_request_list() do
+  def param_request_list(opts \\ []) when is_list(opts) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
       Logger.info("Waiting to receive first parameter from vehicle #{system_id}.#{component_id}")
-      param_request_list(system_id, component_id, mavlink_version)
+      param_request_list(system_id, component_id, mavlink_version, opts)
     end
   end
 
-  def param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded \\ 0) do
-    with [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <-
+  def param_request_list(system_id, component_id, mavlink_version, _opts_or_last \\ [])
+
+  def param_request_list(system_id, component_id, mavlink_version, opts) when is_list(opts) do
+    opts = command_opts(opts)
+    do_param_request_list(system_id, component_id, mavlink_version, 0, opts)
+  end
+
+  def param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded)
+      when is_integer(last_param_count_loaded) do
+    opts = command_opts([])
+    do_param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded, opts)
+  end
+
+  defp do_param_request_list(
+         system_id,
+         component_id,
+         mavlink_version,
+         last_param_count_loaded,
+         opts
+       ) do
+    with :ok <- require_table(@systems),
+         [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <-
            :ets.lookup(@systems, {system_id, component_id}),
          retry <- param_count_loaded == last_param_count_loaded,
          complete <- param_count_loaded == param_count and param_count > 0 do
-      if complete do
-        Logger.info(
-          "All #{param_count} parameters loaded for vehicle #{system_id}.#{component_id}"
-        )
-      else
-        if param_count > 0 do
+      cond do
+        complete ->
           Logger.info(
-            "Loaded #{param_count_loaded}/#{param_count} parameters for vehicle #{system_id}.#{component_id}"
+            "All #{param_count} parameters loaded for vehicle #{system_id}.#{component_id}"
           )
-        end
 
-        if retry do
-          MAV.pack_and_send(
-            %Common.Message.ParamRequestList{
-              target_system: system_id,
-              target_component: component_id
-            },
-            mavlink_version
-          )
-        end
+        retry and opts.attempts == 0 ->
+          {:error, :timeout}
 
-        Process.sleep(@param_retry_interval)
-        param_request_list(system_id, component_id, mavlink_version, param_count_loaded)
+        true ->
+          if param_count > 0 do
+            Logger.info(
+              "Loaded #{param_count_loaded}/#{param_count} parameters for vehicle #{system_id}.#{component_id}"
+            )
+          end
+
+          with :ok <-
+                 maybe_send_param_request(retry, system_id, component_id, mavlink_version, opts) do
+            opts =
+              if retry do
+                %{opts | attempts: next_attempts(opts.attempts)}
+              else
+                %{
+                  opts
+                  | attempts: attempts(Keyword.get(opts.source_opts, :retries, @param_retries))
+                }
+              end
+
+            Process.sleep(opts.retry_interval_ms)
+
+            do_param_request_list(
+              system_id,
+              component_id,
+              mavlink_version,
+              param_count_loaded,
+              opts
+            )
+          end
       end
+    else
+      [] -> {:error, :no_such_mav}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_send_param_request(false, _system_id, _component_id, _mavlink_version, _opts),
+    do: :ok
+
+  defp maybe_send_param_request(true, system_id, component_id, mavlink_version, opts) do
+    XMAVLink.Router.pack_and_send(
+      opts.router,
+      %Common.Message.ParamRequestList{
+        target_system: system_id,
+        target_component: component_id
+      },
+      mavlink_version
+    )
+  end
+
+  defp command_opts(opts) do
+    retries = Keyword.get(opts, :retries, @param_retries)
+
+    %{
+      router: Keyword.get(opts, :router, CacheManager.router()),
+      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
+      attempts: attempts(retries),
+      source_opts: opts
+    }
+  end
+
+  defp attempts(:infinity), do: :infinity
+  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
+
+  defp next_attempts(:infinity), do: :infinity
+  defp next_attempts(attempts), do: attempts - 1
+
+  defp require_table(table) do
+    case :ets.info(table) do
+      :undefined -> {:error, :not_started}
+      _ -> :ok
     end
   end
 end

--- a/lib/mavlink_util/param_set.ex
+++ b/lib/mavlink_util/param_set.ex
@@ -1,58 +1,120 @@
 defmodule XMAVLink.Util.ParamSet do
-  @moduledoc false
+  @moduledoc """
+  Convenience helper for setting cached MAVLink parameters.
+
+  The helper uses the parameter type cached by `XMAVLink.Util.CacheManager`,
+  sends `PARAM_SET`, and waits for a matching `PARAM_VALUE` confirmation.
+  Retries are bounded by default; pass `:retries`, `:retry_interval_ms`, or
+  `:router` in the options to override the defaults.
+  """
 
   @params :params
   @param_retry_interval 3000
+  @param_retries 5
 
   require Logger
-  alias XMAVLink.Router, as: MAV
+  alias XMAVLink.Util.CacheManager
   alias Common.Message.ParamValue
   alias Common.Message.ParamSet
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
-  def param_set(param, new_value) do
+  def param_set(param, new_value, opts \\ []) when is_list(opts) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
-      param_set(system_id, component_id, mavlink_version, param, new_value)
+      param_set(system_id, component_id, mavlink_version, param, new_value, opts)
     end
   end
 
-  def param_set(system_id, component_id, mavlink_version, param, new_value) when is_atom(param) do
-    param_set(
-      system_id,
-      component_id,
-      mavlink_version,
-      param |> Atom.to_string() |> String.upcase(),
-      new_value
-    )
+  def param_set(system_id, component_id, mavlink_version, param, new_value, opts \\ []) do
+    param = normalize_param_id(param)
+    opts = command_opts(opts)
+
+    with :ok <- require_table(@params),
+         [{{^system_id, ^component_id, ^param}, {_time, %ParamValue{param_type: param_type}}}] <-
+           :ets.lookup(@params, {system_id, component_id, param}),
+         :ok <-
+           XMAVLink.Router.subscribe(opts.router, message: ParamValue, source_system: system_id) do
+      try do
+        do_param_set(system_id, component_id, mavlink_version, param, new_value, param_type, opts)
+      after
+        XMAVLink.Router.unsubscribe(opts.router)
+      end
+    else
+      [] -> {:error, :unknown_param}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
-  def param_set(system_id, component_id, mavlink_version, param, new_value) do
-    with [{{^system_id, ^component_id, ^param}, {_time, %ParamValue{param_type: param_type}}}] <-
-           :ets.lookup(@params, {system_id, component_id, param}) do
-      MAV.subscribe(message: ParamValue, source_system: system_id)
+  defp do_param_set(
+         _system_id,
+         _component_id,
+         _mavlink_version,
+         _param,
+         _new_value,
+         _param_type,
+         _opts = %{attempts: 0}
+       ),
+       do: {:error, :timeout}
 
-      MAV.pack_and_send(
-        %ParamSet{
-          target_system: system_id,
-          target_component: component_id,
-          param_id: param,
-          param_value: new_value,
-          param_type: param_type
-        },
-        mavlink_version
-      )
-
+  defp do_param_set(system_id, component_id, mavlink_version, param, new_value, param_type, opts) do
+    with :ok <-
+           XMAVLink.Router.pack_and_send(
+             opts.router,
+             %ParamSet{
+               target_system: system_id,
+               target_component: component_id,
+               param_id: param,
+               param_value: new_value,
+               param_type: param_type
+             },
+             mavlink_version
+           ) do
       receive do
         %ParamValue{param_id: ^param, param_value: ^new_value} ->
-          MAV.unsubscribe()
-
           Logger.info(
-            "Set #{param |> String.downcase()} to #{inspect(new_value)} for vehicle #{system_id}.#{component_id}"
+            "Set #{String.downcase(param)} to #{inspect(new_value)} for vehicle #{system_id}.#{component_id}"
           )
+
+          :ok
       after
-        @param_retry_interval ->
-          param_set(system_id, component_id, mavlink_version, param, new_value)
+        opts.retry_interval_ms ->
+          do_param_set(
+            system_id,
+            component_id,
+            mavlink_version,
+            param,
+            new_value,
+            param_type,
+            %{opts | attempts: next_attempts(opts.attempts)}
+          )
       end
+    end
+  end
+
+  defp normalize_param_id(param) when is_atom(param),
+    do: param |> Atom.to_string() |> String.upcase()
+
+  defp normalize_param_id(param) when is_binary(param), do: String.upcase(param)
+
+  defp command_opts(opts) do
+    retries = Keyword.get(opts, :retries, @param_retries)
+
+    %{
+      router: Keyword.get(opts, :router, CacheManager.router()),
+      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
+      attempts: attempts(retries)
+    }
+  end
+
+  defp attempts(:infinity), do: :infinity
+  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
+
+  defp next_attempts(:infinity), do: :infinity
+  defp next_attempts(attempts), do: attempts - 1
+
+  defp require_table(table) do
+    case :ets.info(table) do
+      :undefined -> {:error, :not_started}
+      _ -> :ok
     end
   end
 end

--- a/lib/mavlink_util/sitl.ex
+++ b/lib/mavlink_util/sitl.ex
@@ -72,10 +72,12 @@ defmodule XMAVLink.Util.SITL do
         destination_address
       )
     else
-      _ ->
+      {:error, reason} ->
         Logger.warning(
-          "Could not subscribe or open port to forward RC from vehicle #{system_id}.#{component_id}"
+          "Could not subscribe or open port to forward RC from vehicle #{system_id}.#{component_id}: #{inspect(reason)}"
         )
+
+        {:error, reason}
     end
   end
 
@@ -165,6 +167,13 @@ defmodule XMAVLink.Util.SITL do
     end
   end
 
-  defp resolve_destination_address(address) when is_tuple(address), do: {:ok, address}
+  defp resolve_destination_address({a, b, c, d} = address)
+       when a in 0..255 and b in 0..255 and c in 0..255 and d in 0..255,
+       do: {:ok, address}
+
+  defp resolve_destination_address(address) when is_tuple(address),
+    do: {:error, :invalid_destination_address}
+
   defp resolve_destination_address(address) when is_binary(address), do: resolve_address(address)
+  defp resolve_destination_address(_address), do: {:error, :invalid_destination_address}
 end

--- a/lib/mavlink_util/sitl.ex
+++ b/lib/mavlink_util/sitl.ex
@@ -1,44 +1,76 @@
 defmodule XMAVLink.Util.SITL do
   @moduledoc """
-  Provide SITL specific support e.g RC channel forwarding
+  Provides SITL-specific support such as RC channel forwarding.
+
+  `forward_rc/2` starts a linked task that subscribes to `RC_CHANNELS_RAW`
+  messages and forwards the eight primary channels as little-endian 16-bit
+  values to a SITL RC input UDP endpoint. Pass `:router` to target a named
+  router and `:destination_address` to forward somewhere other than
+  `{127, 0, 0, 1}`.
   """
 
   require Logger
-  alias XMAVLink.Router, as: MAV
+  import XMAVLink.Utils, only: [resolve_address: 1]
+
+  alias XMAVLink.Util.CacheManager
   alias Common.Message.RcChannelsRaw
   alias Common.Message.RequestDataStream
   import XMAVLink.Util.FocusManager, only: [focus: 0]
 
   @resend_stream_interval 90
 
-  def forward_rc(sitl_rc_in_port \\ 5501) do
+  def forward_rc(sitl_rc_in_port_or_opts \\ 5501, opts \\ [])
+
+  def forward_rc(opts, []) when is_list(opts), do: forward_rc(5501, opts)
+
+  def forward_rc(sitl_rc_in_port, opts) do
     with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
-      forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port)
+      forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port, opts)
     end
   end
 
-  def forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port) do
+  def forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port, opts \\ []) do
     Task.start_link(__MODULE__, :_connect, [
       system_id,
       component_id,
       mavlink_version,
-      sitl_rc_in_port
+      sitl_rc_in_port,
+      Keyword.get(opts, :router, CacheManager.router()),
+      Keyword.get(opts, :destination_address, {127, 0, 0, 1})
     ])
   end
 
-  def _connect(system_id, component_id, mavlink_version, sitl_rc_in_port) do
-    with {:ok, socket} <- :gen_udp.open(0, [:binary, ip: {127, 0, 0, 1}]),
+  def _connect(
+        system_id,
+        component_id,
+        mavlink_version,
+        sitl_rc_in_port,
+        router,
+        destination_address
+      ) do
+    with {:ok, destination_address} <- resolve_destination_address(destination_address),
+         {:ok, socket} <- :gen_udp.open(0, [:binary, ip: {127, 0, 0, 1}]),
          :ok <-
-           MAV.subscribe(
+           XMAVLink.Router.subscribe(
+             router,
              message: RcChannelsRaw,
              source_system: system_id,
              source_component: component_id
            ) do
       Logger.info(
-        "Start forwarding RC from vehicle #{system_id}.#{component_id} to SITL rc-in port #{sitl_rc_in_port}}"
+        "Start forwarding RC from vehicle #{system_id}.#{component_id} to SITL rc-in port #{sitl_rc_in_port}"
       )
 
-      _forward(system_id, component_id, mavlink_version, sitl_rc_in_port, socket, 0)
+      _forward(
+        system_id,
+        component_id,
+        mavlink_version,
+        sitl_rc_in_port,
+        socket,
+        0,
+        router,
+        destination_address
+      )
     else
       _ ->
         Logger.warning(
@@ -47,8 +79,18 @@ defmodule XMAVLink.Util.SITL do
     end
   end
 
-  def _forward(system_id, component_id, mavlink_version, sitl_rc_in_port, socket, 0) do
-    MAV.pack_and_send(
+  def _forward(
+        system_id,
+        component_id,
+        mavlink_version,
+        sitl_rc_in_port,
+        socket,
+        0,
+        router,
+        destination_address
+      ) do
+    XMAVLink.Router.pack_and_send(
+      router,
       %RequestDataStream{
         target_system: system_id,
         # APM Planner sends this, doesn't work with real component id
@@ -67,11 +109,22 @@ defmodule XMAVLink.Util.SITL do
       mavlink_version,
       sitl_rc_in_port,
       socket,
-      @resend_stream_interval
+      @resend_stream_interval,
+      router,
+      destination_address
     )
   end
 
-  def _forward(system_id, component_id, mavlink_version, sitl_rc_in_port, socket, count) do
+  def _forward(
+        system_id,
+        component_id,
+        mavlink_version,
+        sitl_rc_in_port,
+        socket,
+        count,
+        router,
+        destination_address
+      ) do
     receive do
       %RcChannelsRaw{
         chan1_raw: c1,
@@ -85,8 +138,7 @@ defmodule XMAVLink.Util.SITL do
       } ->
         :gen_udp.send(
           socket,
-          # TODO accept destination IP as parameter
-          {127, 0, 0, 1},
+          destination_address,
           sitl_rc_in_port,
           <<
             c1::little-unsigned-integer-size(16),
@@ -100,7 +152,19 @@ defmodule XMAVLink.Util.SITL do
           >>
         )
 
-        _forward(system_id, component_id, mavlink_version, sitl_rc_in_port, socket, count - 1)
+        _forward(
+          system_id,
+          component_id,
+          mavlink_version,
+          sitl_rc_in_port,
+          socket,
+          count - 1,
+          router,
+          destination_address
+        )
     end
   end
+
+  defp resolve_destination_address(address) when is_tuple(address), do: {:ok, address}
+  defp resolve_destination_address(address) when is_binary(address), do: resolve_address(address)
 end

--- a/lib/mavlink_util/supervisor.ex
+++ b/lib/mavlink_util/supervisor.ex
@@ -3,15 +3,17 @@ defmodule XMAVLink.Util.Supervisor do
 
   use Supervisor
 
-  def start_link(_) do
-    Supervisor.start_link(__MODULE__, [], name: :"MAVLink.Util.Supervisor")
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   @impl true
-  def init(_) do
+  def init(opts) do
+    router = Keyword.get(opts, :router, XMAVLink.Router)
+
     children = [
-      {XMAVLink.Util.CacheManager, %{}},
-      {XMAVLink.Util.FocusManager, %{}}
+      {XMAVLink.Util.FocusManager, %{}},
+      {XMAVLink.Util.CacheManager, %{router: router}}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.9.1",
+      version: "0.10.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -43,6 +43,9 @@ defmodule XMAVLink.Mixfile do
         component_id: 250,
         # Default registered router name
         router_name: XMAVLink.Router,
+        # Utility processes are opt-in because CacheManager actively subscribes
+        # to MAVLink traffic and requests vehicle parameter lists.
+        utilities: false,
         connections: []
       ],
       mod: {XMAVLink.Application, []},

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -4,12 +4,9 @@ defmodule XMAVLink.Util.CacheManager.Test do
   alias XMAVLink.Util.CacheManager
 
   setup do
-    delete_table(:systems)
+    delete_utility_tables()
     create_systems_table()
-
-    on_exit(fn ->
-      delete_table(:systems)
-    end)
+    create_params_table()
 
     :ok
   end
@@ -20,6 +17,25 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
     assert {:ok, mavs} = CacheManager.mavs()
     assert Enum.sort(mavs) == [{1, 1}, {2, 1}]
+  end
+
+  test "params/2 returns MAVLink parameter names as string keys" do
+    :ets.insert(
+      :params,
+      {{1, 1, "SYSID_THISMAV"},
+       {0,
+        %Common.Message.ParamValue{
+          param_id: "SYSID_THISMAV",
+          param_value: 42.0,
+          param_count: 1,
+          param_index: 0,
+          param_type: :mav_param_type_real32
+        }}}
+    )
+
+    assert {:ok, params} = CacheManager.params({1, 1, 2}, "SYSID")
+    assert params == %{"SYSID_THISMAV" => 42.0}
+    refute Map.has_key?(params, :sysid_thismav)
   end
 
   test "one second loop reschedules one second loop" do
@@ -47,6 +63,17 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
   defp create_systems_table do
     :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp create_params_table do
+    :ets.new(:params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp delete_utility_tables do
+    delete_table(:messages)
+    delete_table(:systems)
+    delete_table(:params)
+    delete_table(:sessions)
   end
 
   defp delete_table(table) do

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -38,6 +38,16 @@ defmodule XMAVLink.Util.CacheManager.Test do
     refute Map.has_key?(params, :sysid_thismav)
   end
 
+  test "msg/2 preserves not-started errors" do
+    assert {:error, :not_started} = CacheManager.msg({1, 1, 2}, Common.Message.Heartbeat)
+  end
+
+  test "params/2 preserves not-started errors" do
+    delete_table(:params)
+
+    assert {:error, :not_started} = CacheManager.params({1, 1, 2}, "")
+  end
+
   test "one second loop reschedules one second loop" do
     state = %CacheManager{one_second_interval_ms: 1}
 

--- a/test/focus_manager_test.exs
+++ b/test/focus_manager_test.exs
@@ -9,11 +9,6 @@ defmodule XMAVLink.Util.FocusManager.Test do
     create_systems_table()
     start_supervised!(FocusManager)
 
-    on_exit(fn ->
-      delete_table(:sessions)
-      delete_table(:systems)
-    end)
-
     :ok
   end
 
@@ -22,6 +17,16 @@ defmodule XMAVLink.Util.FocusManager.Test do
 
     assert :ok = FocusManager.focus(1, 1)
     assert {:ok, {1, 1, 2}} = FocusManager.focus()
+  end
+
+  test "focus/2 returns an error when the vehicle does not exist" do
+    assert {:error, :no_such_mav} = FocusManager.focus(1, 1)
+  end
+
+  test "focus/2 returns an error when utility state has not been started" do
+    delete_table(:systems)
+
+    assert {:error, :not_started} = FocusManager.focus(1, 1)
   end
 
   test "focus sessions are removed when the owner process exits" do

--- a/test/mavlink_application_test.exs
+++ b/test/mavlink_application_test.exs
@@ -1,0 +1,58 @@
+defmodule XMAVLink.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  test "starts utility processes when utilities are enabled" do
+    previous_env =
+      save_env([:dialect, :router_name, :connections, :utilities, :heartbeat, :heartbeats])
+
+    Application.put_env(:xmavlink, :dialect, Common)
+    Application.put_env(:xmavlink, :router_name, XMAVLink.Router)
+    Application.put_env(:xmavlink, :connections, [])
+    Application.put_env(:xmavlink, :utilities, true)
+    Application.delete_env(:xmavlink, :heartbeat)
+    Application.delete_env(:xmavlink, :heartbeats)
+
+    assert {:ok, supervisor} = XMAVLink.Application.start(:normal, [])
+
+    on_exit(fn ->
+      stop_supervisor(supervisor)
+      cleanup_process(XMAVLink.SubscriptionCache)
+      delete_utility_tables()
+      restore_env(previous_env)
+    end)
+
+    assert Process.whereis(XMAVLink.Util.Supervisor)
+    assert Process.whereis(XMAVLink.Util.CacheManager)
+    assert Process.whereis(XMAVLink.Util.FocusManager)
+    assert XMAVLink.Util.CacheManager.router() == XMAVLink.Router
+  end
+
+  defp save_env(keys) do
+    Map.new(keys, &{&1, Application.fetch_env(:xmavlink, &1)})
+  end
+
+  defp restore_env(env) do
+    Enum.each(env, fn
+      {key, {:ok, value}} -> Application.put_env(:xmavlink, key, value)
+      {key, :error} -> Application.delete_env(:xmavlink, key)
+    end)
+  end
+
+  defp stop_supervisor(supervisor) do
+    if Process.alive?(supervisor) do
+      Supervisor.stop(supervisor)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp cleanup_process(name) do
+    if pid = Process.whereis(name), do: Process.exit(pid, :kill)
+  end
+
+  defp delete_utility_tables do
+    for table <- [:messages, :systems, :params, :sessions], :ets.info(table) != :undefined do
+      :ets.delete(table)
+    end
+  end
+end

--- a/test/mavlink_util_command_test.exs
+++ b/test/mavlink_util_command_test.exs
@@ -5,6 +5,7 @@ defmodule XMAVLink.Util.CommandTest do
   alias XMAVLink.Util.Arm
   alias XMAVLink.Util.ParamRequest
   alias XMAVLink.Util.ParamSet
+  alias XMAVLink.Util.SITL
 
   setup do
     delete_utility_tables()
@@ -75,6 +76,14 @@ defmodule XMAVLink.Util.CommandTest do
              )
 
     assert_subscriptions(router, [])
+  end
+
+  test "SITL RC forwarding rejects invalid destination addresses", %{router: router} do
+    assert {:error, :invalid_destination_address} =
+             SITL._connect(1, 1, 2, 5501, router, %{bad: :address})
+
+    assert {:error, :invalid_destination_address} =
+             SITL._connect(1, 1, 2, 5501, router, {127, 0, 0, 999})
   end
 
   defp assert_subscriptions(router, subscriptions, attempts \\ 20)

--- a/test/mavlink_util_command_test.exs
+++ b/test/mavlink_util_command_test.exs
@@ -1,0 +1,120 @@
+defmodule XMAVLink.Util.CommandTest do
+  use ExUnit.Case, async: false
+
+  alias XMAVLink.Router
+  alias XMAVLink.Util.Arm
+  alias XMAVLink.Util.ParamRequest
+  alias XMAVLink.Util.ParamSet
+
+  setup do
+    delete_utility_tables()
+    create_utility_tables()
+
+    {:ok, router} =
+      Router.start_link(%{
+        name: nil,
+        system: 245,
+        component: 250,
+        dialect: Common,
+        connection_strings: []
+      })
+
+    on_exit(fn ->
+      if Process.alive?(router), do: GenServer.stop(router)
+    end)
+
+    {:ok, router: router}
+  end
+
+  test "param_set/6 times out and cleans up its subscription", %{router: router} do
+    :ets.insert(
+      :params,
+      {{1, 1, "SYSID_THISMAV"},
+       {0,
+        %Common.Message.ParamValue{
+          param_id: "SYSID_THISMAV",
+          param_value: 1.0,
+          param_count: 1,
+          param_index: 0,
+          param_type: :mav_param_type_real32
+        }}}
+    )
+
+    assert {:error, :timeout} =
+             ParamSet.param_set(1, 1, 2, "sysid_thismav", 2.0,
+               router: router,
+               retries: 0,
+               retry_interval_ms: 1
+             )
+
+    assert_subscriptions(router, [])
+  end
+
+  test "param_request_list/4 times out instead of retrying forever", %{router: router} do
+    :ets.insert(:systems, {{1, 1}, %{param_count: 0, param_count_loaded: 0}})
+
+    assert {:error, :timeout} =
+             ParamRequest.param_request_list(1, 1, 2,
+               router: router,
+               retries: 0,
+               retry_interval_ms: 1
+             )
+  end
+
+  test "arm/4 times out and cleans up its subscription", %{router: router} do
+    :ets.insert(
+      :messages,
+      {{1, 1, Common.Message.Heartbeat}, {0, heartbeat(:mav_state_standby, MapSet.new())}}
+    )
+
+    assert {:error, :timeout} =
+             Arm.arm(1, 1, 2,
+               router: router,
+               retries: 0,
+               retry_interval_ms: 1
+             )
+
+    assert_subscriptions(router, [])
+  end
+
+  defp assert_subscriptions(router, subscriptions, attempts \\ 20)
+
+  defp assert_subscriptions(router, subscriptions, attempts) when attempts > 0 do
+    state = :sys.get_state(router)
+
+    if state.connections.local.subscriptions == subscriptions do
+      :ok
+    else
+      Process.sleep(10)
+      assert_subscriptions(router, subscriptions, attempts - 1)
+    end
+  end
+
+  defp assert_subscriptions(router, subscriptions, 0) do
+    state = :sys.get_state(router)
+    assert state.connections.local.subscriptions == subscriptions
+  end
+
+  defp heartbeat(system_status, base_mode) do
+    %Common.Message.Heartbeat{
+      type: :mav_type_quadrotor,
+      autopilot: :mav_autopilot_ardupilotmega,
+      base_mode: base_mode,
+      custom_mode: 0,
+      system_status: system_status,
+      mavlink_version: 3
+    }
+  end
+
+  defp create_utility_tables do
+    :ets.new(:messages, [:named_table, :protected, {:read_concurrency, true}, :set])
+    :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    :ets.new(:params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp delete_utility_tables do
+    for table <- [:messages, :systems, :params, :sessions], :ets.info(table) != :undefined do
+      :ets.delete(table)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- make utility supervision opt-in and document explicit startup for the configured router or a named router
- clarify the current utility layer as a one-selected-router convenience API while keeping `XMAVLink.Router` as the multi-router surface
- return normal focus/cache errors for missing utility state or MAV data
- add bounded retry and cleanup behavior to arm/disarm, parameter request, and parameter set helpers
- return string-keyed parameter maps instead of creating atoms from MAVLink parameter names
- add configurable SITL RC forwarding destination addresses
- bump the package to `0.10.0` and document the release notes

## Validation

- `mix format --check-formatted`
- `mise exec -- mix deps.unlock --check-unused`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix dialyzer`

Closes #40
Closes #41
Closes #42
Closes #43
Closes #44