### PR TITLE
Fix UDP incompatible frame handling and release 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.10.2 - 2026-05-08
+
+- Dropped unsupported MAVLink 2 frames with incompatible flags on UDP receive
+  paths instead of crashing while attempting to validate a nil frame.
+- Added `auto_param_request: false` utility configuration for deployments that
+  need to discover vehicles before automatically requesting parameter lists.
+- Documented security reporting, MAVLink trust boundaries, and trusted-input
+  expectations for dialect XML generation.
+
 ## 0.10.1 - 2026-05-07
 
 - Made generated dialect source deterministic and formatter-compatible by

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.10.1"}
+     {:xmavlink, "~> 0.10.2"}
    ]
  end
  ```
@@ -54,6 +54,9 @@ MAVLink Common dialect. Treat generated dialect modules as build artifacts:
 change the generator or XML input and regenerate them rather than editing or
 formatting generated files by hand. The generator emits deterministic,
 formatter-compatible source for repeatable diffs.
+
+Treat MAVLink XML dialect files as trusted build inputs. The generator is meant
+for upstream or application-owned dialect files, not arbitrary untrusted XML.
 
 ## Configuring the XMAVLink Application
 
@@ -310,6 +313,16 @@ config :xmavlink,
   utilities: true
 ```
 
+MAVLink transports are commonly deployed on trusted local links. If an
+application exposes a UDP listener to a less trusted network, disable automatic
+parameter-list requests and start them deliberately after deciding a vehicle is
+trusted:
+
+```elixir
+config :xmavlink,
+  utilities: [auto_param_request: false]
+```
+
 or supervise it explicitly when using a named router:
 
 ```elixir
@@ -325,6 +338,9 @@ children = [
   {XMAVLink.Util.Supervisor, router: MyApp.VehicleRouter}
 ]
 ```
+
+Pass `auto_param_request: false` to `XMAVLink.Util.Supervisor` for the same
+behavior when supervising utilities explicitly.
 
 The current utility API is scoped to one configured router per VM. It uses
 global process names and ETS tables for IEx-friendly helpers, so applications

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the current supported release line. Before
+`1.0.0`, use the latest published version or the default branch when evaluating
+security-related fixes.
+
+## Reporting a Vulnerability
+
+Report vulnerabilities privately to the maintainer before opening public issues
+with exploit details. Include the affected version or commit, a concise
+reproduction, and the transport or generator input involved.
+
+## Security Model
+
+XMAVLink is a MAVLink transport and code generation library. MAVLink networks
+are often local radio, serial, simulator, or vehicle LAN links, and unauthenticated
+peers can send valid MAVLink frames unless the deployment adds its own access
+control.
+
+Current trust boundaries:
+
+- MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed.
+- MAVLink 2 signing is not implemented. Frames with incompatible MAVLink 2 flags
+  are discarded.
+- UDP listeners should be exposed only to trusted networks unless the application
+  adds network-level filtering or validates peers at a higher layer.
+- Utility processes are opt-in. When enabled, `CacheManager` subscribes to
+  traffic and, by default, requests parameter lists from newly seen vehicles.
+  Use `utilities: [auto_param_request: false]` or pass
+  `auto_param_request: false` to `XMAVLink.Util.Supervisor` when vehicle
+  discovery happens on a less trusted network.
+- `mix xmavlink` treats MAVLink XML dialect files as trusted build inputs. Do
+  not run the generator on arbitrary untrusted XML.

--- a/lib/mavlink/application.ex
+++ b/lib/mavlink/application.ex
@@ -15,8 +15,14 @@ defmodule XMAVLink.Application do
 
   defp utility_child_specs(router_name) do
     case Application.get_env(:xmavlink, :utilities, false) do
-      true -> [{XMAVLink.Util.Supervisor, router: router_name}]
-      _ -> []
+      true ->
+        [{XMAVLink.Util.Supervisor, router: router_name}]
+
+      opts when is_list(opts) ->
+        [{XMAVLink.Util.Supervisor, Keyword.put_new(opts, :router, router_name)}]
+
+      _ ->
+        []
     end
   end
 end

--- a/lib/mavlink/application.ex
+++ b/lib/mavlink/application.ex
@@ -15,14 +15,29 @@ defmodule XMAVLink.Application do
 
   defp utility_child_specs(router_name) do
     case Application.get_env(:xmavlink, :utilities, false) do
+      false ->
+        []
+
+      nil ->
+        []
+
       true ->
         [{XMAVLink.Util.Supervisor, router: router_name}]
 
       opts when is_list(opts) ->
-        [{XMAVLink.Util.Supervisor, Keyword.put_new(opts, :router, router_name)}]
+        if Keyword.keyword?(opts) do
+          [{XMAVLink.Util.Supervisor, Keyword.put_new(opts, :router, router_name)}]
+        else
+          invalid_utilities_config!(opts)
+        end
 
-      _ ->
-        []
+      invalid ->
+        invalid_utilities_config!(invalid)
     end
+  end
+
+  defp invalid_utilities_config!(value) do
+    raise ArgumentError,
+          ":utilities must be true, false, nil, or a keyword list, got: #{inspect(value)}"
   end
 end

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -38,9 +38,9 @@ defmodule XMAVLink.UDPInConnection do
         {:error, :not_a_frame, {socket, source_addr, source_port}, receiving_connection}
 
       {nil, _rest} ->
-        # MAVLink 2 frames with incompatible flags are intentionally unsupported.
-        :ok = Logger.debug("UDPInConnection.handle_info: Incompatible MAVLink 2 frame")
-        {:error, :incompatible_flags, {socket, source_addr, source_port}, receiving_connection}
+        reason = frame_parse_error(raw)
+        :ok = Logger.debug("UDPInConnection.handle_info: #{parse_error_message(reason)}")
+        {:error, reason, {socket, source_addr, source_port}, receiving_connection}
 
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
@@ -86,6 +86,19 @@ defmodule XMAVLink.UDPInConnection do
   def handle_info(message, receiving_connection, dialect, _worker) do
     handle_info(message, receiving_connection, dialect)
   end
+
+  defp frame_parse_error(
+         raw =
+           <<0xFD, payload_length::unsigned-integer-size(8),
+             incompatible_flags::unsigned-integer-size(8), _rest::binary>>
+       )
+       when incompatible_flags != 0 and byte_size(raw) >= payload_length + 12,
+       do: :incompatible_flags
+
+  defp frame_parse_error(_raw), do: :incomplete_frame
+
+  defp parse_error_message(:incompatible_flags), do: "Incompatible MAVLink 2 frame"
+  defp parse_error_message(:incomplete_frame), do: "Incomplete MAVLink frame"
 
   def open(["udpin", address, port], controlling_process) do
     # Do not add to connections, we don't want to forward to ourselves

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -37,6 +37,11 @@ defmodule XMAVLink.UDPInConnection do
         :ok = Logger.debug("UDPInConnection.handle_info: Not a frame #{inspect(raw)}")
         {:error, :not_a_frame, {socket, source_addr, source_port}, receiving_connection}
 
+      {nil, _rest} ->
+        # MAVLink 2 frames with incompatible flags are intentionally unsupported.
+        :ok = Logger.debug("UDPInConnection.handle_info: Incompatible MAVLink 2 frame")
+        {:error, :incompatible_flags, {socket, source_addr, source_port}, receiving_connection}
+
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
         case validate_and_unpack(received_frame, dialect) do

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -36,6 +36,11 @@ defmodule XMAVLink.UDPOutConnection do
         :ok = Logger.debug("UDPOutConnection.handle_info: Not a frame #{inspect(raw)}")
         {:error, :not_a_frame, socket, receiving_connection}
 
+      {nil, _rest} ->
+        # MAVLink 2 frames with incompatible flags are intentionally unsupported.
+        :ok = Logger.debug("UDPOutConnection.handle_info: Incompatible MAVLink 2 frame")
+        {:error, :incompatible_flags, socket, receiving_connection}
+
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
         case validate_and_unpack(received_frame, dialect) do

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -37,9 +37,9 @@ defmodule XMAVLink.UDPOutConnection do
         {:error, :not_a_frame, socket, receiving_connection}
 
       {nil, _rest} ->
-        # MAVLink 2 frames with incompatible flags are intentionally unsupported.
-        :ok = Logger.debug("UDPOutConnection.handle_info: Incompatible MAVLink 2 frame")
-        {:error, :incompatible_flags, socket, receiving_connection}
+        reason = frame_parse_error(raw)
+        :ok = Logger.debug("UDPOutConnection.handle_info: #{parse_error_message(reason)}")
+        {:error, reason, socket, receiving_connection}
 
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
@@ -96,6 +96,19 @@ defmodule XMAVLink.UDPOutConnection do
   def close(%XMAVLink.UDPOutConnection{socket: socket}) do
     :gen_udp.close(socket)
   end
+
+  defp frame_parse_error(
+         raw =
+           <<0xFD, payload_length::unsigned-integer-size(8),
+             incompatible_flags::unsigned-integer-size(8), _rest::binary>>
+       )
+       when incompatible_flags != 0 and byte_size(raw) >= payload_length + 12,
+       do: :incompatible_flags
+
+  defp frame_parse_error(_raw), do: :incomplete_frame
+
+  defp parse_error_message(:incompatible_flags), do: "Incompatible MAVLink 2 frame"
+  defp parse_error_message(:incomplete_frame), do: "Incomplete MAVLink frame"
 
   def forward(
         connection = %XMAVLink.UDPOutConnection{

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -28,7 +28,8 @@ defmodule XMAVLink.Util.CacheManager do
   defstruct one_second_interval_ms: 1_000,
             five_second_interval_ms: 5_000,
             ten_second_interval_ms: 10_000,
-            router: nil
+            router: nil,
+            auto_param_request: true
 
   # API
 
@@ -262,12 +263,14 @@ defmodule XMAVLink.Util.CacheManager do
       "First sighting of vehicle #{source_system_id}.#{source_component_id}: #{Common.describe(type)}"
     )
 
-    spawn_link(ParamRequest, :param_request_list, [
-      source_system_id,
-      source_component_id,
-      mavlink_major_version,
-      [router: state.router]
-    ])
+    if state.auto_param_request do
+      spawn_link(ParamRequest, :param_request_list, [
+        source_system_id,
+        source_component_id,
+        mavlink_major_version,
+        [router: state.router]
+      ])
+    end
 
     state
   end

--- a/lib/mavlink_util/supervisor.ex
+++ b/lib/mavlink_util/supervisor.ex
@@ -10,10 +10,11 @@ defmodule XMAVLink.Util.Supervisor do
   @impl true
   def init(opts) do
     router = Keyword.get(opts, :router, XMAVLink.Router)
+    auto_param_request = Keyword.get(opts, :auto_param_request, true)
 
     children = [
       {XMAVLink.Util.FocusManager, %{}},
-      {XMAVLink.Util.CacheManager, %{router: router}}
+      {XMAVLink.Util.CacheManager, %{router: router, auto_param_request: auto_param_request}}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule XMAVLink.Mixfile do
       files: ["lib", "priv", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE", "SECURITY.md"],
       exclude_patterns: [".DS_Store"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/fancydrones/xmavlink"},
+      links: %{"GitHub" => "https://github.com/fancydrones/xmavlink"},
       maintainers: ["Roy Veshovda"]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.10.1",
+      version: "0.10.2",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -73,7 +73,7 @@ defmodule XMAVLink.Mixfile do
   defp package() do
     [
       name: "xmavlink",
-      files: ["lib", "priv", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE"],
+      files: ["lib", "priv", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE", "SECURITY.md"],
       exclude_patterns: [".DS_Store"],
       licenses: ["MIT"],
       links: %{"Github" => "https://github.com/fancydrones/xmavlink"},

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -48,6 +48,40 @@ defmodule XMAVLink.Util.CacheManager.Test do
     assert {:error, :not_started} = CacheManager.params({1, 1, 2}, "")
   end
 
+  test "does not request parameters for a first heartbeat when auto_param_request is disabled" do
+    create_messages_table()
+
+    heartbeat = %Common.Message.Heartbeat{
+      type: :mav_type_quadrotor,
+      autopilot: :mav_autopilot_ardupilotmega,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+
+    frame = %XMAVLink.Frame{
+      message: heartbeat,
+      source_system: 1,
+      source_component: 1,
+      version: 2
+    }
+
+    state = %CacheManager{router: XMAVLink.Router, auto_param_request: false}
+
+    assert {:noreply, ^state} = CacheManager.handle_info(frame, state)
+
+    assert [
+             {{1, 1},
+              %{
+                mavlink_major_version: 2,
+                mavlink_minor_version: 3,
+                param_count: 0,
+                param_count_loaded: 0
+              }}
+           ] = :ets.lookup(:systems, {1, 1})
+  end
+
   test "one second loop reschedules one second loop" do
     state = %CacheManager{one_second_interval_ms: 1}
 
@@ -73,6 +107,10 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
   defp create_systems_table do
     :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp create_messages_table do
+    :ets.new(:messages, [:named_table, :protected, {:read_concurrency, true}, :set])
   end
 
   defp create_params_table do

--- a/test/mavlink_application_test.exs
+++ b/test/mavlink_application_test.exs
@@ -51,6 +51,28 @@ defmodule XMAVLink.ApplicationTest do
     assert %XMAVLink.Util.CacheManager{auto_param_request: false} = :sys.get_state(cache_manager)
   end
 
+  test "rejects invalid utility options with a clear error" do
+    previous_env =
+      save_env([:dialect, :router_name, :connections, :utilities, :heartbeat, :heartbeats])
+
+    Application.put_env(:xmavlink, :dialect, Common)
+    Application.put_env(:xmavlink, :router_name, XMAVLink.Router)
+    Application.put_env(:xmavlink, :connections, [])
+    Application.put_env(:xmavlink, :utilities, [:auto_param_request])
+    Application.delete_env(:xmavlink, :heartbeat)
+    Application.delete_env(:xmavlink, :heartbeats)
+
+    on_exit(fn ->
+      cleanup_process(XMAVLink.SubscriptionCache)
+      delete_utility_tables()
+      restore_env(previous_env)
+    end)
+
+    assert_raise ArgumentError, ~r/:utilities must be true, false, nil, or a keyword list/, fn ->
+      XMAVLink.Application.start(:normal, [])
+    end
+  end
+
   defp save_env(keys) do
     Map.new(keys, &{&1, Application.fetch_env(:xmavlink, &1)})
   end

--- a/test/mavlink_application_test.exs
+++ b/test/mavlink_application_test.exs
@@ -27,6 +27,30 @@ defmodule XMAVLink.ApplicationTest do
     assert XMAVLink.Util.CacheManager.router() == XMAVLink.Router
   end
 
+  test "passes utility options to utility processes" do
+    previous_env =
+      save_env([:dialect, :router_name, :connections, :utilities, :heartbeat, :heartbeats])
+
+    Application.put_env(:xmavlink, :dialect, Common)
+    Application.put_env(:xmavlink, :router_name, XMAVLink.Router)
+    Application.put_env(:xmavlink, :connections, [])
+    Application.put_env(:xmavlink, :utilities, auto_param_request: false)
+    Application.delete_env(:xmavlink, :heartbeat)
+    Application.delete_env(:xmavlink, :heartbeats)
+
+    assert {:ok, supervisor} = XMAVLink.Application.start(:normal, [])
+
+    on_exit(fn ->
+      stop_supervisor(supervisor)
+      cleanup_process(XMAVLink.SubscriptionCache)
+      delete_utility_tables()
+      restore_env(previous_env)
+    end)
+
+    cache_manager = Process.whereis(XMAVLink.Util.CacheManager)
+    assert %XMAVLink.Util.CacheManager{auto_param_request: false} = :sys.get_state(cache_manager)
+  end
+
   defp save_env(keys) do
     Map.new(keys, &{&1, Application.fetch_env(:xmavlink, &1)})
   end

--- a/test/mavlink_udp_connection_test.exs
+++ b/test/mavlink_udp_connection_test.exs
@@ -6,6 +6,8 @@ defmodule XMAVLink.Test.UDPConnection do
 
   @incompatible_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
                                   0::little-unsigned-integer-size(16)>>
+  @incomplete_mavlink_1_frame <<0xFE, 1, 0, 1>>
+  @incomplete_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1>>
 
   describe "handle_info/3" do
     test "UDPIn drops MAVLink 2 frames with incompatible flags" do
@@ -23,6 +25,28 @@ defmodule XMAVLink.Test.UDPConnection do
                )
     end
 
+    test "UDPIn reports incomplete MAVLink frames separately" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPInConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :incomplete_frame, {^socket, ^address, ^port}, ^connection} =
+               UDPInConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_mavlink_1_frame},
+                 connection,
+                 Common
+               )
+
+      assert {:error, :incomplete_frame, {^socket, ^address, ^port}, ^connection} =
+               UDPInConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
     test "UDPOut drops MAVLink 2 frames with incompatible flags" do
       socket = :socket
       address = {127, 0, 0, 1}
@@ -33,6 +57,28 @@ defmodule XMAVLink.Test.UDPConnection do
       assert {:error, :incompatible_flags, ^socket, ^connection} =
                UDPOutConnection.handle_info(
                  {:udp, socket, address, port, @incompatible_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
+    test "UDPOut reports incomplete MAVLink frames separately" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPOutConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :incomplete_frame, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_mavlink_1_frame},
+                 connection,
+                 Common
+               )
+
+      assert {:error, :incomplete_frame, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_mavlink_2_frame},
                  connection,
                  Common
                )

--- a/test/mavlink_udp_connection_test.exs
+++ b/test/mavlink_udp_connection_test.exs
@@ -1,0 +1,41 @@
+defmodule XMAVLink.Test.UDPConnection do
+  use ExUnit.Case, async: true
+
+  alias XMAVLink.UDPInConnection
+  alias XMAVLink.UDPOutConnection
+
+  @incompatible_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
+                                  0::little-unsigned-integer-size(16)>>
+
+  describe "handle_info/3" do
+    test "UDPIn drops MAVLink 2 frames with incompatible flags" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPInConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :incompatible_flags, {^socket, ^address, ^port}, ^connection} =
+               UDPInConnection.handle_info(
+                 {:udp, socket, address, port, @incompatible_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
+    test "UDPOut drops MAVLink 2 frames with incompatible flags" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPOutConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :incompatible_flags, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, @incompatible_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Drop unsupported MAVLink 2 frames with incompatible flags on UDP receive paths instead of attempting to validate a nil frame.
- Add `auto_param_request: false` utility configuration for deployments that need to trust/discover vehicles before automatic parameter-list requests.
- Add `SECURITY.md`, document MAVLink trust boundaries and trusted XML dialect inputs, and include it in the Hex package.
- Bump package/docs/changelog to `0.10.2`.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test --warnings-as-errors` (`80 tests, 0 failures`)
- `mix xref graph --label compile-connected --fail-above 0`
- `mix deps.unlock --check-unused`
- `mix dialyzer`
- `mix hex.build --unpack --output /private/tmp/xmavlink_0_10_2_hex_build`

## Follow-ups

- Generator input hardening is tracked in #49.
- MAVLink 2 signing evaluation is tracked in #47.
- Full MAVLink spec alignment review is tracked in #48.