### PR TITLE
[codex] Update cache action for Node 24

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install -y build-essential
 
       - name: Cache Mix dependencies and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -163,7 +163,7 @@ jobs:
           sudo apt-get install -y build-essential
 
       - name: Cache Dialyzer PLTs and Mix build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -221,7 +221,7 @@ jobs:
           sudo apt-get install -y build-essential
 
       - name: Cache Mix dependencies and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

Updates GitHub Actions cache usage from `actions/cache@v4` to `actions/cache@v5` in the Elixir workflow.

This should remove the Node 20 runtime warnings from the `quality`, `dialyzer`, and publish jobs while leaving the existing cache keys and paths unchanged.

## Validation

- Parsed `.github/workflows/elixir.yml` as YAML
- `mise exec -- mix format --check-formatted`
- `mise exec -- mix test --warnings-as-errors`