### PR TITLE
[codex] Fix Hex dry-run authentication

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -261,7 +261,18 @@ jobs:
 
       - name: Verify Hex package
         if: steps.published.outputs.already_published == 'false'
-        run: mix hex.publish --dry-run --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${HEX_API_KEY}" ]]; then
+            echo "HEX_API_KEY environment secret is required to verify the Hex package."
+            exit 1
+          fi
+
+          mix hex.publish --dry-run --yes
 
       - name: Publish Hex package
         if: steps.published.outputs.already_published == 'false'


### PR DESCRIPTION
## Summary

- Pass `HEX_API_KEY` into the Hex publish dry-run verification step.
- Make the dry-run fail with a clear message if the `HEX_API_KEY` environment secret is unavailable.

## Root Cause

The publish workflow failed before the real publish step because `mix hex.publish --dry-run --yes` required Hex authentication, but only the later publish step received `HEX_API_KEY`.

## Validation

- `git diff --check`
- YAML parse of `.github/workflows/elixir.yml`
- `mise exec -- mix format --check-formatted`
- `mise exec -- mix test --warnings-as-errors`
- `MIX_ENV=dev mise exec -- mix hex.build --output /private/tmp/xmavlink-hex-verify.tar`

Note: the first full test run hit an unrelated intermittent cleanup failure in `test/mavlink_util_command_test.exs`; the focused test passed, and a second full run passed.