### PR TITLE
Add MAVLink 2 signed-frame parsing and signing helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added MAVLink 2 signed-frame parsing and signature trailer representation
   while continuing to reject signed frames before unpacking or routing until
   signature validation and replay checks are implemented.
+- Added a low-level MAVLink 2 frame signing helper for already packed frames;
+  router and connection signing policy is still pending.
 
 ## 0.11.1 - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added MAVLink 2 signed-frame parsing and signature trailer representation
+  while continuing to reject signed frames before unpacking or routing until
+  signature validation and replay checks are implemented.
+
 ## 0.11.1 - 2026-05-08
 
 - Made generated MAVLink 2 packers use zero-equivalent defaults for omitted

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -1,0 +1,73 @@
+# MAVLink 2 Signing Plan
+
+Primary references:
+
+- MAVLink message signing: https://mavlink.io/en/guide/message_signing.html
+- MAVLink packet serialization: https://mavlink.io/en/guide/serialization.html
+
+## Current State
+
+XMAVLink parses the MAVLink 2 signing incompatibility flag (`0x01`) as a known
+frame-shape feature and extracts the 13-byte signing trailer into
+`XMAVLink.Frame.Signature`.
+
+Signed frames are still not authenticated, unpacked, delivered to subscribers,
+or forwarded by the router. Until key configuration, signature validation, and
+replay checks exist, `XMAVLink.Frame.validate_and_unpack/2` returns
+`:signed_frame_unsupported` for parsed signed frames.
+
+Unknown incompatible flags are still rejected. If a frame has both the signing
+flag and unsupported incompatible flags, XMAVLink consumes the known 13-byte
+signature trailer when present so stream transports keep frame boundaries, but
+the packet is not accepted.
+
+## Signature Frame Shape
+
+The MAVLink 2 signed trailer is 13 bytes:
+
+- `link_id`: 8-bit link identifier.
+- `timestamp`: little-endian 48-bit timestamp in 10 microsecond units since
+  2015-01-01 00:00:00 GMT.
+- `signature`: 48-bit signature value.
+
+The signature is defined as the first 48 bits of SHA-256 over the 32-byte shared
+secret key followed by `header + payload + CRC + link_id + timestamp`.
+
+## Intended Public Policy Shape
+
+Signing should be configured per router or per connection. The likely public
+shape is:
+
+- `signing: nil` or omitted: current unsigned behavior, but signed frames remain
+  rejected until an explicit acceptance policy is configured.
+- `signing: [secret_key: <<_::256>>, link_id: 0..255, timestamp_source: ...]`:
+  validate inbound signed frames and sign outbound MAVLink 2 frames on that
+  connection.
+- `accept_unsigned: ...`: explicit policy for unsigned frames when signing is
+  enabled. This must default to reject or to a narrow documented compatibility
+  rule, not silent accept-all.
+- `accept_invalid_signatures: false`: default. Any diagnostic override must be
+  explicit and visible to callers.
+
+## Required Follow-Up Work
+
+1. Inbound validation:
+   - verify the 32-byte key shape;
+   - calculate the 48-bit SHA-256 signature;
+   - compare signatures in constant time if practical;
+   - reject stale timestamps by `(source_system, source_component, link_id)`;
+   - reject first-seen timestamps more than 6,000,000 ticks behind local time.
+2. Router and connection policy:
+   - decide where per-link timestamp state lives;
+   - make unsigned-frame acceptance explicit;
+   - avoid forwarding `SETUP_SIGNING` from a secure link to other links.
+3. Outbound signing:
+   - append the signature trailer only to MAVLink 2 frames;
+   - set `MAVLINK_IFLAG_SIGNED`;
+   - monotonically increment timestamps per outbound link;
+   - keep MAVLink 1 behavior unsigned and unchanged.
+4. Persistence hooks:
+   - expose timestamp load/save integration points;
+   - document that applications must store keys and timestamps securely.
+
+Each step should land with focused tests before #47 is closed.

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -11,6 +11,11 @@ XMAVLink parses the MAVLink 2 signing incompatibility flag (`0x01`) as a known
 frame-shape feature and extracts the 13-byte signing trailer into
 `XMAVLink.Frame.Signature`.
 
+`XMAVLink.Frame.sign_frame/4` can sign an already packed MAVLink 2 frame when
+given a 32-byte key, link id, and timestamp. This is a low-level utility for the
+remaining signing implementation; router and connection configuration do not
+use it yet.
+
 Signed frames are still not authenticated, unpacked, delivered to subscribers,
 or forwarded by the router. Until key configuration, signature validation, and
 replay checks exist, `XMAVLink.Frame.validate_and_unpack/2` returns
@@ -31,7 +36,8 @@ The MAVLink 2 signed trailer is 13 bytes:
 - `signature`: 48-bit signature value.
 
 The signature is defined as the first 48 bits of SHA-256 over the 32-byte shared
-secret key followed by `header + payload + CRC + link_id + timestamp`.
+secret key followed by the wire header including the magic byte, payload, CRC,
+link id, and timestamp.
 
 ## Intended Public Policy Shape
 
@@ -61,9 +67,8 @@ shape is:
    - decide where per-link timestamp state lives;
    - make unsigned-frame acceptance explicit;
    - avoid forwarding `SETUP_SIGNING` from a secure link to other links.
-3. Outbound signing:
-   - append the signature trailer only to MAVLink 2 frames;
-   - set `MAVLINK_IFLAG_SIGNED`;
+3. Outbound signing policy:
+   - call the low-level frame signing utility from router/connection send paths;
    - monotonically increment timestamps per outbound link;
    - keep MAVLink 1 behavior unsigned and unchanged.
 4. Persistence hooks:

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -7,6 +7,7 @@ Primary references:
 - MAVLink packet serialization: https://mavlink.io/en/guide/serialization.html
 - MAVLink routing: https://mavlink.io/en/guide/routing.html
 - MAVLink 2 overview: https://mavlink.io/en/guide/mavlink_2.html
+- MAVLink 2 signing: https://mavlink.io/en/guide/message_signing.html
 - MAVLink XML schema guide: https://mavlink.io/en/guide/xml_schema.html
 
 ## 1.0 Support Posture
@@ -20,13 +21,16 @@ investment, prefer an explicit support reduction over slowing MAVLink 2 work.
 Supported runtime scope:
 
 - MAVLink 2 unsigned frames without incompatible flags.
+- MAVLink 2 signed-frame boundary parsing and signature trailer
+  representation. Signed frames are rejected until authentication and replay
+  checks are implemented.
 - MAVLink 1 frames for existing users and legacy links.
 - Serial, `udpin`, `udpout`, and outbound TCP (`tcpout`) transports.
 - Generated dialect modules from trusted MAVLink XML build inputs.
 
 Known non-goals for 1.0 unless separately implemented:
 
-- MAVLink 2 packet signing/authentication.
+- Full MAVLink 2 packet signing/authentication.
 - TCP server (`tcpin`) transport.
 - Treating untrusted XML dialect files as safe input.
 - Full `mavgen` feature parity for XML validation, WIP filtering, and every
@@ -37,7 +41,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Unsupported | Signed frames are not authenticated or routed as signed packets. Unsupported signed frames are consumed as complete signed frames where the signature length is known so stream buffers do not retain signature bytes. See #47. |
+| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Signed frames are not authenticated, unpacked, routed, or emitted until signing policy, validation, and replay checks land. See #47 and `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -69,6 +73,8 @@ Known non-goals for 1.0 unless separately implemented:
   packing, and unpacking.
 - Generated MAVLink 2 packers use zero-equivalent defaults for omitted known
   extension fields.
+- MAVLink 2 signed frames now parse the 13-byte signature trailer into frame
+  metadata while remaining rejected by validation until signing support lands.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -78,7 +84,8 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #47: Implement MAVLink 2 packet signing and signed-frame routing behavior.
+- #47: Continue MAVLink 2 packet signing with inbound validation, replay policy,
+  outbound signing, and signed-frame routing behavior.
 - #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
   known system/component.
 - #53: Align XML parser/generator validation with `mavgen` for missing

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -41,7 +41,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Signed frames are not authenticated, unpacked, routed, or emitted until signing policy, validation, and replay checks land. See #47 and `MAVLINK2_SIGNING.md`. |
+| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Low-level frame signing can generate signed MAVLink 2 frame bytes for already packed frames. Signed frames are not authenticated, unpacked, routed, or emitted by router policy until validation, replay checks, and policy wiring land. See #47 and `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -75,6 +75,9 @@ Known non-goals for 1.0 unless separately implemented:
   extension fields.
 - MAVLink 2 signed frames now parse the 13-byte signature trailer into frame
   metadata while remaining rejected by validation until signing support lands.
+- Low-level MAVLink 2 frame signing can set the signed incompatibility flag,
+  recalculate checksum bytes, and append a generated signature trailer for an
+  already packed frame.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ time.
 XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames.
 MAVLink 2 signing authentication is not implemented; inbound signed frames are
 parsed only far enough to preserve frame boundaries and expose the signature
-trailer, then rejected before unpacking or routing. MAVLink 2 frames with other
-incompatible flags are discarded. Supported configured transports are serial,
-UDP client (`udpout`), UDP server (`udpin`), and TCP client (`tcpout`). TCP
-server (`tcpin`) connections are not implemented.
+trailer, then rejected before unpacking or routing. A low-level
+`XMAVLink.Frame.sign_frame/4` helper can generate signed MAVLink 2 frame bytes
+for already packed frames, but router and connection signing policy is not wired
+yet. MAVLink 2 frames with other incompatible flags are discarded. Supported
+configured transports are serial, UDP client (`udpout`), UDP server (`udpin`),
+and TCP client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ on the `hex-publish` environment. If a package-scoped key is not available,
 This library is not officially recognised or supported by MAVLink at this
 time.
 
-XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames that
-do not set incompatible flags. MAVLink 2 signing is not implemented; inbound
-MAVLink 2 frames with incompatible flags are discarded. Supported configured
-transports are serial, UDP client (`udpout`), UDP server (`udpin`), and TCP
-client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
+XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames.
+MAVLink 2 signing authentication is not implemented; inbound signed frames are
+parsed only far enough to preserve frame boundaries and expose the signature
+trailer, then rejected before unpacking or routing. MAVLink 2 frames with other
+incompatible flags are discarded. Supported configured transports are serial,
+UDP client (`udpout`), UDP server (`udpin`), and TCP client (`tcpout`). TCP
+server (`tcpin`) connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,10 @@ control.
 Current trust boundaries:
 
 - MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed.
-- MAVLink 2 signing is not implemented. Frames with incompatible MAVLink 2 flags
-  are discarded.
+- MAVLink 2 signing authentication is not implemented. Signed MAVLink 2 frames
+  are parsed only far enough to preserve frame boundaries and expose the
+  signature trailer; they are rejected before unpacking, routing, or forwarding.
+  Frames with other incompatible MAVLink 2 flags are discarded.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,9 @@ Current trust boundaries:
 - MAVLink 2 signing authentication is not implemented. Signed MAVLink 2 frames
   are parsed only far enough to preserve frame boundaries and expose the
   signature trailer; they are rejected before unpacking, routing, or forwarding.
-  Frames with other incompatible MAVLink 2 flags are discarded.
+  A low-level frame signing helper can generate signed MAVLink 2 bytes, but
+  router and connection signing policy is not wired yet. Frames with other
+  incompatible MAVLink 2 flags are discarded.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -295,12 +295,15 @@ defmodule XMAVLink.Frame do
   This is a low-level frame utility. It sets `MAVLINK_IFLAG_SIGNED`,
   recalculates the checksum for the signed header, and appends the 13-byte
   MAVLink 2 signature trailer. It does not manage link timestamp state or
-  router/connection signing policy.
+  router/connection signing policy. The existing packed frame checksum must
+  already match the frame's `crc_extra`.
   """
   @spec sign_frame(XMAVLink.Frame.t(), <<_::256>>, 0..255, 0..281_474_976_710_655) ::
           {:ok, XMAVLink.Frame.t()}
           | {:error,
              :already_signed
+             | :checksum_invalid
+             | :invalid_crc_extra
              | :invalid_link_id
              | :invalid_mavlink_2_frame
              | :invalid_secret_key
@@ -318,20 +321,14 @@ defmodule XMAVLink.Frame do
          :ok <- validate_timestamp(timestamp),
          :ok <- validate_crc_extra(frame.crc_extra),
          {:ok, attrs} <- parse_mavlink_2_raw(frame.mavlink_2_raw),
-         :ok <- validate_signable_frame_attrs(attrs) do
+         :ok <- validate_signable_frame_attrs(attrs),
+         :ok <- validate_unsigned_checksum(attrs, frame.crc_extra) do
       signature_prefix =
         <<link_id::unsigned-integer-size(8), timestamp::little-unsigned-integer-size(48)>>
 
       incompatible_flags = attrs.incompatible_flags ||| @mavlink_2_signature_flag
 
-      signed_body =
-        <<attrs.payload_length::unsigned-integer-size(8),
-          incompatible_flags::unsigned-integer-size(8),
-          attrs.compatible_flags::unsigned-integer-size(8),
-          attrs.sequence_number::unsigned-integer-size(8),
-          attrs.source_system::unsigned-integer-size(8),
-          attrs.source_component::unsigned-integer-size(8),
-          attrs.message_id::little-unsigned-integer-size(24), attrs.payload::binary>>
+      signed_body = mavlink_2_body(attrs, incompatible_flags)
 
       checksum = checksum(signed_body, frame.crc_extra)
 
@@ -375,8 +372,9 @@ defmodule XMAVLink.Frame do
 
   defp validate_timestamp(_timestamp), do: {:error, :invalid_timestamp}
 
+  defp validate_crc_extra(nil), do: {:error, :missing_crc_extra}
   defp validate_crc_extra(crc_extra) when is_integer(crc_extra) and crc_extra in 0..255, do: :ok
-  defp validate_crc_extra(_crc_extra), do: {:error, :missing_crc_extra}
+  defp validate_crc_extra(_crc_extra), do: {:error, :invalid_crc_extra}
 
   defp parse_mavlink_2_raw(nil), do: {:error, :missing_mavlink_2_raw}
 
@@ -415,6 +413,27 @@ defmodule XMAVLink.Frame do
 
   defp validate_signable_frame_attrs(%{rest: <<>>}), do: :ok
   defp validate_signable_frame_attrs(_attrs), do: {:error, :invalid_mavlink_2_frame}
+
+  defp validate_unsigned_checksum(attrs, crc_extra) do
+    if checksum(mavlink_2_body(attrs), crc_extra) ==
+         <<attrs.checksum::little-unsigned-integer-size(16)>> do
+      :ok
+    else
+      {:error, :checksum_invalid}
+    end
+  end
+
+  defp mavlink_2_body(attrs), do: mavlink_2_body(attrs, attrs.incompatible_flags)
+
+  defp mavlink_2_body(attrs, incompatible_flags) do
+    <<attrs.payload_length::unsigned-integer-size(8),
+      incompatible_flags::unsigned-integer-size(8),
+      attrs.compatible_flags::unsigned-integer-size(8),
+      attrs.sequence_number::unsigned-integer-size(8),
+      attrs.source_system::unsigned-integer-size(8),
+      attrs.source_component::unsigned-integer-size(8),
+      attrs.message_id::little-unsigned-integer-size(24), attrs.payload::binary>>
+  end
 
   defp signature_hash(secret_key, signed_frame_without_signature, signature_prefix) do
     :crypto.hash(:sha256, secret_key <> signed_frame_without_signature <> signature_prefix)

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -30,6 +30,7 @@ defmodule XMAVLink.Frame do
   @mavlink_2_signature_flag 0x01
   @mavlink_2_signature_length 13
   @mavlink_2_supported_incompatible_flags @mavlink_2_signature_flag
+  @mavlink_2_signature_timestamp_max 0xFFFF_FFFF_FFFF
 
   defstruct [
     # Which raw attributes are populated?
@@ -288,8 +289,137 @@ defmodule XMAVLink.Frame do
   def signed?(incompatible_flags) when is_integer(incompatible_flags),
     do: (incompatible_flags &&& @mavlink_2_signature_flag) != 0
 
+  @doc """
+  Sign an already packed MAVLink 2 frame.
+
+  This is a low-level frame utility. It sets `MAVLINK_IFLAG_SIGNED`,
+  recalculates the checksum for the signed header, and appends the 13-byte
+  MAVLink 2 signature trailer. It does not manage link timestamp state or
+  router/connection signing policy.
+  """
+  @spec sign_frame(XMAVLink.Frame.t(), <<_::256>>, 0..255, 0..281_474_976_710_655) ::
+          {:ok, XMAVLink.Frame.t()}
+          | {:error,
+             :already_signed
+             | :invalid_link_id
+             | :invalid_mavlink_2_frame
+             | :invalid_secret_key
+             | :invalid_timestamp
+             | :mavlink_1_not_signable
+             | :missing_crc_extra
+             | :missing_mavlink_2_raw
+             | :unsupported_incompatible_flags}
+  def sign_frame(%XMAVLink.Frame{version: 1}, _secret_key, _link_id, _timestamp),
+    do: {:error, :mavlink_1_not_signable}
+
+  def sign_frame(frame = %XMAVLink.Frame{version: 2}, secret_key, link_id, timestamp) do
+    with :ok <- validate_secret_key(secret_key),
+         :ok <- validate_link_id(link_id),
+         :ok <- validate_timestamp(timestamp),
+         :ok <- validate_crc_extra(frame.crc_extra),
+         {:ok, attrs} <- parse_mavlink_2_raw(frame.mavlink_2_raw),
+         :ok <- validate_signable_frame_attrs(attrs) do
+      signature_prefix =
+        <<link_id::unsigned-integer-size(8), timestamp::little-unsigned-integer-size(48)>>
+
+      incompatible_flags = attrs.incompatible_flags ||| @mavlink_2_signature_flag
+
+      signed_body =
+        <<attrs.payload_length::unsigned-integer-size(8),
+          incompatible_flags::unsigned-integer-size(8),
+          attrs.compatible_flags::unsigned-integer-size(8),
+          attrs.sequence_number::unsigned-integer-size(8),
+          attrs.source_system::unsigned-integer-size(8),
+          attrs.source_component::unsigned-integer-size(8),
+          attrs.message_id::little-unsigned-integer-size(24), attrs.payload::binary>>
+
+      checksum = checksum(signed_body, frame.crc_extra)
+
+      signature_hash =
+        signature_hash(secret_key, <<0xFD>> <> signed_body <> checksum, signature_prefix)
+
+      signature_raw = signature_prefix <> signature_hash
+      signed_raw = <<0xFD>> <> signed_body <> checksum <> signature_raw
+
+      {:ok,
+       struct(frame,
+         payload_length: attrs.payload_length,
+         incompatible_flags: incompatible_flags,
+         compatible_flags: attrs.compatible_flags,
+         sequence_number: attrs.sequence_number,
+         source_system: attrs.source_system,
+         source_component: attrs.source_component,
+         message_id: attrs.message_id,
+         payload: attrs.payload,
+         checksum: :binary.decode_unsigned(checksum, :little),
+         signature: parse_signature(signature_raw),
+         mavlink_2_raw: signed_raw
+       )}
+    end
+  end
+
   defp unsupported_incompatible_flags?(incompatible_flags),
     do: (incompatible_flags &&& @mavlink_2_supported_incompatible_flags) != incompatible_flags
+
+  defp validate_secret_key(secret_key) when is_binary(secret_key) and byte_size(secret_key) == 32,
+    do: :ok
+
+  defp validate_secret_key(_secret_key), do: {:error, :invalid_secret_key}
+
+  defp validate_link_id(link_id) when is_integer(link_id) and link_id in 0..255, do: :ok
+  defp validate_link_id(_link_id), do: {:error, :invalid_link_id}
+
+  defp validate_timestamp(timestamp)
+       when is_integer(timestamp) and timestamp in 0..@mavlink_2_signature_timestamp_max,
+       do: :ok
+
+  defp validate_timestamp(_timestamp), do: {:error, :invalid_timestamp}
+
+  defp validate_crc_extra(crc_extra) when is_integer(crc_extra) and crc_extra in 0..255, do: :ok
+  defp validate_crc_extra(_crc_extra), do: {:error, :missing_crc_extra}
+
+  defp parse_mavlink_2_raw(nil), do: {:error, :missing_mavlink_2_raw}
+
+  defp parse_mavlink_2_raw(
+         <<0xFD, payload_length::unsigned-integer-size(8),
+           incompatible_flags::unsigned-integer-size(8),
+           compatible_flags::unsigned-integer-size(8), sequence_number::unsigned-integer-size(8),
+           source_system::unsigned-integer-size(8), source_component::unsigned-integer-size(8),
+           message_id::little-unsigned-integer-size(24), payload::binary-size(payload_length),
+           checksum::little-unsigned-integer-size(16), rest::binary>>
+       ) do
+    {:ok,
+     %{
+       payload_length: payload_length,
+       incompatible_flags: incompatible_flags,
+       compatible_flags: compatible_flags,
+       sequence_number: sequence_number,
+       source_system: source_system,
+       source_component: source_component,
+       message_id: message_id,
+       payload: payload,
+       checksum: checksum,
+       rest: rest
+     }}
+  end
+
+  defp parse_mavlink_2_raw(_raw), do: {:error, :invalid_mavlink_2_frame}
+
+  defp validate_signable_frame_attrs(%{incompatible_flags: incompatible_flags})
+       when (incompatible_flags &&& @mavlink_2_signature_flag) != 0,
+       do: {:error, :already_signed}
+
+  defp validate_signable_frame_attrs(%{incompatible_flags: incompatible_flags})
+       when incompatible_flags != 0,
+       do: {:error, :unsupported_incompatible_flags}
+
+  defp validate_signable_frame_attrs(%{rest: <<>>}), do: :ok
+  defp validate_signable_frame_attrs(_attrs), do: {:error, :invalid_mavlink_2_frame}
+
+  defp signature_hash(secret_key, signed_frame_without_signature, signature_prefix) do
+    :crypto.hash(:sha256, secret_key <> signed_frame_without_signature <> signature_prefix)
+    |> binary_part(0, 6)
+  end
 
   defp signed_frame_and_tail(raw_and_rest, frame, rest) do
     case rest do

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -1,3 +1,22 @@
+defmodule XMAVLink.Frame.Signature do
+  @moduledoc """
+  MAVLink 2 signed-frame trailer.
+
+  MAVLink 2 signing appends a 13-byte trailer after the checksum:
+  one-byte link id, 48-bit timestamp, and 48-bit signature.
+  """
+
+  defstruct link_id: nil,
+            timestamp: nil,
+            signature: nil
+
+  @type t :: %XMAVLink.Frame.Signature{
+          link_id: 0..255,
+          timestamp: 0..281_474_976_710_655,
+          signature: <<_::48>>
+        }
+end
+
 defmodule XMAVLink.Frame do
   @moduledoc """
   Represent and work with MAVLink v1/2 message frames
@@ -10,6 +29,7 @@ defmodule XMAVLink.Frame do
 
   @mavlink_2_signature_flag 0x01
   @mavlink_2_signature_length 13
+  @mavlink_2_supported_incompatible_flags @mavlink_2_signature_flag
 
   defstruct [
     # Which raw attributes are populated?
@@ -30,7 +50,7 @@ defmodule XMAVLink.Frame do
     crc_extra: nil,
     payload: nil,
     checksum: nil,
-    # MAVLink 2 signing only (not implemented)
+    # MAVLink 2 signing only
     signature: nil,
     # Original binary frame
     mavlink_1_raw: nil,
@@ -55,6 +75,7 @@ defmodule XMAVLink.Frame do
           crc_extra: XMAVLink.Types.crc_extra(),
           payload: binary,
           checksum: 0..65_535,
+          signature: XMAVLink.Frame.Signature.t() | nil,
           mavlink_1_raw: binary,
           mavlink_2_raw: binary,
           message: message
@@ -102,21 +123,33 @@ defmodule XMAVLink.Frame do
             message_id::little-unsigned-integer-size(24), payload::binary-size(payload_length),
             checksum::little-unsigned-integer-size(16), rest::binary>>
       ) do
-    case incompatible_flags do
-      0 ->
-        # Vanilla MAVLink 2, we can deal with this
+    frame =
+      struct(XMAVLink.Frame,
+        version: 2,
+        payload_length: payload_length,
+        incompatible_flags: incompatible_flags,
+        compatible_flags: compatible_flags,
+        sequence_number: sequence_number,
+        source_system: source_system,
+        source_component: source_component,
+        message_id: message_id,
+        payload: payload,
+        checksum: checksum
+      )
+
+    cond do
+      unsupported_incompatible_flags?(incompatible_flags) and signed?(incompatible_flags) ->
+        drop_incompatible_signed_frame(raw_and_rest, rest)
+
+      unsupported_incompatible_flags?(incompatible_flags) ->
+        {nil, rest}
+
+      signed?(incompatible_flags) ->
+        signed_frame_and_tail(raw_and_rest, frame, rest)
+
+      true ->
         {
-          struct(XMAVLink.Frame,
-            version: 2,
-            payload_length: payload_length,
-            incompatible_flags: 0,
-            compatible_flags: compatible_flags,
-            sequence_number: sequence_number,
-            source_system: source_system,
-            source_component: source_component,
-            message_id: message_id,
-            payload: payload,
-            checksum: checksum,
+          struct(frame,
             mavlink_2_raw:
               binary_part(
                 raw_and_rest,
@@ -126,15 +159,6 @@ defmodule XMAVLink.Frame do
           ),
           rest
         }
-
-      _ ->
-        # We don't support any incompatible flags at present
-        # e.g. signing, so drop the frame
-        if signed?(incompatible_flags) do
-          drop_incompatible_signed_frame(raw_and_rest, rest)
-        else
-          {nil, rest}
-        end
     end
   end
 
@@ -148,11 +172,25 @@ defmodule XMAVLink.Frame do
   def binary_to_frame_and_tail(<<>>), do: :not_a_frame
 
   @spec validate_and_unpack(XMAVLink.Frame.t(), module) ::
-          {:ok, XMAVLink.Frame.t()} | :failed_to_unpack | :checksum_invalid | :unknown_message
-  def validate_and_unpack(
-        frame = %XMAVLink.Frame{message_id: message_id, version: version, payload: payload},
-        dialect
-      ) do
+          {:ok, XMAVLink.Frame.t()}
+          | :failed_to_unpack
+          | :checksum_invalid
+          | :unknown_message
+          | :signed_frame_unsupported
+  def validate_and_unpack(frame = %XMAVLink.Frame{version: 2}, dialect) do
+    if signed?(frame) do
+      :signed_frame_unsupported
+    else
+      validate_unsigned_and_unpack(frame, dialect)
+    end
+  end
+
+  def validate_and_unpack(frame, dialect), do: validate_unsigned_and_unpack(frame, dialect)
+
+  defp validate_unsigned_and_unpack(
+         frame = %XMAVLink.Frame{message_id: message_id, version: version, payload: payload},
+         dialect
+       ) do
     case apply(dialect, :msg_attributes, [message_id]) do
       {:ok, crc_extra, expected_length, target} ->
         if frame.checksum ==
@@ -241,6 +279,50 @@ defmodule XMAVLink.Frame do
     end
   end
 
+  @spec signed?(XMAVLink.Frame.t() | non_neg_integer) :: boolean
+  def signed?(%XMAVLink.Frame{version: 2, incompatible_flags: incompatible_flags}),
+    do: signed?(incompatible_flags)
+
+  def signed?(%XMAVLink.Frame{}), do: false
+
+  def signed?(incompatible_flags) when is_integer(incompatible_flags),
+    do: (incompatible_flags &&& @mavlink_2_signature_flag) != 0
+
+  defp unsupported_incompatible_flags?(incompatible_flags),
+    do: (incompatible_flags &&& @mavlink_2_supported_incompatible_flags) != incompatible_flags
+
+  defp signed_frame_and_tail(raw_and_rest, frame, rest) do
+    case rest do
+      <<signature_raw::binary-size(@mavlink_2_signature_length), rest_after_signature::binary>> ->
+        {
+          struct(frame,
+            signature: parse_signature(signature_raw),
+            mavlink_2_raw:
+              binary_part(
+                raw_and_rest,
+                0,
+                byte_size(raw_and_rest) - byte_size(rest_after_signature)
+              )
+          ),
+          rest_after_signature
+        }
+
+      _ ->
+        {nil, raw_and_rest}
+    end
+  end
+
+  defp parse_signature(
+         <<link_id::unsigned-integer-size(8), timestamp::little-unsigned-integer-size(48),
+           signature::binary-size(6)>>
+       ) do
+    %XMAVLink.Frame.Signature{
+      link_id: link_id,
+      timestamp: timestamp,
+      signature: signature
+    }
+  end
+
   # Pack message frame
   def pack_frame(frame = %XMAVLink.Frame{version: 1}) do
     payload_length = byte_size(frame.payload)
@@ -298,9 +380,6 @@ defmodule XMAVLink.Frame do
     cs = x25_crc(frame <> <<crc_extra::unsigned-integer-size(8)>>)
     <<cs::little-unsigned-integer-size(16)>>
   end
-
-  defp signed?(incompatible_flags),
-    do: (incompatible_flags &&& @mavlink_2_signature_flag) != 0
 
   defp drop_incompatible_signed_frame(raw_and_rest, rest) do
     case rest do

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -9,6 +9,9 @@ defmodule XMAVLink.UDPInConnection do
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
+  @mavlink_2_signature_flag 0x01
+  @mavlink_2_signature_length 13
+
   defstruct address: nil,
             port: nil,
             socket: nil,
@@ -92,8 +95,21 @@ defmodule XMAVLink.UDPInConnection do
            <<0xFD, payload_length::unsigned-integer-size(8),
              incompatible_flags::unsigned-integer-size(8), _rest::binary>>
        )
-       when incompatible_flags != 0 and byte_size(raw) >= payload_length + 12,
-       do: :incompatible_flags
+       when incompatible_flags != 0 do
+    complete_length =
+      payload_length + 12 +
+        if Bitwise.band(incompatible_flags, @mavlink_2_signature_flag) != 0 do
+          @mavlink_2_signature_length
+        else
+          0
+        end
+
+    if byte_size(raw) >= complete_length do
+      :incompatible_flags
+    else
+      :incomplete_frame
+    end
+  end
 
   defp frame_parse_error(_raw), do: :incomplete_frame
 

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -8,6 +8,9 @@ defmodule XMAVLink.UDPOutConnection do
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
+  @mavlink_2_signature_flag 0x01
+  @mavlink_2_signature_length 13
+
   defstruct address: nil,
             port: nil,
             socket: nil,
@@ -102,8 +105,21 @@ defmodule XMAVLink.UDPOutConnection do
            <<0xFD, payload_length::unsigned-integer-size(8),
              incompatible_flags::unsigned-integer-size(8), _rest::binary>>
        )
-       when incompatible_flags != 0 and byte_size(raw) >= payload_length + 12,
-       do: :incompatible_flags
+       when incompatible_flags != 0 do
+    complete_length =
+      payload_length + 12 +
+        if Bitwise.band(incompatible_flags, @mavlink_2_signature_flag) != 0 do
+          @mavlink_2_signature_length
+        else
+          0
+        end
+
+    if byte_size(raw) >= complete_length do
+      :incompatible_flags
+    else
+      :incomplete_frame
+    end
+  end
 
   defp frame_parse_error(_raw), do: :incomplete_frame
 

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -8,6 +8,9 @@ defmodule XMAVLink.Test.Frame do
   @signed_unknown_incompatible_flags 0x03
   @signature_hash <<8, 9, 10, 11, 12, 13>>
   @signature <<99, 0x010203040506::little-unsigned-integer-size(48), @signature_hash::binary>>
+  @secret_key :binary.copy(<<42>>, 32)
+  @link_id 17
+  @timestamp 0x010203040506
 
   test "MAVLink 2 signed frames parse the signature trailer and tail" do
     tail = <<0xFE, 0, 0, 1, 1, 0, 0, 0>>
@@ -72,8 +75,133 @@ defmodule XMAVLink.Test.Frame do
     assert byte_size(frame.mavlink_2_raw) == 12
   end
 
+  test "MAVLink 2 frame signing appends a valid signature trailer" do
+    frame =
+      Frame.pack_frame(%Frame{
+        version: 2,
+        sequence_number: 7,
+        source_system: 1,
+        source_component: 1,
+        message_id: 24,
+        payload: <<1, 2, 0>>,
+        crc_extra: 0
+      })
+
+    assert {:ok, signed_frame} = Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
+    assert Frame.signed?(signed_frame)
+
+    expected_payload = <<1, 2>>
+
+    expected_body =
+      <<2, 1, 0, 7, 1, 1, 24::little-unsigned-integer-size(24), expected_payload::binary>>
+
+    expected_checksum = expected_checksum(expected_body, frame.crc_extra)
+    expected_signature_prefix = <<@link_id, @timestamp::little-unsigned-integer-size(48)>>
+
+    expected_signature_hash =
+      :crypto.hash(
+        :sha256,
+        @secret_key <> <<0xFD>> <> expected_body <> expected_checksum <> expected_signature_prefix
+      )
+      |> binary_part(0, 6)
+
+    expected_raw =
+      <<0xFD>> <>
+        expected_body <> expected_checksum <> expected_signature_prefix <> expected_signature_hash
+
+    assert signed_frame.mavlink_2_raw == expected_raw
+    assert signed_frame.payload_length == 2
+    assert signed_frame.payload == expected_payload
+    assert signed_frame.incompatible_flags == @signed_incompatible_flags
+    assert signed_frame.signature.link_id == @link_id
+    assert signed_frame.signature.timestamp == @timestamp
+    assert signed_frame.signature.signature == expected_signature_hash
+
+    assert {%Frame{} = parsed_frame, <<>>} = Frame.binary_to_frame_and_tail(expected_raw)
+    assert parsed_frame.signature == signed_frame.signature
+    assert :signed_frame_unsupported = Frame.validate_and_unpack(parsed_frame, Common)
+  end
+
+  test "MAVLink 2 frame signing rejects invalid inputs" do
+    %Frame{} =
+      unsigned_frame =
+      Frame.pack_frame(%Frame{
+        version: 2,
+        sequence_number: 7,
+        source_system: 1,
+        source_component: 1,
+        message_id: 24,
+        payload: <<1, 2, 3>>,
+        crc_extra: 0
+      })
+
+    mavlink_1_frame =
+      Frame.pack_frame(%Frame{
+        version: 1,
+        sequence_number: 7,
+        source_system: 1,
+        source_component: 1,
+        message_id: 24,
+        payload: <<>>,
+        crc_extra: 0
+      })
+
+    assert {:error, :mavlink_1_not_signable} =
+             Frame.sign_frame(mavlink_1_frame, @secret_key, @link_id, @timestamp)
+
+    assert {:error, :invalid_secret_key} =
+             Frame.sign_frame(unsigned_frame, <<1, 2, 3>>, @link_id, @timestamp)
+
+    assert {:error, :invalid_link_id} =
+             Frame.sign_frame(unsigned_frame, @secret_key, 256, @timestamp)
+
+    assert {:error, :invalid_timestamp} =
+             Frame.sign_frame(unsigned_frame, @secret_key, @link_id, 0x1_0000_0000_0000)
+
+    assert {:error, :missing_crc_extra} =
+             Frame.sign_frame(
+               %Frame{unsigned_frame | crc_extra: nil},
+               @secret_key,
+               @link_id,
+               @timestamp
+             )
+
+    assert {:error, :missing_mavlink_2_raw} =
+             Frame.sign_frame(
+               %Frame{unsigned_frame | mavlink_2_raw: nil},
+               @secret_key,
+               @link_id,
+               @timestamp
+             )
+
+    unsupported_incompatible_frame = %Frame{
+      unsigned_frame
+      | mavlink_2_raw:
+          <<0xFD, 3, @unknown_incompatible_flags, 0, 7, 1, 1,
+            24::little-unsigned-integer-size(24), 1, 2, 3, 0::little-unsigned-integer-size(16)>>
+    }
+
+    assert {:error, :unsupported_incompatible_flags} =
+             Frame.sign_frame(unsupported_incompatible_frame, @secret_key, @link_id, @timestamp)
+
+    assert {:ok, signed_frame} =
+             Frame.sign_frame(unsigned_frame, @secret_key, @link_id, @timestamp)
+
+    assert {:error, :already_signed} =
+             Frame.sign_frame(signed_frame, @secret_key, @link_id, @timestamp)
+  end
+
   defp signed_frame_raw(incompatible_flags \\ @signed_incompatible_flags) do
     <<0xFD, 0, incompatible_flags, 0, 7, 1, 1, 0::little-unsigned-integer-size(24),
       0::little-unsigned-integer-size(16)>> <> @signature
+  end
+
+  defp expected_checksum(frame_body, crc_extra) do
+    checksum =
+      frame_body
+      |> XMAVLink.Utils.x25_crc()
+      |> XMAVLink.Utils.x25_crc([crc_extra])
+
+    <<checksum::little-unsigned-integer-size(16)>>
   end
 end

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -4,15 +4,46 @@ defmodule XMAVLink.Test.Frame do
   alias XMAVLink.Frame
 
   @signed_incompatible_flags 0x01
+  @unknown_incompatible_flags 0x02
+  @signed_unknown_incompatible_flags 0x03
+  @signature_hash <<8, 9, 10, 11, 12, 13>>
+  @signature <<99, 0x010203040506::little-unsigned-integer-size(48), @signature_hash::binary>>
 
-  test "MAVLink 2 signed frames with unsupported incompatible flags consume the signature" do
-    signature = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13>>
+  test "MAVLink 2 signed frames parse the signature trailer and tail" do
+    tail = <<0xFE, 0, 0, 1, 1, 0, 0, 0>>
+    raw = signed_frame_raw() <> tail
+
+    assert {%Frame{signature: signature, mavlink_2_raw: signed_raw} = frame, ^tail} =
+             Frame.binary_to_frame_and_tail(raw)
+
+    assert Frame.signed?(frame)
+    assert %Frame.Signature{} = signature
+    assert signature.link_id == 99
+    assert signature.timestamp == 0x010203040506
+    assert signature.signature == @signature_hash
+    assert signed_raw == signed_frame_raw()
+  end
+
+  test "MAVLink 2 signed frames are not unpacked before signature validation exists" do
+    assert {%Frame{} = frame, <<>>} = Frame.binary_to_frame_and_tail(signed_frame_raw())
+
+    assert :signed_frame_unsupported = Frame.validate_and_unpack(frame, Common)
+  end
+
+  test "MAVLink 2 signed frames with additional unsupported flags consume the signature" do
+    tail = <<0xFE, 0, 0, 1, 1, 0, 0, 0>>
+    raw = signed_frame_raw(@signed_unknown_incompatible_flags) <> tail
+
+    assert {nil, ^tail} = Frame.binary_to_frame_and_tail(raw)
+  end
+
+  test "MAVLink 2 frames with unknown incompatible flags are dropped" do
     tail = <<0xFE, 0, 0, 1, 1, 0, 0, 0>>
 
     raw =
-      <<0xFD, 0, @signed_incompatible_flags, 0, 7, 1, 1, 0::little-unsigned-integer-size(24),
+      <<0xFD, 0, @unknown_incompatible_flags, 0, 7, 1, 1, 0::little-unsigned-integer-size(24),
         0::little-unsigned-integer-size(16)>> <>
-        signature <> tail
+        tail
 
     assert {nil, ^tail} = Frame.binary_to_frame_and_tail(raw)
   end
@@ -39,5 +70,10 @@ defmodule XMAVLink.Test.Frame do
 
     assert <<0xFD, 0, _rest::binary>> = frame.mavlink_2_raw
     assert byte_size(frame.mavlink_2_raw) == 12
+  end
+
+  defp signed_frame_raw(incompatible_flags \\ @signed_incompatible_flags) do
+    <<0xFD, 0, incompatible_flags, 0, 7, 1, 1, 0::little-unsigned-integer-size(24),
+      0::little-unsigned-integer-size(16)>> <> @signature
   end
 end

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -166,6 +166,14 @@ defmodule XMAVLink.Test.Frame do
                @timestamp
              )
 
+    assert {:error, :invalid_crc_extra} =
+             Frame.sign_frame(
+               %Frame{unsigned_frame | crc_extra: 256},
+               @secret_key,
+               @link_id,
+               @timestamp
+             )
+
     assert {:error, :missing_mavlink_2_raw} =
              Frame.sign_frame(
                %Frame{unsigned_frame | mavlink_2_raw: nil},
@@ -183,6 +191,14 @@ defmodule XMAVLink.Test.Frame do
 
     assert {:error, :unsupported_incompatible_flags} =
              Frame.sign_frame(unsupported_incompatible_frame, @secret_key, @link_id, @timestamp)
+
+    assert {:error, :checksum_invalid} =
+             Frame.sign_frame(
+               corrupt_mavlink_2_checksum(unsigned_frame),
+               @secret_key,
+               @link_id,
+               @timestamp
+             )
 
     assert {:ok, signed_frame} =
              Frame.sign_frame(unsigned_frame, @secret_key, @link_id, @timestamp)
@@ -203,5 +219,17 @@ defmodule XMAVLink.Test.Frame do
       |> XMAVLink.Utils.x25_crc([crc_extra])
 
     <<checksum::little-unsigned-integer-size(16)>>
+  end
+
+  defp corrupt_mavlink_2_checksum(%Frame{mavlink_2_raw: raw} = frame) do
+    checksum_offset = byte_size(raw) - 2
+
+    <<prefix::binary-size(checksum_offset), checksum::little-unsigned-integer-size(16)>> = raw
+
+    %Frame{
+      frame
+      | mavlink_2_raw:
+          prefix <> <<Bitwise.bxor(checksum, 0xFFFF)::little-unsigned-integer-size(16)>>
+    }
   end
 end

--- a/test/mavlink_udp_connection_test.exs
+++ b/test/mavlink_udp_connection_test.exs
@@ -4,12 +4,33 @@ defmodule XMAVLink.Test.UDPConnection do
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
 
-  @incompatible_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
+  @signed_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
+                            0::little-unsigned-integer-size(16), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                            11, 12, 13>>
+  @incompatible_mavlink_2_frame <<0xFD, 0, 2, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
                                   0::little-unsigned-integer-size(16)>>
   @incomplete_mavlink_1_frame <<0xFE, 1, 0, 1>>
   @incomplete_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1>>
+  @incomplete_signed_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1,
+                                       0::little-unsigned-integer-size(24),
+                                       0::little-unsigned-integer-size(16)>>
 
   describe "handle_info/3" do
+    test "UDPIn rejects MAVLink 2 signed frames until signing validation exists" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPInConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :signed_frame_unsupported, {^socket, ^address, ^port}, ^connection} =
+               UDPInConnection.handle_info(
+                 {:udp, socket, address, port, @signed_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
     test "UDPIn drops MAVLink 2 frames with incompatible flags" do
       socket = :socket
       address = {127, 0, 0, 1}
@@ -42,6 +63,28 @@ defmodule XMAVLink.Test.UDPConnection do
       assert {:error, :incomplete_frame, {^socket, ^address, ^port}, ^connection} =
                UDPInConnection.handle_info(
                  {:udp, socket, address, port, @incomplete_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+
+      assert {:error, :incomplete_frame, {^socket, ^address, ^port}, ^connection} =
+               UDPInConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_signed_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
+    test "UDPOut rejects MAVLink 2 signed frames until signing validation exists" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPOutConnection{socket: socket, address: address, port: port}
+
+      assert {:error, :signed_frame_unsupported, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, @signed_mavlink_2_frame},
                  connection,
                  Common
                )
@@ -79,6 +122,13 @@ defmodule XMAVLink.Test.UDPConnection do
       assert {:error, :incomplete_frame, ^socket, ^connection} =
                UDPOutConnection.handle_info(
                  {:udp, socket, address, port, @incomplete_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+
+      assert {:error, :incomplete_frame, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, @incomplete_signed_mavlink_2_frame},
                  connection,
                  Common
                )


### PR DESCRIPTION
## Summary

- Parse MAVLink 2 signed-frame trailers into `XMAVLink.Frame.Signature` while still rejecting signed frames before unpacking and routing.
- Add low-level `XMAVLink.Frame.sign_frame/4` for already packed MAVLink 2 frames.
- Keep router/connection signing policy, inbound signature validation, and replay protection for follow-up work.
- Document the staged signing plan.

Refs #47.

## Validation

- `mix test test/mavlink_frame_test.exs test/mavlink_udp_connection_test.exs` (14 tests, 0 failures)
- `mix test` (96 tests, 0 failures)
- `mix compile --warnings-as-errors --force`
- `git diff --check`