### PR TITLE
Add MAVLink 2 signing policy helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - Added MAVLink 2 signed-frame parsing and signature trailer representation
   while continuing to reject signed frames before unpacking or routing until
-  signature validation and replay checks are implemented.
+  router and connection policy wiring is implemented.
 - Added a low-level MAVLink 2 frame signing helper for already packed frames;
   router and connection signing policy is still pending.
+- Added reusable MAVLink 2 signature validation and inbound replay-policy
+  helpers for the next signing integration stage.
 
 ## 0.11.1 - 2026-05-08
 

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -16,9 +16,15 @@ given a 32-byte key, link id, and timestamp. This is a low-level utility for the
 remaining signing implementation; router and connection configuration do not
 use it yet.
 
-Signed frames are still not authenticated, unpacked, delivered to subscribers,
-or forwarded by the router. Until key configuration, signature validation, and
-replay checks exist, `XMAVLink.Frame.validate_and_unpack/2` returns
+`XMAVLink.Frame.validate_signature/2` verifies the 48-bit signature for a
+parsed signed frame. `XMAVLink.Signing.validate_inbound/2` adds the policy
+state needed for replay protection by tracking the last accepted timestamp per
+`{source_system, source_component, link_id}` stream and rejecting first-seen
+streams more than 6,000,000 ticks behind the local signing timestamp.
+
+Frames received by the router are still not authenticated, unpacked, delivered
+to subscribers, or forwarded when they are signed. Until router and connection
+policy wiring exists, `XMAVLink.Frame.validate_and_unpack/2` returns
 `:signed_frame_unsupported` for parsed signed frames.
 
 Unknown incompatible flags are still rejected. If a frame has both the signing
@@ -49,24 +55,22 @@ shape is:
 - `signing: [secret_key: <<_::256>>, link_id: 0..255, timestamp_source: ...]`:
   validate inbound signed frames and sign outbound MAVLink 2 frames on that
   connection.
-- `accept_unsigned: ...`: explicit policy for unsigned frames when signing is
-  enabled. This must default to reject or to a narrow documented compatibility
-  rule, not silent accept-all.
+- `accept_unsigned: false | true`: explicit policy for unsigned frames when
+  signing is enabled. The policy helper defaults to reject.
 - `accept_invalid_signatures: false`: default. Any diagnostic override must be
   explicit and visible to callers.
 
 ## Required Follow-Up Work
 
-1. Inbound validation:
-   - verify the 32-byte key shape;
-   - calculate the 48-bit SHA-256 signature;
-   - compare signatures in constant time if practical;
-   - reject stale timestamps by `(source_system, source_component, link_id)`;
-   - reject first-seen timestamps more than 6,000,000 ticks behind local time.
-2. Router and connection policy:
+1. Router and connection policy:
    - decide where per-link timestamp state lives;
    - make unsigned-frame acceptance explicit;
    - avoid forwarding `SETUP_SIGNING` from a secure link to other links.
+2. Signed unpack/routing:
+   - call `XMAVLink.Signing.validate_inbound/2` before unpacking signed frames;
+   - allow validated signed frames through checksum validation and dialect
+     unpacking;
+   - keep invalid signed frames invisible to subscribers and route tables.
 3. Outbound signing policy:
    - call the low-level frame signing utility from router/connection send paths;
    - monotonically increment timestamps per outbound link;

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -41,7 +41,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Low-level frame signing can generate signed MAVLink 2 frame bytes for already packed frames. Signed frames are not authenticated, unpacked, routed, or emitted by router policy until validation, replay checks, and policy wiring land. See #47 and `MAVLINK2_SIGNING.md`. |
+| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Low-level helpers can generate signed MAVLink 2 frame bytes, verify frame signatures, and enforce replay checks. Signed frames are not unpacked, routed, or emitted by router policy until policy wiring lands. See #47 and `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -78,6 +78,8 @@ Known non-goals for 1.0 unless separately implemented:
 - Low-level MAVLink 2 frame signing can set the signed incompatibility flag,
   recalculate checksum bytes, and append a generated signature trailer for an
   already packed frame.
+- Low-level MAVLink 2 signing validation can verify signed frames and reject
+  replayed or too-old timestamps before router policy wiring lands.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -87,7 +89,7 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #47: Continue MAVLink 2 packet signing with inbound validation, replay policy,
+- #47: Continue MAVLink 2 packet signing with router/connection policy wiring,
   outbound signing, and signed-frame routing behavior.
 - #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
   known system/component.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ This library is not officially recognised or supported by MAVLink at this
 time.
 
 XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames.
-MAVLink 2 signing authentication is not implemented; inbound signed frames are
-parsed only far enough to preserve frame boundaries and expose the signature
-trailer, then rejected before unpacking or routing. A low-level
+Router-level MAVLink 2 signing authentication is not wired; inbound signed
+frames are parsed only far enough to preserve frame boundaries and expose the
+signature trailer, then rejected before unpacking or routing. A low-level
 `XMAVLink.Frame.sign_frame/4` helper can generate signed MAVLink 2 frame bytes
-for already packed frames, but router and connection signing policy is not wired
-yet. MAVLink 2 frames with other incompatible flags are discarded. Supported
+for already packed frames. `XMAVLink.Frame.validate_signature/2` and
+`XMAVLink.Signing.validate_inbound/2` provide reusable signature and replay
+validation helpers, but router and connection signing policy is not wired yet.
+MAVLink 2 frames with other incompatible flags are discarded. Supported
 configured transports are serial, UDP client (`udpout`), UDP server (`udpin`),
 and TCP client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,12 +22,12 @@ control.
 Current trust boundaries:
 
 - MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed.
-- MAVLink 2 signing authentication is not implemented. Signed MAVLink 2 frames
-  are parsed only far enough to preserve frame boundaries and expose the
+- Router-level MAVLink 2 signing authentication is not wired. Signed MAVLink 2
+  frames are parsed only far enough to preserve frame boundaries and expose the
   signature trailer; they are rejected before unpacking, routing, or forwarding.
-  A low-level frame signing helper can generate signed MAVLink 2 bytes, but
-  router and connection signing policy is not wired yet. Frames with other
-  incompatible MAVLink 2 flags are discarded.
+  Low-level helpers can generate signed MAVLink 2 bytes and validate signed
+  frames with replay checks, but router and connection signing policy is not
+  wired yet. Frames with other incompatible MAVLink 2 flags are discarded.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -473,8 +473,6 @@ defmodule XMAVLink.Frame do
     end
   end
 
-  defp validate_signed_frame_shape(_frame), do: {:error, :invalid_mavlink_2_frame}
-
   defp signed_packet_without_signature(raw)
        when is_binary(raw) and byte_size(raw) >= 12 + @mavlink_2_signature_length do
     signed_packet_size = byte_size(raw) - 6

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -77,9 +77,9 @@ defmodule XMAVLink.Frame do
           payload: binary,
           checksum: 0..65_535,
           signature: XMAVLink.Frame.Signature.t() | nil,
-          mavlink_1_raw: binary,
-          mavlink_2_raw: binary,
-          message: message
+          mavlink_1_raw: binary | nil,
+          mavlink_2_raw: binary | nil,
+          message: message | nil
         }
 
   @spec binary_to_frame_and_tail(binary) ::
@@ -472,6 +472,8 @@ defmodule XMAVLink.Frame do
         error
     end
   end
+
+  defp validate_signed_frame_shape(%XMAVLink.Frame{}), do: {:error, :invalid_mavlink_2_frame}
 
   defp signed_packet_without_signature(raw)
        when is_binary(raw) and byte_size(raw) >= 12 + @mavlink_2_signature_length do

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -355,6 +355,37 @@ defmodule XMAVLink.Frame do
     end
   end
 
+  @doc """
+  Validate the MAVLink 2 signature trailer for an already parsed signed frame.
+
+  This only verifies the cryptographic signature over the signed packet bytes.
+  It does not enforce timestamp replay rules or unpack the frame payload.
+  """
+  @spec validate_signature(XMAVLink.Frame.t(), <<_::256>>) ::
+          :ok
+          | {:error,
+             :invalid_secret_key
+             | :invalid_mavlink_2_frame
+             | :signature_invalid
+             | :unsigned_frame}
+  def validate_signature(frame = %XMAVLink.Frame{version: 2}, secret_key) do
+    with :ok <- validate_secret_key(secret_key),
+         :ok <- validate_signed_frame(frame),
+         {:ok, signed_packet_without_signature, signature} <-
+           signed_packet_without_signature(frame.mavlink_2_raw) do
+      expected_signature =
+        signature_hash(secret_key, signed_packet_without_signature, <<>>)
+
+      if secure_compare(signature, expected_signature) do
+        :ok
+      else
+        {:error, :signature_invalid}
+      end
+    end
+  end
+
+  def validate_signature(%XMAVLink.Frame{}, _secret_key), do: {:error, :unsigned_frame}
+
   defp unsupported_incompatible_flags?(incompatible_flags),
     do: (incompatible_flags &&& @mavlink_2_supported_incompatible_flags) != incompatible_flags
 
@@ -414,6 +445,48 @@ defmodule XMAVLink.Frame do
   defp validate_signable_frame_attrs(%{rest: <<>>}), do: :ok
   defp validate_signable_frame_attrs(_attrs), do: {:error, :invalid_mavlink_2_frame}
 
+  defp validate_signed_frame(frame = %XMAVLink.Frame{}) do
+    if signed?(frame) do
+      validate_signed_frame_shape(frame)
+    else
+      {:error, :unsigned_frame}
+    end
+  end
+
+  defp validate_signed_frame_shape(%XMAVLink.Frame{signature: nil}), do: {:error, :unsigned_frame}
+
+  defp validate_signed_frame_shape(%XMAVLink.Frame{mavlink_2_raw: mavlink_2_raw})
+       when is_binary(mavlink_2_raw) do
+    case parse_mavlink_2_raw(mavlink_2_raw) do
+      {:ok,
+       %{
+         incompatible_flags: incompatible_flags,
+         rest: <<_signature::binary-size(@mavlink_2_signature_length)>>
+       }} ->
+        if signed?(incompatible_flags), do: :ok, else: {:error, :invalid_mavlink_2_frame}
+
+      {:ok, _attrs} ->
+        {:error, :invalid_mavlink_2_frame}
+
+      error ->
+        error
+    end
+  end
+
+  defp validate_signed_frame_shape(_frame), do: {:error, :invalid_mavlink_2_frame}
+
+  defp signed_packet_without_signature(raw)
+       when is_binary(raw) and byte_size(raw) >= 12 + @mavlink_2_signature_length do
+    signed_packet_size = byte_size(raw) - 6
+
+    <<signed_packet_without_signature::binary-size(signed_packet_size),
+      signature::binary-size(6)>> = raw
+
+    {:ok, signed_packet_without_signature, signature}
+  end
+
+  defp signed_packet_without_signature(_raw), do: {:error, :invalid_mavlink_2_frame}
+
   defp validate_unsigned_checksum(attrs, crc_extra) do
     if checksum(mavlink_2_body(attrs), crc_extra) ==
          <<attrs.checksum::little-unsigned-integer-size(16)>> do
@@ -438,6 +511,18 @@ defmodule XMAVLink.Frame do
   defp signature_hash(secret_key, signed_frame_without_signature, signature_prefix) do
     :crypto.hash(:sha256, secret_key <> signed_frame_without_signature <> signature_prefix)
     |> binary_part(0, 6)
+  end
+
+  defp secure_compare(left, right) when is_binary(left) and is_binary(right) do
+    if byte_size(left) == byte_size(right) do
+      left
+      |> :binary.bin_to_list()
+      |> Enum.zip(:binary.bin_to_list(right))
+      |> Enum.reduce(0, fn {left_byte, right_byte}, acc -> acc ||| bxor(left_byte, right_byte) end)
+      |> Kernel.==(0)
+    else
+      false
+    end
   end
 
   defp signed_frame_and_tail(raw_and_rest, frame, rest) do

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -1,0 +1,194 @@
+defmodule XMAVLink.Signing do
+  @moduledoc """
+  Stateful MAVLink 2 signing policy helpers.
+
+  This module validates parsed signed frames against a shared key and tracks
+  inbound replay state by `{source_system, source_component, link_id}`. It is
+  intentionally independent from router/connection wiring so the policy can be
+  tested before transports start accepting signed traffic.
+  """
+
+  alias XMAVLink.Frame
+  alias XMAVLink.Signing
+
+  @mavlink_epoch_unix_microseconds 1_420_070_400_000_000
+  @signature_timestamp_max 0xFFFF_FFFF_FFFF
+  @max_initial_timestamp_lag 6_000_000
+
+  defstruct secret_key: nil,
+            link_id: nil,
+            timestamp: nil,
+            accept_unsigned: false,
+            stream_timestamps: %{}
+
+  @type stream_key :: {0..255, 0..255, 0..255}
+  @type t :: %Signing{
+          secret_key: <<_::256>>,
+          link_id: 0..255,
+          timestamp: 0..281_474_976_710_655,
+          accept_unsigned: boolean,
+          stream_timestamps: %{stream_key() => 0..281_474_976_710_655}
+        }
+
+  @type new_error ::
+          :invalid_accept_unsigned
+          | :invalid_link_id
+          | :invalid_secret_key
+          | :invalid_timestamp
+          | :missing_link_id
+          | :missing_secret_key
+
+  @type validate_error ::
+          :invalid_mavlink_2_frame
+          | :invalid_secret_key
+          | :signature_invalid
+          | :signature_replay
+          | :signature_too_old
+          | :signed_frame_unsupported
+          | :unsigned_frame
+          | :unsigned_frame_rejected
+
+  @spec new(nil | keyword()) :: {:ok, t | nil} | {:error, new_error}
+  def new(nil), do: {:ok, nil}
+
+  def new(opts) when is_list(opts) do
+    with {:ok, secret_key} <- fetch_secret_key(opts),
+         {:ok, link_id} <- fetch_link_id(opts),
+         {:ok, timestamp} <- validate_timestamp(Keyword.get(opts, :timestamp, now_timestamp())),
+         {:ok, accept_unsigned} <-
+           validate_accept_unsigned(Keyword.get(opts, :accept_unsigned, false)) do
+      {:ok,
+       %Signing{
+         secret_key: secret_key,
+         link_id: link_id,
+         timestamp: timestamp,
+         accept_unsigned: accept_unsigned
+       }}
+    end
+  end
+
+  @spec validate_inbound(Frame.t(), t | nil) ::
+          {:ok, Frame.t(), t | nil} | {:error, validate_error, t | nil}
+  def validate_inbound(frame = %Frame{}, nil) do
+    if Frame.signed?(frame) do
+      {:error, :signed_frame_unsupported, nil}
+    else
+      {:ok, frame, nil}
+    end
+  end
+
+  def validate_inbound(frame = %Frame{}, signing = %Signing{}) do
+    cond do
+      Frame.signed?(frame) ->
+        validate_signed_inbound(frame, signing)
+
+      signing.accept_unsigned ->
+        {:ok, frame, signing}
+
+      true ->
+        {:error, :unsigned_frame_rejected, signing}
+    end
+  end
+
+  @spec now_timestamp() :: 0..281_474_976_710_655
+  def now_timestamp do
+    timestamp =
+      (System.os_time(:microsecond) - @mavlink_epoch_unix_microseconds)
+      |> div(10)
+
+    timestamp
+    |> max(0)
+    |> min(@signature_timestamp_max)
+  end
+
+  defp validate_signed_inbound(frame, signing) do
+    with :ok <- Frame.validate_signature(frame, signing.secret_key),
+         :ok <- validate_inbound_timestamp(frame, signing) do
+      {:ok, frame, record_inbound_timestamp(frame, signing)}
+    else
+      {:error, reason} -> {:error, reason, signing}
+    end
+  end
+
+  defp validate_inbound_timestamp(
+         %Frame{
+           source_system: source_system,
+           source_component: source_component,
+           signature: %{link_id: link_id, timestamp: timestamp}
+         },
+         %Signing{stream_timestamps: stream_timestamps, timestamp: local_timestamp}
+       ) do
+    stream_key = {source_system, source_component, link_id}
+
+    case Map.fetch(stream_timestamps, stream_key) do
+      {:ok, previous_timestamp} when timestamp <= previous_timestamp ->
+        {:error, :signature_replay}
+
+      {:ok, _previous_timestamp} ->
+        :ok
+
+      :error ->
+        if timestamp + @max_initial_timestamp_lag < local_timestamp do
+          {:error, :signature_too_old}
+        else
+          :ok
+        end
+    end
+  end
+
+  defp record_inbound_timestamp(
+         frame = %Frame{signature: %{timestamp: timestamp}},
+         signing = %Signing{timestamp: local_timestamp, stream_timestamps: stream_timestamps}
+       ) do
+    %Signing{
+      signing
+      | timestamp: max(local_timestamp, timestamp),
+        stream_timestamps: Map.put(stream_timestamps, stream_key(frame), timestamp)
+    }
+  end
+
+  defp stream_key(%Frame{
+         source_system: source_system,
+         source_component: source_component,
+         signature: %{link_id: link_id}
+       }) do
+    {source_system, source_component, link_id}
+  end
+
+  defp fetch_secret_key(opts) do
+    case Keyword.fetch(opts, :secret_key) do
+      {:ok, secret_key} when is_binary(secret_key) and byte_size(secret_key) == 32 ->
+        {:ok, secret_key}
+
+      {:ok, _secret_key} ->
+        {:error, :invalid_secret_key}
+
+      :error ->
+        {:error, :missing_secret_key}
+    end
+  end
+
+  defp fetch_link_id(opts) do
+    case Keyword.fetch(opts, :link_id) do
+      {:ok, link_id} when is_integer(link_id) and link_id in 0..255 ->
+        {:ok, link_id}
+
+      {:ok, _link_id} ->
+        {:error, :invalid_link_id}
+
+      :error ->
+        {:error, :missing_link_id}
+    end
+  end
+
+  defp validate_timestamp(timestamp)
+       when is_integer(timestamp) and timestamp in 0..@signature_timestamp_max,
+       do: {:ok, timestamp}
+
+  defp validate_timestamp(_timestamp), do: {:error, :invalid_timestamp}
+
+  defp validate_accept_unsigned(accept_unsigned) when is_boolean(accept_unsigned),
+    do: {:ok, accept_unsigned}
+
+  defp validate_accept_unsigned(_accept_unsigned), do: {:error, :invalid_accept_unsigned}
+end

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -32,6 +32,7 @@ defmodule XMAVLink.Signing do
 
   @type new_error ::
           :invalid_accept_unsigned
+          | :invalid_options
           | :invalid_link_id
           | :invalid_secret_key
           | :invalid_timestamp
@@ -52,6 +53,16 @@ defmodule XMAVLink.Signing do
   def new(nil), do: {:ok, nil}
 
   def new(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      new_keyword(opts)
+    else
+      {:error, :invalid_options}
+    end
+  end
+
+  def new(_opts), do: {:error, :invalid_options}
+
+  defp new_keyword(opts) do
     with {:ok, secret_key} <- fetch_secret_key(opts),
          {:ok, link_id} <- fetch_link_id(opts),
          {:ok, timestamp} <- validate_timestamp(Keyword.get(opts, :timestamp, now_timestamp())),
@@ -79,6 +90,9 @@ defmodule XMAVLink.Signing do
 
   def validate_inbound(frame = %Frame{}, signing = %Signing{}) do
     cond do
+      frame.version == 1 ->
+        {:ok, frame, signing}
+
       Frame.signed?(frame) ->
         validate_signed_inbound(frame, signing)
 

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -87,7 +87,9 @@ defmodule XMAVLink.Test.Frame do
         crc_extra: 0
       })
 
-    assert {:ok, signed_frame} = Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
+    assert {:ok, %Frame{} = signed_frame} =
+             Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
+
     assert Frame.signed?(signed_frame)
 
     expected_payload = <<1, 2>>
@@ -225,10 +227,17 @@ defmodule XMAVLink.Test.Frame do
 
     assert {:error, :unsigned_frame} = Frame.validate_signature(frame, @secret_key)
 
-    assert {:ok, signed_frame} = Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
+    assert {:ok, %Frame{} = signed_frame} =
+             Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
 
     assert {:error, :signature_invalid} =
              Frame.validate_signature(corrupt_signature(signed_frame), @secret_key)
+
+    assert {:error, :invalid_mavlink_2_frame} =
+             Frame.validate_signature(
+               %Frame{signed_frame | mavlink_2_raw: nil},
+               @secret_key
+             )
   end
 
   defp signed_frame_raw(incompatible_flags \\ @signed_incompatible_flags) do

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -120,6 +120,10 @@ defmodule XMAVLink.Test.Frame do
     assert {%Frame{} = parsed_frame, <<>>} = Frame.binary_to_frame_and_tail(expected_raw)
     assert parsed_frame.signature == signed_frame.signature
     assert :signed_frame_unsupported = Frame.validate_and_unpack(parsed_frame, Common)
+    assert :ok = Frame.validate_signature(parsed_frame, @secret_key)
+
+    assert {:error, :signature_invalid} =
+             Frame.validate_signature(parsed_frame, wrong_secret_key())
   end
 
   test "MAVLink 2 frame signing rejects invalid inputs" do
@@ -207,6 +211,26 @@ defmodule XMAVLink.Test.Frame do
              Frame.sign_frame(signed_frame, @secret_key, @link_id, @timestamp)
   end
 
+  test "MAVLink 2 signature validation rejects unsigned and corrupted frames" do
+    frame =
+      Frame.pack_frame(%Frame{
+        version: 2,
+        sequence_number: 7,
+        source_system: 1,
+        source_component: 1,
+        message_id: 24,
+        payload: <<1, 2, 3>>,
+        crc_extra: 0
+      })
+
+    assert {:error, :unsigned_frame} = Frame.validate_signature(frame, @secret_key)
+
+    assert {:ok, signed_frame} = Frame.sign_frame(frame, @secret_key, @link_id, @timestamp)
+
+    assert {:error, :signature_invalid} =
+             Frame.validate_signature(corrupt_signature(signed_frame), @secret_key)
+  end
+
   defp signed_frame_raw(incompatible_flags \\ @signed_incompatible_flags) do
     <<0xFD, 0, incompatible_flags, 0, 7, 1, 1, 0::little-unsigned-integer-size(24),
       0::little-unsigned-integer-size(16)>> <> @signature
@@ -232,4 +256,18 @@ defmodule XMAVLink.Test.Frame do
           prefix <> <<Bitwise.bxor(checksum, 0xFFFF)::little-unsigned-integer-size(16)>>
     }
   end
+
+  defp corrupt_signature(%Frame{mavlink_2_raw: raw} = frame) do
+    signature_offset = byte_size(raw) - 6
+
+    <<prefix::binary-size(signature_offset), signature_head, signature_tail::binary-size(5)>> =
+      raw
+
+    %Frame{
+      frame
+      | mavlink_2_raw: prefix <> <<Bitwise.bxor(signature_head, 0xFF)>> <> signature_tail
+    }
+  end
+
+  defp wrong_secret_key, do: :binary.copy(<<43>>, 32)
 end

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -1,0 +1,159 @@
+defmodule XMAVLink.Test.Signing do
+  use ExUnit.Case, async: true
+
+  alias XMAVLink.Frame
+  alias XMAVLink.Signing
+
+  @secret_key :binary.copy(<<42>>, 32)
+  @wrong_secret_key :binary.copy(<<43>>, 32)
+  @link_id 9
+  @local_timestamp 10_000_000
+  @valid_timestamp 10_000_001
+
+  describe "new/1" do
+    test "normalizes disabled and configured signing policy" do
+      assert {:ok, nil} = Signing.new(nil)
+
+      assert {:ok,
+              %Signing{
+                secret_key: @secret_key,
+                link_id: @link_id,
+                timestamp: @local_timestamp,
+                accept_unsigned: true,
+                stream_timestamps: %{}
+              }} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp: @local_timestamp,
+                 accept_unsigned: true
+               )
+    end
+
+    test "rejects invalid signing policy inputs" do
+      assert {:error, :missing_secret_key} = Signing.new(link_id: @link_id)
+      assert {:error, :invalid_secret_key} = Signing.new(secret_key: <<1>>, link_id: @link_id)
+      assert {:error, :missing_link_id} = Signing.new(secret_key: @secret_key)
+      assert {:error, :invalid_link_id} = Signing.new(secret_key: @secret_key, link_id: 256)
+
+      assert {:error, :invalid_timestamp} =
+               Signing.new(secret_key: @secret_key, link_id: @link_id, timestamp: -1)
+
+      assert {:error, :invalid_accept_unsigned} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 accept_unsigned: :sometimes
+               )
+    end
+  end
+
+  describe "validate_inbound/2" do
+    test "accepts valid signed frames and records replay state" do
+      signing = signing()
+      frame = signed_frame(@valid_timestamp)
+
+      assert {:ok, ^frame, updated_signing} = Signing.validate_inbound(frame, signing)
+
+      assert updated_signing.timestamp == @valid_timestamp
+
+      assert updated_signing.stream_timestamps[
+               {frame.source_system, frame.source_component, @link_id}
+             ] == @valid_timestamp
+    end
+
+    test "rejects repeated or older timestamps for the same signed stream" do
+      frame = signed_frame(@valid_timestamp)
+
+      assert {:ok, ^frame, updated_signing} = Signing.validate_inbound(frame, signing())
+
+      assert {:error, :signature_replay, ^updated_signing} =
+               Signing.validate_inbound(signed_frame(@valid_timestamp), updated_signing)
+
+      assert {:error, :signature_replay, ^updated_signing} =
+               Signing.validate_inbound(signed_frame(@valid_timestamp - 1), updated_signing)
+
+      assert {:ok, _frame, newer_signing} =
+               Signing.validate_inbound(signed_frame(@valid_timestamp + 1), updated_signing)
+
+      assert newer_signing.stream_timestamps[{1, 1, @link_id}] == @valid_timestamp + 1
+    end
+
+    test "rejects first-seen signed frames more than one minute behind local signing time" do
+      signing = signing()
+
+      assert {:error, :signature_too_old, ^signing} =
+               Signing.validate_inbound(signed_frame(@local_timestamp - 6_000_001), signing)
+
+      assert {:ok, _frame, _updated_signing} =
+               Signing.validate_inbound(signed_frame(@local_timestamp - 6_000_000), signing)
+    end
+
+    test "rejects invalid signatures without updating replay state" do
+      signing = signing()
+
+      assert {:error, :signature_invalid, ^signing} =
+               Signing.validate_inbound(
+                 signed_frame(@valid_timestamp, @wrong_secret_key),
+                 signing
+               )
+    end
+
+    test "rejects unsigned frames unless policy explicitly accepts them" do
+      unsigned_frame = unsigned_frame()
+      signing = signing()
+
+      assert {:error, :unsigned_frame_rejected, ^signing} =
+               Signing.validate_inbound(unsigned_frame, signing)
+
+      {:ok, permissive_signing} =
+        Signing.new(
+          secret_key: @secret_key,
+          link_id: @link_id,
+          timestamp: @local_timestamp,
+          accept_unsigned: true
+        )
+
+      assert {:ok, ^unsigned_frame, ^permissive_signing} =
+               Signing.validate_inbound(unsigned_frame, permissive_signing)
+    end
+
+    test "disabled policy keeps unsigned frames accepted and signed frames unsupported" do
+      unsigned_frame = unsigned_frame()
+      signed_frame = signed_frame(@valid_timestamp)
+
+      assert {:ok, ^unsigned_frame, nil} = Signing.validate_inbound(unsigned_frame, nil)
+
+      assert {:error, :signed_frame_unsupported, nil} =
+               Signing.validate_inbound(signed_frame, nil)
+    end
+  end
+
+  defp signing do
+    {:ok, signing} =
+      Signing.new(
+        secret_key: @secret_key,
+        link_id: @link_id,
+        timestamp: @local_timestamp
+      )
+
+    signing
+  end
+
+  defp signed_frame(timestamp, secret_key \\ @secret_key) do
+    {:ok, frame} = Frame.sign_frame(unsigned_frame(), secret_key, @link_id, timestamp)
+    frame
+  end
+
+  defp unsigned_frame do
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 7,
+      source_system: 1,
+      source_component: 1,
+      message_id: 24,
+      payload: <<1, 2, 3>>,
+      crc_extra: 0
+    })
+  end
+end

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -45,6 +45,9 @@ defmodule XMAVLink.Test.Signing do
                  link_id: @link_id,
                  accept_unsigned: :sometimes
                )
+
+      assert {:error, :invalid_options} = Signing.new([1, 2])
+      assert {:error, :invalid_options} = Signing.new(:invalid)
     end
   end
 
@@ -116,6 +119,23 @@ defmodule XMAVLink.Test.Signing do
 
       assert {:ok, ^unsigned_frame, ^permissive_signing} =
                Signing.validate_inbound(unsigned_frame, permissive_signing)
+    end
+
+    test "keeps MAVLink 1 frames accepted when signing policy is enabled" do
+      frame =
+        Frame.pack_frame(%Frame{
+          version: 1,
+          sequence_number: 7,
+          source_system: 1,
+          source_component: 1,
+          message_id: 24,
+          payload: <<1, 2, 3>>,
+          crc_extra: 0
+        })
+
+      signing = signing()
+
+      assert {:ok, ^frame, ^signing} = Signing.validate_inbound(frame, signing)
     end
 
     test "disabled policy keeps unsigned frames accepted and signed frames unsupported" do


### PR DESCRIPTION
## Summary

- Add `XMAVLink.Frame.validate_signature/2` for low-level MAVLink 2 signed-frame signature verification.
- Add `XMAVLink.Signing` policy state for inbound signature validation, unsigned-frame acceptance policy, and replay checks by `{source_system, source_component, link_id}`.
- Keep router/transport signed-frame acceptance out of scope; signed frames are still rejected by `validate_and_unpack/2` until policy wiring lands.
- Update signing docs, security notes, spec alignment, and changelog.

Refs #47.

## Validation

- `mix test test/mavlink_frame_test.exs test/mavlink_signing_test.exs test/mavlink_udp_connection_test.exs` (23 tests, 0 failures)
- `mix test test/mavlink_connection_worker_test.exs` (3 tests, 0 failures; rerun after one full-suite timing miss)
- `mix test` (105 tests, 0 failures on rerun)
- `mix compile --warnings-as-errors --force`
- `git diff --check`

Note: the first full-suite run hit the existing timing-sensitive `ConnectionWorker` retry test after its 100 ms receive window; the focused rerun and full-suite rerun both passed.