### PR TITLE
Wire inbound MAVLink 2 signing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-- Added MAVLink 2 signed-frame parsing and signature trailer representation
-  while continuing to reject signed frames before unpacking or routing until
-  router and connection policy wiring is implemented.
+- Added MAVLink 2 signed-frame parsing and signature trailer representation.
 - Added a low-level MAVLink 2 frame signing helper for already packed frames;
-  router and connection signing policy is still pending.
+  outbound router signing policy is still pending.
 - Added reusable MAVLink 2 signature validation and inbound replay-policy
-  helpers for the next signing integration stage.
+  helpers.
+- Added inbound router and connection signing policy wiring so configured
+  receive paths can verify signed MAVLink 2 frames, reject replayed signatures,
+  and reject unsigned MAVLink 2 frames by default while signing is enabled.
 
 ## 0.11.1 - 2026-05-08
 

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -12,9 +12,8 @@ frame-shape feature and extracts the 13-byte signing trailer into
 `XMAVLink.Frame.Signature`.
 
 `XMAVLink.Frame.sign_frame/4` can sign an already packed MAVLink 2 frame when
-given a 32-byte key, link id, and timestamp. This is a low-level utility for the
-remaining signing implementation; router and connection configuration do not
-use it yet.
+given a 32-byte key, link id, and timestamp. This remains a low-level utility;
+outbound router and connection signing does not use it yet.
 
 `XMAVLink.Frame.validate_signature/2` verifies the 48-bit signature for a
 parsed signed frame. `XMAVLink.Signing.validate_inbound/2` adds the policy
@@ -22,10 +21,15 @@ state needed for replay protection by tracking the last accepted timestamp per
 `{source_system, source_component, link_id}` stream and rejecting first-seen
 streams more than 6,000,000 ticks behind the local signing timestamp.
 
-Frames received by the router are still not authenticated, unpacked, delivered
-to subscribers, or forwarded when they are signed. Until router and connection
-policy wiring exists, `XMAVLink.Frame.validate_and_unpack/2` returns
-`:signed_frame_unsupported` for parsed signed frames.
+Routers accept a `:signing` configuration with `:secret_key`, `:link_id`,
+`:timestamp`, and optional `:accept_unsigned`. Receive paths seed each
+connection with that policy. Configured signed MAVLink 2 frames are verified
+before dialect unpacking, delivered to subscribers, forwarded through the normal
+routing logic, and recorded for replay protection. Unsigned MAVLink 2 inbound
+frames are rejected by default while signing is enabled unless
+`accept_unsigned: true` is set. MAVLink 1 frames remain accepted under a signing
+policy. When signing is not configured, signed MAVLink 2 frames still return
+`:signed_frame_unsupported`.
 
 Unknown incompatible flags are still rejected. If a frame has both the signing
 flag and unsupported incompatible flags, XMAVLink consumes the known 13-byte
@@ -47,36 +51,28 @@ link id, and timestamp.
 
 ## Intended Public Policy Shape
 
-Signing should be configured per router or per connection. The likely public
-shape is:
+Signing is currently configured per router and copied into each receive-side
+connection:
 
 - `signing: nil` or omitted: current unsigned behavior, but signed frames remain
   rejected until an explicit acceptance policy is configured.
-- `signing: [secret_key: <<_::256>>, link_id: 0..255, timestamp_source: ...]`:
-  validate inbound signed frames and sign outbound MAVLink 2 frames on that
-  connection.
+- `signing: [secret_key: <<_::256>>, link_id: 0..255, timestamp: non_neg_integer]`:
+  validate inbound signed MAVLink 2 frames and track replay timestamps on the
+  receiving connection.
 - `accept_unsigned: false | true`: explicit policy for unsigned frames when
   signing is enabled. The policy helper defaults to reject.
-- `accept_invalid_signatures: false`: default. Any diagnostic override must be
-  explicit and visible to callers.
 
 ## Required Follow-Up Work
 
-1. Router and connection policy:
-   - decide where per-link timestamp state lives;
-   - make unsigned-frame acceptance explicit;
-   - avoid forwarding `SETUP_SIGNING` from a secure link to other links.
-2. Signed unpack/routing:
-   - call `XMAVLink.Signing.validate_inbound/2` before unpacking signed frames;
-   - allow validated signed frames through checksum validation and dialect
-     unpacking;
-   - keep invalid signed frames invisible to subscribers and route tables.
-3. Outbound signing policy:
+1. Outbound signing policy:
    - call the low-level frame signing utility from router/connection send paths;
    - monotonically increment timestamps per outbound link;
    - keep MAVLink 1 behavior unsigned and unchanged.
-4. Persistence hooks:
+2. Persistence hooks:
    - expose timestamp load/save integration points;
    - document that applications must store keys and timestamps securely.
+3. `SETUP_SIGNING` handling:
+   - avoid forwarding `SETUP_SIGNING` from a secure link to other links;
+   - document any explicit provisioning workflow XMAVLink supports.
 
 Each step should land with focused tests before #47 is closed.

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -22,15 +22,15 @@ Supported runtime scope:
 
 - MAVLink 2 unsigned frames without incompatible flags.
 - MAVLink 2 signed-frame boundary parsing and signature trailer
-  representation. Signed frames are rejected until authentication and replay
-  checks are implemented.
+  representation. Configured inbound signed frames are authenticated before
+  unpacking and routed with replay protection.
 - MAVLink 1 frames for existing users and legacy links.
 - Serial, `udpin`, `udpout`, and outbound TCP (`tcpout`) transports.
 - Generated dialect modules from trusted MAVLink XML build inputs.
 
 Known non-goals for 1.0 unless separately implemented:
 
-- Full MAVLink 2 packet signing/authentication.
+- Outbound MAVLink 2 packet signing and timestamp persistence.
 - TCP server (`tcpin`) transport.
 - Treating untrusted XML dialect files as safe input.
 - Full `mavgen` feature parity for XML validation, WIP filtering, and every
@@ -41,7 +41,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Low-level helpers can generate signed MAVLink 2 frame bytes, verify frame signatures, and enforce replay checks. Signed frames are not unpacked, routed, or emitted by router policy until policy wiring lands. See #47 and `MAVLINK2_SIGNING.md`. |
+| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Configured inbound signed frames are verified before unpacking and routed with per-connection replay checks. Unsigned MAVLink 2 inbound frames are rejected by default while signing is enabled unless explicitly accepted. Outbound signing and timestamp persistence remain follow-up work. See #47 and `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -52,7 +52,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Unknown message handling | Partial | Unknown known-shape frames are forwarded as broadcast when the message id is not present in the dialect. Unknown messages cannot expose target fields because the payload cannot be decoded. |
 | Compatible flags | Supported | MAVLink 2 compatible flags are retained and otherwise ignored. |
 | Incompatible flags | Partial | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed, but full signing support is tracked separately. |
-| Routing unchanged packets | Supported for decoded/unknown unsigned frames | Forwarding uses the original raw frame bytes. Signed-frame forwarding is not supported until signing is implemented. |
+| Routing unchanged packets | Supported for decoded/unknown unsigned frames and configured signed inbound frames | Forwarding uses the original raw frame bytes. Outbound generation of signed frames is not wired yet. |
 | Target inference | Supported | Generated metadata classifies broadcast, system, component, and system-component targets from `target_system` and `target_component` fields. |
 | Route reset after reboot | Partial | Routing learns source system/component locations but does not yet clear routes on `SYSTEM_TIME.time_boot_ms` decrease. |
 | XML includes | Partial | Includes are recursive and deterministic, but missing include errors and duplicate handling are not yet aligned with `mavgen`. |
@@ -74,12 +74,15 @@ Known non-goals for 1.0 unless separately implemented:
 - Generated MAVLink 2 packers use zero-equivalent defaults for omitted known
   extension fields.
 - MAVLink 2 signed frames now parse the 13-byte signature trailer into frame
-  metadata while remaining rejected by validation until signing support lands.
+  metadata.
 - Low-level MAVLink 2 frame signing can set the signed incompatibility flag,
   recalculate checksum bytes, and append a generated signature trailer for an
   already packed frame.
 - Low-level MAVLink 2 signing validation can verify signed frames and reject
-  replayed or too-old timestamps before router policy wiring lands.
+  replayed or too-old timestamps.
+- Inbound router and connection signing policy can verify signed MAVLink 2
+  frames before unpacking, track replay state per connection, and reject
+  unsigned MAVLink 2 frames by default while signing is enabled.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -89,8 +92,8 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #47: Continue MAVLink 2 packet signing with router/connection policy wiring,
-  outbound signing, and signed-frame routing behavior.
+- #47: Continue MAVLink 2 packet signing with outbound signing, timestamp
+  persistence hooks, and `SETUP_SIGNING` handling.
 - #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
   known system/component.
 - #53: Align XML parser/generator validation with `mavgen` for missing

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This library includes a mix task that generates code from MAVLink XML
 definition files and an application that enables communication with other
-systems using MAVLink 1 frames and unsigned MAVLink 2 frames over serial,
-UDP, and outbound TCP connections.
+systems using MAVLink 1 frames, unsigned MAVLink 2 frames, and configured
+inbound signed MAVLink 2 frames over serial, UDP, and outbound TCP connections.
 
 MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk,
 ArduPilot and other leading autopilot platforms. For more information
@@ -50,16 +50,17 @@ This library is not officially recognised or supported by MAVLink at this
 time.
 
 XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames.
-Router-level MAVLink 2 signing authentication is not wired; inbound signed
-frames are parsed only far enough to preserve frame boundaries and expose the
-signature trailer, then rejected before unpacking or routing. A low-level
+Router-level MAVLink 2 signing can be configured for inbound frames with a
+32-byte key, link id, and local timestamp. Signed inbound frames are verified
+before unpacking, replay timestamps are tracked per connection, and unsigned
+MAVLink 2 inbound frames are rejected by default while signing is enabled unless
+`accept_unsigned: true` is set. MAVLink 1 inbound frames remain accepted under a
+signing policy. Outbound signing is not wired yet; the low-level
 `XMAVLink.Frame.sign_frame/4` helper can generate signed MAVLink 2 frame bytes
-for already packed frames. `XMAVLink.Frame.validate_signature/2` and
-`XMAVLink.Signing.validate_inbound/2` provide reusable signature and replay
-validation helpers, but router and connection signing policy is not wired yet.
-MAVLink 2 frames with other incompatible flags are discarded. Supported
-configured transports are serial, UDP client (`udpout`), UDP server (`udpin`),
-and TCP client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
+for already packed frames. MAVLink 2 frames with other incompatible flags are
+discarded. Supported configured transports are serial, UDP client (`udpout`),
+UDP server (`udpin`), and TCP client (`tcpout`). TCP server (`tcpin`)
+connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,13 +21,15 @@ control.
 
 Current trust boundaries:
 
-- MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed.
-- Router-level MAVLink 2 signing authentication is not wired. Signed MAVLink 2
-  frames are parsed only far enough to preserve frame boundaries and expose the
-  signature trailer; they are rejected before unpacking, routing, or forwarding.
-  Low-level helpers can generate signed MAVLink 2 bytes and validate signed
-  frames with replay checks, but router and connection signing policy is not
-  wired yet. Frames with other incompatible MAVLink 2 flags are discarded.
+- MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed when signing is
+  not configured.
+- Router-level MAVLink 2 signing can be configured for inbound frames. Signed
+  frames are verified before unpacking, replay timestamps are tracked per
+  connection, and unsigned MAVLink 2 inbound frames are rejected by default
+  while signing is enabled unless `accept_unsigned: true` is set. MAVLink 1
+  inbound frames remain accepted under a signing policy. Outbound signing and
+  timestamp persistence hooks are not wired yet. Frames with other incompatible
+  MAVLink 2 flags are discarded.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -188,6 +188,27 @@ defmodule XMAVLink.Frame do
 
   def validate_and_unpack(frame, dialect), do: validate_unsigned_and_unpack(frame, dialect)
 
+  @spec validate_and_unpack(XMAVLink.Frame.t(), module, XMAVLink.Signing.t() | nil) ::
+          {:ok, XMAVLink.Frame.t(), XMAVLink.Signing.t() | nil}
+          | {:unknown_message, XMAVLink.Signing.t() | nil}
+          | {:error,
+             :failed_to_unpack
+             | :checksum_invalid
+             | :unknown_message
+             | XMAVLink.Signing.validate_error(), XMAVLink.Signing.t() | nil}
+  def validate_and_unpack(frame, dialect, signing) do
+    with {:ok, validated_frame, updated_signing} <-
+           XMAVLink.Signing.validate_inbound(frame, signing) do
+      case validate_unsigned_and_unpack(validated_frame, dialect) do
+        {:ok, valid_frame} -> {:ok, valid_frame, updated_signing}
+        :unknown_message -> {:unknown_message, updated_signing}
+        reason -> {:error, reason, updated_signing}
+      end
+    else
+      {:error, reason, updated_signing} -> {:error, reason, updated_signing}
+    end
+  end
+
   defp validate_unsigned_and_unpack(
          frame = %XMAVLink.Frame{message_id: message_id, version: version, payload: payload},
          dialect

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -23,6 +23,7 @@ defmodule XMAVLink.Router do
   alias XMAVLink.Frame
   alias XMAVLink.Message
   alias XMAVLink.Router
+  alias XMAVLink.Signing
   alias XMAVLink.LocalConnection
   alias XMAVLink.SerialConnection
   alias XMAVLink.TCPOutConnection
@@ -65,6 +66,8 @@ defmodule XMAVLink.Router do
     connection_retry_ms: 1_000,
     # Subscription cache name for restart restoration, if any
     subscription_cache: nil,
+    # Per-connection MAVLink 2 signing policy seed
+    signing: nil,
     # Per-router supervised connection workers
     connection_supervisor: nil,
     connection_workers: %{},
@@ -91,6 +94,7 @@ defmodule XMAVLink.Router do
           dialect: module | nil,
           connection_strings: [String.t()],
           connection_retry_ms: non_neg_integer,
+          signing: Signing.t() | nil,
           subscription_cache: router_name | nil,
           connection_supervisor: pid | nil,
           connection_workers: %{connection_key() => pid},
@@ -147,7 +151,8 @@ defmodule XMAVLink.Router do
             optional(:name) => router_name | nil,
             optional(:connection_strings) => [String.t()],
             optional(:connections) => [String.t()],
-            optional(:connection_retry_ms) => non_neg_integer
+            optional(:connection_retry_ms) => non_neg_integer,
+            optional(:signing) => keyword() | nil
           },
           [{atom, any}]
         ) :: {:ok, pid}
@@ -400,6 +405,7 @@ defmodule XMAVLink.Router do
     args = Map.new(args)
     connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
     connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
+    signing = normalize_signing!(Map.get(args, :signing))
 
     if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
       raise ArgumentError, "connection_retry_ms must be a non-negative integer"
@@ -408,6 +414,14 @@ defmodule XMAVLink.Router do
     args
     |> Map.put(:connection_strings, connection_strings)
     |> Map.put(:connection_retry_ms, connection_retry_ms)
+    |> Map.put(:signing, signing)
+  end
+
+  defp normalize_signing!(signing) do
+    case Signing.new(signing) do
+      {:ok, signing} -> signing
+      {:error, reason} -> raise ArgumentError, "invalid signing config: #{inspect(reason)}"
+    end
   end
 
   defp start_options(opts, nil), do: Keyword.delete(opts, :name)
@@ -498,6 +512,7 @@ defmodule XMAVLink.Router do
        connection_retry_ms: args.connection_retry_ms,
        connection_supervisor: connection_supervisor,
        subscription_cache: subscription_cache,
+       signing: args.signing,
        connections: %{local: local_connection}
      }}
   end
@@ -604,6 +619,8 @@ defmodule XMAVLink.Router do
         {:add_connection, connection_key, connection},
         state = %Router{connections: connections}
       ) do
+    connection = connection_with_signing(connection, state.signing)
+
     {
       :noreply,
       struct(
@@ -617,6 +634,8 @@ defmodule XMAVLink.Router do
         {:add_connection, connection_key, connection, worker},
         state = %Router{connections: connections}
       ) do
+    connection = connection_with_signing(connection, state.signing)
+
     {
       :noreply,
       state
@@ -636,7 +655,7 @@ defmodule XMAVLink.Router do
   defp handle_udp_message(
          message = {:udp, socket, address, port, _},
          worker,
-         state = %Router{connections: connections, dialect: dialect}
+         state = %Router{connections: connections, dialect: dialect, signing: signing}
        ) do
     {
       :noreply,
@@ -664,7 +683,7 @@ defmodule XMAVLink.Router do
 
             nil ->
               # New previously unseen UDPIn client
-              UDPInConnection.handle_info(message, nil, dialect, worker)
+              UDPInConnection.handle_info(message, nil, dialect, worker, signing)
           end
       end
       |> update_route_info(state)
@@ -705,6 +724,14 @@ defmodule XMAVLink.Router do
   ####################
   # Helper Functions #
   ####################
+
+  defp connection_with_signing(connection, signing) do
+    if Map.has_key?(connection, :signing) do
+      struct(connection, signing: signing)
+    else
+      connection
+    end
+  end
 
   # Handle user configured connections with supervised workers. If
   # successful they send us an :add_connection message with the details. The

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -11,20 +11,22 @@ defmodule XMAVLink.SerialConnection do
   alias XMAVLink.Frame
   alias Circuits.UART
 
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
+  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
 
   defstruct port: nil,
             baud: nil,
             uart: nil,
             buffer: <<>>,
-            worker: nil
+            worker: nil,
+            signing: nil
 
   @type t :: %XMAVLink.SerialConnection{
           port: binary,
           baud: non_neg_integer,
           uart: pid,
           buffer: binary,
-          worker: pid | nil
+          worker: pid | nil,
+          signing: XMAVLink.Signing.t() | nil
         }
 
   def handle_info(
@@ -50,25 +52,27 @@ defmodule XMAVLink.SerialConnection do
         if byte_size(rest) >= @smallest_mavlink_message,
           do: send(self(), {:circuits_uart, port, <<>>})
 
-        case validate_and_unpack(received_frame, dialect) do
-          {:ok, valid_frame} ->
-            {:ok, port, struct(receiving_connection, buffer: rest), valid_frame}
+        connection = struct(receiving_connection, buffer: rest)
 
-          :unknown_message ->
+        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
+          {:ok, valid_frame, signing} ->
+            {:ok, port, struct(connection, signing: signing), valid_frame}
+
+          {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
               Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
 
-            {:ok, port, struct(receiving_connection, buffer: rest),
+            {:ok, port, struct(connection, signing: signing),
              struct(received_frame, target: :broadcast)}
 
-          reason ->
+          {:error, reason, signing} ->
             :ok =
               Logger.debug(
                 "SerialConnection.handle_info: frame received failed: #{Atom.to_string(reason)}"
               )
 
-            {:error, reason, port, struct(receiving_connection, buffer: rest)}
+            {:error, reason, port, struct(connection, signing: signing)}
         end
     end
   end

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -61,7 +61,7 @@ defmodule XMAVLink.SerialConnection do
           {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
+              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
 
             {:ok, port, struct(connection, signing: signing),
              struct(received_frame, target: :broadcast)}

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -29,7 +29,8 @@ defmodule XMAVLink.Supervisor do
             system: Application.get_env(:xmavlink, :system_id),
             component: Application.get_env(:xmavlink, :component_id),
             connection_strings: Application.get_env(:xmavlink, :connections),
-            connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000)
+            connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000),
+            signing: Application.get_env(:xmavlink, :signing)
           }
         }
       ] ++ heartbeat_child_specs(router_name)

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -54,7 +54,7 @@ defmodule XMAVLink.TCPOutConnection do
           {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
+              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
 
             {:ok, socket, struct(connection, signing: signing),
              struct(received_frame, target: :broadcast)}

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -10,16 +10,17 @@ defmodule XMAVLink.TCPOutConnection do
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
+  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
 
-  defstruct socket: nil, address: nil, port: nil, buffer: <<>>, worker: nil
+  defstruct socket: nil, address: nil, port: nil, buffer: <<>>, worker: nil, signing: nil
 
   @type t :: %XMAVLink.TCPOutConnection{
           socket: pid,
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
           buffer: binary,
-          worker: pid | nil
+          worker: pid | nil,
+          signing: XMAVLink.Signing.t() | nil
         }
 
   def handle_info(
@@ -44,25 +45,27 @@ defmodule XMAVLink.TCPOutConnection do
         # Rest could be a message, return later to try emptying the buffer
         if byte_size(rest) >= @smallest_mavlink_message, do: send(self(), {:tcp, socket, <<>>})
 
-        case validate_and_unpack(received_frame, dialect) do
-          {:ok, valid_frame} ->
-            {:ok, socket, struct(receiving_connection, buffer: rest), valid_frame}
+        connection = struct(receiving_connection, buffer: rest)
 
-          :unknown_message ->
+        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
+          {:ok, valid_frame, signing} ->
+            {:ok, socket, struct(connection, signing: signing), valid_frame}
+
+          {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
               Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
 
-            {:ok, socket, struct(receiving_connection, buffer: rest),
+            {:ok, socket, struct(connection, signing: signing),
              struct(received_frame, target: :broadcast)}
 
-          reason ->
+          {:error, reason, signing} ->
             :ok =
               Logger.debug(
                 "TCPOutConnection.handle_info: frame received failed: #{Atom.to_string(reason)}"
               )
 
-            {:error, reason, socket, struct(receiving_connection, buffer: rest)}
+            {:error, reason, socket, struct(connection, signing: signing)}
         end
     end
   end

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -4,7 +4,7 @@ defmodule XMAVLink.UDPInConnection do
   """
 
   require Logger
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
+  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
 
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
@@ -15,13 +15,15 @@ defmodule XMAVLink.UDPInConnection do
   defstruct address: nil,
             port: nil,
             socket: nil,
-            worker: nil
+            worker: nil,
+            signing: nil
 
   @type t :: %XMAVLink.UDPInConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
           socket: pid,
-          worker: pid | nil
+          worker: pid | nil,
+          signing: XMAVLink.Signing.t() | nil
         }
 
   # Create connection if this is the first time we've received on it
@@ -47,47 +49,55 @@ defmodule XMAVLink.UDPInConnection do
 
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
-        case validate_and_unpack(received_frame, dialect) do
-          {:ok, valid_frame} ->
+        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
+          {:ok, valid_frame, signing} ->
             # Include address and port in connection key because multiple
             # clients can connect to a UDP "in" port.
-            {:ok, {socket, source_addr, source_port}, receiving_connection, valid_frame}
+            {:ok, {socket, source_addr, source_port},
+             struct(receiving_connection, signing: signing), valid_frame}
 
-          :unknown_message ->
+          {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
               Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
 
-            {:ok, {socket, source_addr, source_port}, receiving_connection,
+            {:ok, {socket, source_addr, source_port},
+             struct(receiving_connection, signing: signing),
              struct(received_frame, target: :broadcast)}
 
-          reason ->
+          {:error, reason, signing} ->
             :ok =
               Logger.debug(
                 "UDPInConnection.handle_info: frame received from " <>
                   "#{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port} failed: #{Atom.to_string(reason)}"
               )
 
-            {:error, reason, {socket, source_addr, source_port}, receiving_connection}
+            {:error, reason, {socket, source_addr, source_port},
+             struct(receiving_connection, signing: signing)}
         end
     end
   end
 
   def handle_info({:udp, socket, source_addr, source_port, raw}, nil, dialect, worker) do
+    handle_info({:udp, socket, source_addr, source_port, raw}, nil, dialect, worker, nil)
+  end
+
+  def handle_info(message, receiving_connection, dialect, _worker) do
+    handle_info(message, receiving_connection, dialect)
+  end
+
+  def handle_info({:udp, socket, source_addr, source_port, raw}, nil, dialect, worker, signing) do
     handle_info(
       {:udp, socket, source_addr, source_port, raw},
       %XMAVLink.UDPInConnection{
         address: source_addr,
         port: source_port,
         socket: socket,
-        worker: worker
+        worker: worker,
+        signing: signing
       },
       dialect
     )
-  end
-
-  def handle_info(message, receiving_connection, dialect, _worker) do
-    handle_info(message, receiving_connection, dialect)
   end
 
   defp frame_parse_error(

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -59,7 +59,7 @@ defmodule XMAVLink.UDPInConnection do
           {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}}")
+              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
 
             {:ok, {socket, source_addr, source_port},
              struct(receiving_connection, signing: signing),

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -4,7 +4,7 @@ defmodule XMAVLink.UDPOutConnection do
   """
 
   require Logger
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 2]
+  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
 
@@ -14,13 +14,15 @@ defmodule XMAVLink.UDPOutConnection do
   defstruct address: nil,
             port: nil,
             socket: nil,
-            worker: nil
+            worker: nil,
+            signing: nil
 
   @type t :: %XMAVLink.UDPOutConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
           socket: pid,
-          worker: pid | nil
+          worker: pid | nil,
+          signing: XMAVLink.Signing.t() | nil
         }
 
   # Create connection if this is the first time we've received on it
@@ -46,8 +48,8 @@ defmodule XMAVLink.UDPOutConnection do
 
       # UDP sends frame per packet, so ignore rest
       {received_frame, _rest} ->
-        case validate_and_unpack(received_frame, dialect) do
-          {:ok, valid_frame} ->
+        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
+          {:ok, valid_frame, signing} ->
             # A udpout connection is single-target, single-socket. Key it by
             # the bare `socket` so update_route_info/2 updates the existing
             # connection entry rather than creating a sibling under
@@ -55,22 +57,23 @@ defmodule XMAVLink.UDPOutConnection do
             # broadcast `route/1` clause to forward back out the same UDPOut
             # (echo) when the reply's source IP differs from the configured
             # target (NAT / masquerade / kube-proxy DNAT).
-            {:ok, socket, receiving_connection, valid_frame}
+            {:ok, socket, struct(receiving_connection, signing: signing), valid_frame}
 
-          :unknown_message ->
+          {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
             :ok = Logger.debug("relaying unknown message with id #{received_frame.message_id}}")
 
-            {:ok, socket, receiving_connection, struct(received_frame, target: :broadcast)}
+            {:ok, socket, struct(receiving_connection, signing: signing),
+             struct(received_frame, target: :broadcast)}
 
-          reason ->
+          {:error, reason, signing} ->
             :ok =
               Logger.debug(
                 "UDPOutConnection.handle_info: frame received from " <>
                   "#{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port} failed: #{Atom.to_string(reason)}"
               )
 
-            {:error, reason, socket, receiving_connection}
+            {:error, reason, socket, struct(receiving_connection, signing: signing)}
         end
     end
   end

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -61,7 +61,7 @@ defmodule XMAVLink.UDPOutConnection do
 
           {:unknown_message, signing} ->
             # We re-broadcast valid frames with unknown messages
-            :ok = Logger.debug("relaying unknown message with id #{received_frame.message_id}}")
+            :ok = Logger.debug("relaying unknown message with id #{received_frame.message_id}")
 
             {:ok, socket, struct(receiving_connection, signing: signing),
              struct(received_frame, target: :broadcast)}

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -1,6 +1,13 @@
 defmodule XMAVLink.Test.Router do
   use ExUnit.Case
+
+  alias XMAVLink.Frame
   alias XMAVLink.Router
+
+  @secret_key :binary.copy(<<42>>, 32)
+  @link_id 9
+  @local_timestamp 10_000_000
+  @valid_timestamp 10_000_001
 
   describe "connection string parsing" do
     test "accepts IP address in udpout connection string" do
@@ -152,6 +159,21 @@ defmodule XMAVLink.Test.Router do
             dialect: APM.Dialect,
             connection_strings: [],
             connection_retry_ms: -1
+          },
+          []
+        )
+      end
+    end
+
+    test "rejects invalid signing config" do
+      assert_raise ArgumentError, ~r/invalid signing config: :invalid_secret_key/, fn ->
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            signing: [secret_key: <<1>>, link_id: @link_id]
           },
           []
         )
@@ -627,6 +649,88 @@ defmodule XMAVLink.Test.Router do
     end
   end
 
+  describe "inbound signing policy" do
+    test "valid signed UDP frames are unpacked, routed, and recorded for replay protection" do
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            signing: [
+              secret_key: @secret_key,
+              link_id: @link_id,
+              timestamp: @local_timestamp
+            ]
+          },
+          []
+        )
+
+      on_exit(fn -> stop_router(router_pid) end)
+
+      assert :ok = Router.subscribe(router_pid, message: Common.Message.Heartbeat, as_frame: true)
+
+      socket = :signed_udp_socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+      raw = signed_heartbeat_frame().mavlink_2_raw
+
+      send(router_pid, {:udp, socket, address, port, raw})
+
+      assert_receive %Frame{
+                       source_system: 1,
+                       source_component: 1,
+                       signature: %{link_id: @link_id, timestamp: @valid_timestamp},
+                       message: %Common.Message.Heartbeat{}
+                     },
+                     200
+
+      state = :sys.get_state(router_pid)
+      connection_key = {socket, address, port}
+
+      assert state.routes[{1, 1}] == connection_key
+
+      assert state.connections[connection_key].signing.stream_timestamps[{1, 1, @link_id}] ==
+               @valid_timestamp
+    end
+
+    test "unsigned MAVLink 2 UDP frames are rejected when signing requires signed input" do
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            signing: [
+              secret_key: @secret_key,
+              link_id: @link_id,
+              timestamp: @local_timestamp
+            ]
+          },
+          []
+        )
+
+      on_exit(fn -> stop_router(router_pid) end)
+
+      assert :ok = Router.subscribe(router_pid, message: Common.Message.Heartbeat, as_frame: true)
+
+      socket = :unsigned_udp_socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      send(router_pid, {:udp, socket, address, port, unsigned_heartbeat_frame().mavlink_2_raw})
+
+      refute_receive %Frame{message: %Common.Message.Heartbeat{}}, 50
+
+      state = :sys.get_state(router_pid)
+      refute Map.has_key?(state.routes, {1, 1})
+    end
+  end
+
   describe "subscribe/1" do
     test "is synchronous - subscription is committed when call returns" do
       {udp_socket, udp_port} = open_udp_socket()
@@ -821,6 +925,26 @@ defmodule XMAVLink.Test.Router do
       system_status: :mav_state_active,
       mavlink_version: 3
     }
+  end
+
+  defp signed_heartbeat_frame(timestamp \\ @valid_timestamp) do
+    {:ok, frame} = Frame.sign_frame(unsigned_heartbeat_frame(), @secret_key, @link_id, timestamp)
+    frame
+  end
+
+  defp unsigned_heartbeat_frame do
+    {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
+      XMAVLink.Message.pack(sample_heartbeat(), 2)
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 7,
+      source_system: 1,
+      source_component: 1,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
   end
 
   defp open_udp_socket do

--- a/test/mavlink_udp_connection_test.exs
+++ b/test/mavlink_udp_connection_test.exs
@@ -1,8 +1,15 @@
 defmodule XMAVLink.Test.UDPConnection do
   use ExUnit.Case, async: true
 
+  alias XMAVLink.Frame
+  alias XMAVLink.Signing
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
+
+  @secret_key :binary.copy(<<42>>, 32)
+  @link_id 9
+  @local_timestamp 10_000_000
+  @valid_timestamp 10_000_001
 
   @signed_mavlink_2_frame <<0xFD, 0, 1, 0, 0, 1, 1, 0::little-unsigned-integer-size(24),
                             0::little-unsigned-integer-size(16), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
@@ -16,7 +23,7 @@ defmodule XMAVLink.Test.UDPConnection do
                                        0::little-unsigned-integer-size(16)>>
 
   describe "handle_info/3" do
-    test "UDPIn rejects MAVLink 2 signed frames until signing validation exists" do
+    test "UDPIn rejects MAVLink 2 signed frames when signing is disabled" do
       socket = :socket
       address = {127, 0, 0, 1}
       port = 14_550
@@ -29,6 +36,33 @@ defmodule XMAVLink.Test.UDPConnection do
                  connection,
                  Common
                )
+    end
+
+    test "UDPIn accepts valid signed MAVLink 2 frames when signing is configured" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPInConnection{
+        socket: socket,
+        address: address,
+        port: port,
+        signing: signing()
+      }
+
+      raw = signed_heartbeat_frame().mavlink_2_raw
+
+      assert {:ok, {^socket, ^address, ^port}, updated_connection,
+              %Frame{
+                source_system: 1,
+                source_component: 1,
+                signature: %{link_id: @link_id, timestamp: @valid_timestamp},
+                message: %Common.Message.Heartbeat{}
+              }} =
+               UDPInConnection.handle_info({:udp, socket, address, port, raw}, connection, Common)
+
+      assert updated_connection.signing.stream_timestamps[{1, 1, @link_id}] ==
+               @valid_timestamp
     end
 
     test "UDPIn drops MAVLink 2 frames with incompatible flags" do
@@ -75,7 +109,7 @@ defmodule XMAVLink.Test.UDPConnection do
                )
     end
 
-    test "UDPOut rejects MAVLink 2 signed frames until signing validation exists" do
+    test "UDPOut rejects MAVLink 2 signed frames when signing is disabled" do
       socket = :socket
       address = {127, 0, 0, 1}
       port = 14_550
@@ -85,6 +119,26 @@ defmodule XMAVLink.Test.UDPConnection do
       assert {:error, :signed_frame_unsupported, ^socket, ^connection} =
                UDPOutConnection.handle_info(
                  {:udp, socket, address, port, @signed_mavlink_2_frame},
+                 connection,
+                 Common
+               )
+    end
+
+    test "UDPOut rejects unsigned MAVLink 2 frames when signing requires signed input" do
+      socket = :socket
+      address = {127, 0, 0, 1}
+      port = 14_550
+
+      connection = %UDPOutConnection{
+        socket: socket,
+        address: address,
+        port: port,
+        signing: signing()
+      }
+
+      assert {:error, :unsigned_frame_rejected, ^socket, ^connection} =
+               UDPOutConnection.handle_info(
+                 {:udp, socket, address, port, unsigned_heartbeat_frame().mavlink_2_raw},
                  connection,
                  Common
                )
@@ -133,5 +187,47 @@ defmodule XMAVLink.Test.UDPConnection do
                  Common
                )
     end
+  end
+
+  defp signing do
+    {:ok, signing} =
+      Signing.new(
+        secret_key: @secret_key,
+        link_id: @link_id,
+        timestamp: @local_timestamp
+      )
+
+    signing
+  end
+
+  defp signed_heartbeat_frame(timestamp \\ @valid_timestamp) do
+    {:ok, frame} = Frame.sign_frame(unsigned_heartbeat_frame(), @secret_key, @link_id, timestamp)
+    frame
+  end
+
+  defp unsigned_heartbeat_frame do
+    {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
+      XMAVLink.Message.pack(sample_heartbeat(), 2)
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 7,
+      source_system: 1,
+      source_component: 1,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
+  end
+
+  defp sample_heartbeat do
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
   end
 end


### PR DESCRIPTION
## Summary

- Adds `Frame.validate_and_unpack/3` so configured receive paths validate MAVLink 2 signing policy before dialect unpacking.
- Carries signing state on UDP, TCP, and serial receive connections and seeds it from router `:signing` config.
- Adds focused coverage for signed UDP routing, unsigned MAVLink 2 rejection under signing policy, and invalid signing config.
- Updates signing/security/spec docs to reflect inbound authentication support while leaving outbound signing, timestamp persistence, and `SETUP_SIGNING` handling as follow-up #47 slices.

Refs #47.

## Validation

- `mix format`
- `mix test test/mavlink_frame_test.exs test/mavlink_signing_test.exs test/mavlink_udp_connection_test.exs test/mavlink_router_test.exs`
- `mix test` (rerun passed after one non-reproducing utility cleanup race on the first full-suite run)
- `mix compile --warnings-as-errors --force`
- `mix dialyzer`
- `git diff --check`