### PR TITLE
Sign outbound MAVLink 2 frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ## Unreleased
 
 - Added MAVLink 2 signed-frame parsing and signature trailer representation.
-- Added a low-level MAVLink 2 frame signing helper for already packed frames;
-  outbound router signing policy is still pending.
+- Added a low-level MAVLink 2 frame signing helper for already packed frames.
 - Added reusable MAVLink 2 signature validation and inbound replay-policy
   helpers.
 - Added inbound router and connection signing policy wiring so configured
   receive paths can verify signed MAVLink 2 frames, reject replayed signatures,
   and reject unsigned MAVLink 2 frames by default while signing is enabled.
+- Added outbound router signing for unsigned MAVLink 2 frames sent over
+  signing-enabled connections, with per-connection timestamp increments.
 
 ## 0.11.1 - 2026-05-08
 

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -12,8 +12,9 @@ frame-shape feature and extracts the 13-byte signing trailer into
 `XMAVLink.Frame.Signature`.
 
 `XMAVLink.Frame.sign_frame/4` can sign an already packed MAVLink 2 frame when
-given a 32-byte key, link id, and timestamp. This remains a low-level utility;
-outbound router and connection signing does not use it yet.
+given a 32-byte key, link id, and timestamp. Router forwarding uses it through
+`XMAVLink.Signing.sign_outbound/2` when a signing-enabled connection sends an
+unsigned MAVLink 2 frame.
 
 `XMAVLink.Frame.validate_signature/2` verifies the 48-bit signature for a
 parsed signed frame. `XMAVLink.Signing.validate_inbound/2` adds the policy
@@ -30,6 +31,11 @@ frames are rejected by default while signing is enabled unless
 `accept_unsigned: true` is set. MAVLink 1 frames remain accepted under a signing
 policy. When signing is not configured, signed MAVLink 2 frames still return
 `:signed_frame_unsupported`.
+
+Outbound routing signs unsigned MAVLink 2 frames on signing-enabled
+connections, updates that connection's local timestamp after each signed send,
+and leaves MAVLink 1 frames unsigned. Already signed MAVLink 2 frames are
+forwarded with their existing signature rather than being re-signed.
 
 Unknown incompatible flags are still rejected. If a frame has both the signing
 flag and unsupported incompatible flags, XMAVLink consumes the known 13-byte
@@ -51,27 +57,22 @@ link id, and timestamp.
 
 ## Intended Public Policy Shape
 
-Signing is currently configured per router and copied into each receive-side
-connection:
+Signing is currently configured per router and copied into each connection:
 
 - `signing: nil` or omitted: current unsigned behavior, but signed frames remain
   rejected until an explicit acceptance policy is configured.
 - `signing: [secret_key: <<_::256>>, link_id: 0..255, timestamp: non_neg_integer]`:
-  validate inbound signed MAVLink 2 frames and track replay timestamps on the
-  receiving connection.
+  validate inbound signed MAVLink 2 frames, track inbound replay timestamps, and
+  sign unsigned outbound MAVLink 2 frames on each connection.
 - `accept_unsigned: false | true`: explicit policy for unsigned frames when
   signing is enabled. The policy helper defaults to reject.
 
 ## Required Follow-Up Work
 
-1. Outbound signing policy:
-   - call the low-level frame signing utility from router/connection send paths;
-   - monotonically increment timestamps per outbound link;
-   - keep MAVLink 1 behavior unsigned and unchanged.
-2. Persistence hooks:
+1. Persistence hooks:
    - expose timestamp load/save integration points;
    - document that applications must store keys and timestamps securely.
-3. `SETUP_SIGNING` handling:
+2. `SETUP_SIGNING` handling:
    - avoid forwarding `SETUP_SIGNING` from a secure link to other links;
    - document any explicit provisioning workflow XMAVLink supports.
 

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -23,14 +23,15 @@ Supported runtime scope:
 - MAVLink 2 unsigned frames without incompatible flags.
 - MAVLink 2 signed-frame boundary parsing and signature trailer
   representation. Configured inbound signed frames are authenticated before
-  unpacking and routed with replay protection.
+  unpacking and routed with replay protection, and unsigned outbound MAVLink 2
+  frames are signed on signing-enabled connections.
 - MAVLink 1 frames for existing users and legacy links.
 - Serial, `udpin`, `udpout`, and outbound TCP (`tcpout`) transports.
 - Generated dialect modules from trusted MAVLink XML build inputs.
 
 Known non-goals for 1.0 unless separately implemented:
 
-- Outbound MAVLink 2 packet signing and timestamp persistence.
+- Signing timestamp persistence.
 - TCP server (`tcpin`) transport.
 - Treating untrusted XML dialect files as safe input.
 - Full `mavgen` feature parity for XML validation, WIP filtering, and every
@@ -41,7 +42,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Configured inbound signed frames are verified before unpacking and routed with per-connection replay checks. Unsigned MAVLink 2 inbound frames are rejected by default while signing is enabled unless explicitly accepted. Outbound signing and timestamp persistence remain follow-up work. See #47 and `MAVLINK2_SIGNING.md`. |
+| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Configured inbound signed frames are verified before unpacking and routed with per-connection replay checks. Unsigned MAVLink 2 inbound frames are rejected by default while signing is enabled unless explicitly accepted. Unsigned outbound MAVLink 2 frames are signed on signing-enabled connections with per-connection timestamp increments. Timestamp persistence remains follow-up work. See #47 and `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -52,7 +53,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Unknown message handling | Partial | Unknown known-shape frames are forwarded as broadcast when the message id is not present in the dialect. Unknown messages cannot expose target fields because the payload cannot be decoded. |
 | Compatible flags | Supported | MAVLink 2 compatible flags are retained and otherwise ignored. |
 | Incompatible flags | Partial | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed, but full signing support is tracked separately. |
-| Routing unchanged packets | Supported for decoded/unknown unsigned frames and configured signed inbound frames | Forwarding uses the original raw frame bytes. Outbound generation of signed frames is not wired yet. |
+| Routing unchanged packets | Supported with signing caveat | Forwarding generally uses the original raw frame bytes. Unsigned MAVLink 2 frames sent over signing-enabled connections are signed for that outbound link; already signed MAVLink 2 frames are forwarded unchanged. |
 | Target inference | Supported | Generated metadata classifies broadcast, system, component, and system-component targets from `target_system` and `target_component` fields. |
 | Route reset after reboot | Partial | Routing learns source system/component locations but does not yet clear routes on `SYSTEM_TIME.time_boot_ms` decrease. |
 | XML includes | Partial | Includes are recursive and deterministic, but missing include errors and duplicate handling are not yet aligned with `mavgen`. |
@@ -83,6 +84,8 @@ Known non-goals for 1.0 unless separately implemented:
 - Inbound router and connection signing policy can verify signed MAVLink 2
   frames before unpacking, track replay state per connection, and reject
   unsigned MAVLink 2 frames by default while signing is enabled.
+- Outbound router signing can sign unsigned MAVLink 2 frames on signing-enabled
+  connections while leaving MAVLink 1 frames unsigned.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -92,8 +95,8 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #47: Continue MAVLink 2 packet signing with outbound signing, timestamp
-  persistence hooks, and `SETUP_SIGNING` handling.
+- #47: Continue MAVLink 2 packet signing with timestamp persistence hooks and
+  `SETUP_SIGNING` handling.
 - #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
   known system/component.
 - #53: Align XML parser/generator validation with `mavgen` for missing

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library includes a mix task that generates code from MAVLink XML
 definition files and an application that enables communication with other
 systems using MAVLink 1 frames, unsigned MAVLink 2 frames, and configured
-inbound signed MAVLink 2 frames over serial, UDP, and outbound TCP connections.
+signed MAVLink 2 frames over serial, UDP, and outbound TCP connections.
 
 MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk,
 ArduPilot and other leading autopilot platforms. For more information
@@ -50,17 +50,16 @@ This library is not officially recognised or supported by MAVLink at this
 time.
 
 XMAVLink parses and emits MAVLink 1 frames and unsigned MAVLink 2 frames.
-Router-level MAVLink 2 signing can be configured for inbound frames with a
-32-byte key, link id, and local timestamp. Signed inbound frames are verified
-before unpacking, replay timestamps are tracked per connection, and unsigned
-MAVLink 2 inbound frames are rejected by default while signing is enabled unless
-`accept_unsigned: true` is set. MAVLink 1 inbound frames remain accepted under a
-signing policy. Outbound signing is not wired yet; the low-level
-`XMAVLink.Frame.sign_frame/4` helper can generate signed MAVLink 2 frame bytes
-for already packed frames. MAVLink 2 frames with other incompatible flags are
-discarded. Supported configured transports are serial, UDP client (`udpout`),
-UDP server (`udpin`), and TCP client (`tcpout`). TCP server (`tcpin`)
-connections are not implemented.
+Router-level MAVLink 2 signing can be configured with a 32-byte key, link id,
+and local timestamp. Signed inbound frames are verified before unpacking, replay
+timestamps are tracked per connection, and unsigned MAVLink 2 inbound frames are
+rejected by default while signing is enabled unless `accept_unsigned: true` is
+set. Unsigned outbound MAVLink 2 frames sent over a signing-enabled connection
+are signed with a monotonically incremented per-connection timestamp. MAVLink 1
+inbound and outbound frames remain unsigned and accepted under a signing policy.
+MAVLink 2 frames with other incompatible flags are discarded. Supported
+configured transports are serial, UDP client (`udpout`), UDP server (`udpin`),
+and TCP client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,13 +23,15 @@ Current trust boundaries:
 
 - MAVLink 1 and unsigned MAVLink 2 frames are parsed and routed when signing is
   not configured.
-- Router-level MAVLink 2 signing can be configured for inbound frames. Signed
+- Router-level MAVLink 2 signing can be configured for connections. Signed
   frames are verified before unpacking, replay timestamps are tracked per
   connection, and unsigned MAVLink 2 inbound frames are rejected by default
   while signing is enabled unless `accept_unsigned: true` is set. MAVLink 1
-  inbound frames remain accepted under a signing policy. Outbound signing and
-  timestamp persistence hooks are not wired yet. Frames with other incompatible
-  MAVLink 2 flags are discarded.
+  inbound frames remain accepted under a signing policy. Unsigned outbound
+  MAVLink 2 frames sent over signing-enabled connections are signed with a
+  monotonically incremented per-connection timestamp. Timestamp persistence
+  hooks are not wired yet. Frames with other incompatible MAVLink 2 flags are
+  discarded.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -916,13 +916,13 @@ defmodule XMAVLink.Router do
          {:ok, source_connection_key, frame = %Frame{target: :broadcast},
           state = %Router{connections: connections}}
        ) do
-    for {connection_key, connection} <- connections do
+    Enum.reduce(connections, state, fn {connection_key, connection}, routed_state ->
       if match?(:local, connection_key) or !match?(^connection_key, source_connection_key) do
-        forward(connection, frame)
+        forward_and_update(connection_key, connection, frame, routed_state)
+      else
+        routed_state
       end
-    end
-
-    state
+    end)
   end
 
   # Only send targeted messages to observed system/components and local.
@@ -959,11 +959,14 @@ defmodule XMAVLink.Router do
         )
     end
 
-    for connection_key <- recipients do
-      forward(connections[connection_key], frame)
-    end
-
-    state
+    Enum.reduce(recipients, state, fn connection_key, routed_state ->
+      forward_and_update(
+        connection_key,
+        routed_state.connections[connection_key],
+        frame,
+        routed_state
+      )
+    end)
   end
 
   # Swallow any errors from the handle_info |> update_connection_info pipeline
@@ -986,19 +989,52 @@ defmodule XMAVLink.Router do
     ]
   end
 
+  defp forward_and_update(_connection_key, nil, _frame, state), do: state
+
+  defp forward_and_update(connection_key, connection, frame, state) do
+    updated_connection = forward(connection, frame)
+    put_in(state.connections[connection_key], updated_connection)
+  end
+
+  defp forward(connection, frame) do
+    case outbound_frame(connection, frame) do
+      {:ok, updated_connection, outbound_frame} ->
+        _ = forward_raw(updated_connection, outbound_frame)
+        updated_connection
+
+      {:error, reason, updated_connection} ->
+        Logger.debug("Could not sign outbound MAVLink frame: #{inspect(reason)}")
+        updated_connection
+    end
+  end
+
+  defp outbound_frame(connection, frame) do
+    if Map.has_key?(connection, :signing) do
+      case Signing.sign_outbound(frame, connection.signing) do
+        {:ok, outbound_frame, signing} ->
+          {:ok, struct(connection, signing: signing), outbound_frame}
+
+        {:error, reason, signing} ->
+          {:error, reason, struct(connection, signing: signing)}
+      end
+    else
+      {:ok, connection, frame}
+    end
+  end
+
   # Delegate sending a message to connection-type specific code
-  defp forward(connection = %UDPInConnection{}, frame),
+  defp forward_raw(connection = %UDPInConnection{}, frame),
     do: UDPInConnection.forward(connection, frame)
 
-  defp forward(connection = %UDPOutConnection{}, frame),
+  defp forward_raw(connection = %UDPOutConnection{}, frame),
     do: UDPOutConnection.forward(connection, frame)
 
-  defp forward(connection = %TCPOutConnection{}, frame),
+  defp forward_raw(connection = %TCPOutConnection{}, frame),
     do: TCPOutConnection.forward(connection, frame)
 
-  defp forward(connection = %SerialConnection{}, frame),
+  defp forward_raw(connection = %SerialConnection{}, frame),
     do: SerialConnection.forward(connection, frame)
 
-  defp forward(connection = %LocalConnection{}, frame),
+  defp forward_raw(connection = %LocalConnection{}, frame),
     do: LocalConnection.forward(connection, frame)
 end

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -2,10 +2,9 @@ defmodule XMAVLink.Signing do
   @moduledoc """
   Stateful MAVLink 2 signing policy helpers.
 
-  This module validates parsed signed frames against a shared key and tracks
-  inbound replay state by `{source_system, source_component, link_id}`. It is
-  intentionally independent from router/connection wiring so the policy can be
-  tested before transports start accepting signed traffic.
+  This module validates parsed signed frames against a shared key, tracks
+  inbound replay state by `{source_system, source_component, link_id}`, and
+  signs unsigned outbound MAVLink 2 frames with a per-connection timestamp.
   """
 
   alias XMAVLink.Frame
@@ -48,6 +47,20 @@ defmodule XMAVLink.Signing do
           | :signed_frame_unsupported
           | :unsigned_frame
           | :unsigned_frame_rejected
+
+  @type sign_error ::
+          :already_signed
+          | :checksum_invalid
+          | :invalid_crc_extra
+          | :invalid_link_id
+          | :invalid_mavlink_2_frame
+          | :invalid_secret_key
+          | :invalid_timestamp
+          | :mavlink_1_not_signable
+          | :missing_crc_extra
+          | :missing_mavlink_2_raw
+          | :timestamp_exhausted
+          | :unsupported_incompatible_flags
 
   @spec new(nil | keyword()) :: {:ok, t | nil} | {:error, new_error}
   def new(nil), do: {:ok, nil}
@@ -104,6 +117,27 @@ defmodule XMAVLink.Signing do
     end
   end
 
+  @spec sign_outbound(Frame.t(), t | nil) ::
+          {:ok, Frame.t(), t | nil} | {:error, sign_error, t | nil}
+  def sign_outbound(frame = %Frame{}, nil), do: {:ok, frame, nil}
+
+  def sign_outbound(frame = %Frame{version: 1}, signing = %Signing{}),
+    do: {:ok, frame, signing}
+
+  def sign_outbound(frame = %Frame{version: 2}, signing = %Signing{}) do
+    if Frame.signed?(frame) do
+      {:ok, frame, signing}
+    else
+      with {:ok, timestamp} <- next_outbound_timestamp(signing),
+           {:ok, signed_frame} <-
+             Frame.sign_frame(frame, signing.secret_key, signing.link_id, timestamp) do
+        {:ok, signed_frame, %Signing{signing | timestamp: timestamp}}
+      else
+        {:error, reason} -> {:error, reason, signing}
+      end
+    end
+  end
+
   @spec now_timestamp() :: 0..281_474_976_710_655
   def now_timestamp do
     timestamp =
@@ -149,6 +183,11 @@ defmodule XMAVLink.Signing do
         end
     end
   end
+
+  defp next_outbound_timestamp(%Signing{timestamp: @signature_timestamp_max}),
+    do: {:error, :timestamp_exhausted}
+
+  defp next_outbound_timestamp(%Signing{timestamp: timestamp}), do: {:ok, timestamp + 1}
 
   defp record_inbound_timestamp(
          frame = %Frame{signature: %{timestamp: timestamp}},

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -124,17 +124,21 @@ defmodule XMAVLink.Signing do
   def sign_outbound(frame = %Frame{version: 1}, signing = %Signing{}),
     do: {:ok, frame, signing}
 
+  def sign_outbound(
+        frame = %Frame{version: 2, signature: %{timestamp: timestamp}},
+        signing = %Signing{}
+      )
+      when is_integer(timestamp) do
+    {:ok, frame, %Signing{signing | timestamp: max(signing.timestamp, timestamp)}}
+  end
+
   def sign_outbound(frame = %Frame{version: 2}, signing = %Signing{}) do
-    if Frame.signed?(frame) do
-      {:ok, frame, signing}
+    with {:ok, timestamp} <- next_outbound_timestamp(signing),
+         {:ok, signed_frame} <-
+           Frame.sign_frame(frame, signing.secret_key, signing.link_id, timestamp) do
+      {:ok, signed_frame, %Signing{signing | timestamp: timestamp}}
     else
-      with {:ok, timestamp} <- next_outbound_timestamp(signing),
-           {:ok, signed_frame} <-
-             Frame.sign_frame(frame, signing.secret_key, signing.link_id, timestamp) do
-        {:ok, signed_frame, %Signing{signing | timestamp: timestamp}}
-      else
-        {:error, reason} -> {:error, reason, signing}
-      end
+      {:error, reason} -> {:error, reason, signing}
     end
   end
 

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -731,6 +731,95 @@ defmodule XMAVLink.Test.Router do
     end
   end
 
+  describe "outbound signing policy" do
+    test "signs outbound MAVLink 2 frames on signing-enabled UDP connections" do
+      {udp_socket, udp_port} = open_udp_socket()
+      :ok = :inet.setopts(udp_socket, active: true)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:#{udp_port}"],
+            signing: [
+              secret_key: @secret_key,
+              link_id: @link_id,
+              timestamp: @local_timestamp
+            ]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(udp_socket)
+        stop_router(router_pid)
+      end)
+
+      udpout_socket = wait_for_udpout_socket(router_pid)
+
+      assert :ok = Router.pack_and_send(router_pid, sample_heartbeat(), 2)
+
+      assert_receive {:udp, ^udp_socket, {127, 0, 0, 1}, _source_port, raw}, 500
+      assert {%Frame{} = frame, <<>>} = Frame.binary_to_frame_and_tail(raw)
+      assert Frame.signed?(frame)
+      assert frame.signature.link_id == @link_id
+      assert frame.signature.timestamp == @local_timestamp + 1
+      assert :ok = Frame.validate_signature(frame, @secret_key)
+
+      state = :sys.get_state(router_pid)
+      assert state.connections[udpout_socket].signing.timestamp == @local_timestamp + 1
+
+      assert :ok = Router.pack_and_send(router_pid, sample_heartbeat(), 2)
+
+      assert_receive {:udp, ^udp_socket, {127, 0, 0, 1}, _source_port, raw}, 500
+      assert {%Frame{} = frame, <<>>} = Frame.binary_to_frame_and_tail(raw)
+      assert frame.signature.timestamp == @local_timestamp + 2
+
+      state = :sys.get_state(router_pid)
+      assert state.connections[udpout_socket].signing.timestamp == @local_timestamp + 2
+    end
+
+    test "keeps outbound MAVLink 1 frames unsigned when signing is enabled" do
+      {udp_socket, udp_port} = open_udp_socket()
+      :ok = :inet.setopts(udp_socket, active: true)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:#{udp_port}"],
+            signing: [
+              secret_key: @secret_key,
+              link_id: @link_id,
+              timestamp: @local_timestamp
+            ]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(udp_socket)
+        stop_router(router_pid)
+      end)
+
+      udpout_socket = wait_for_udpout_socket(router_pid)
+
+      assert :ok = Router.pack_and_send(router_pid, sample_heartbeat(), 1)
+
+      assert_receive {:udp, ^udp_socket, {127, 0, 0, 1}, _source_port, <<0xFE, _rest::binary>>},
+                     500
+
+      state = :sys.get_state(router_pid)
+      assert state.connections[udpout_socket].signing.timestamp == @local_timestamp
+    end
+  end
+
   describe "subscribe/1" do
     test "is synchronous - subscription is committed when call returns" do
       {udp_socket, udp_port} = open_udp_socket()

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -149,6 +149,54 @@ defmodule XMAVLink.Test.Signing do
     end
   end
 
+  describe "sign_outbound/2" do
+    test "signs unsigned MAVLink 2 frames with the next local timestamp" do
+      frame = unsigned_frame()
+      signing = signing()
+
+      assert {:ok, signed_frame, updated_signing} = Signing.sign_outbound(frame, signing)
+      assert Frame.signed?(signed_frame)
+      assert signed_frame.signature.link_id == @link_id
+      assert signed_frame.signature.timestamp == @local_timestamp + 1
+      assert updated_signing.timestamp == @local_timestamp + 1
+      assert :ok = Frame.validate_signature(signed_frame, @secret_key)
+
+      assert {:ok, newer_frame, newer_signing} =
+               Signing.sign_outbound(unsigned_frame(), updated_signing)
+
+      assert newer_frame.signature.timestamp == @local_timestamp + 2
+      assert newer_signing.timestamp == @local_timestamp + 2
+    end
+
+    test "leaves MAVLink 1 and already signed frames unchanged" do
+      mavlink_1_frame =
+        Frame.pack_frame(%Frame{
+          version: 1,
+          sequence_number: 7,
+          source_system: 1,
+          source_component: 1,
+          message_id: 24,
+          payload: <<1, 2, 3>>,
+          crc_extra: 0
+        })
+
+      signing = signing()
+
+      assert {:ok, ^mavlink_1_frame, ^signing} = Signing.sign_outbound(mavlink_1_frame, signing)
+
+      signed_frame = signed_frame(@valid_timestamp)
+
+      assert {:ok, ^signed_frame, ^signing} = Signing.sign_outbound(signed_frame, signing)
+    end
+
+    test "rejects outbound signing when the timestamp space is exhausted" do
+      %Signing{} = signing = %{signing() | timestamp: 0xFFFF_FFFF_FFFF}
+
+      assert {:error, :timestamp_exhausted, ^signing} =
+               Signing.sign_outbound(unsigned_frame(), signing)
+    end
+  end
+
   defp signing do
     {:ok, signing} =
       Signing.new(

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -168,7 +168,7 @@ defmodule XMAVLink.Test.Signing do
       assert newer_signing.timestamp == @local_timestamp + 2
     end
 
-    test "leaves MAVLink 1 and already signed frames unchanged" do
+    test "leaves MAVLink 1 frames unsigned and unchanged" do
       mavlink_1_frame =
         Frame.pack_frame(%Frame{
           version: 1,
@@ -183,10 +183,21 @@ defmodule XMAVLink.Test.Signing do
       signing = signing()
 
       assert {:ok, ^mavlink_1_frame, ^signing} = Signing.sign_outbound(mavlink_1_frame, signing)
+    end
 
+    test "leaves already signed frames unchanged and catches up local timestamp" do
+      signing = signing()
       signed_frame = signed_frame(@valid_timestamp)
 
-      assert {:ok, ^signed_frame, ^signing} = Signing.sign_outbound(signed_frame, signing)
+      assert {:ok, ^signed_frame, updated_signing} =
+               Signing.sign_outbound(signed_frame, signing)
+
+      assert updated_signing.timestamp == @valid_timestamp
+
+      newer_signing = %{signing | timestamp: @valid_timestamp + 1}
+
+      assert {:ok, ^signed_frame, ^newer_signing} =
+               Signing.sign_outbound(signed_frame, newer_signing)
     end
 
     test "rejects outbound signing when the timestamp space is exhausted" do

--- a/test/mavlink_util_command_test.exs
+++ b/test/mavlink_util_command_test.exs
@@ -126,11 +126,13 @@ defmodule XMAVLink.Util.CommandTest do
   end
 
   defp stop_router(router) do
-    if Process.alive?(router) do
-      GenServer.stop(router)
+    try do
+      if Process.alive?(router) do
+        GenServer.stop(router)
+      end
+    catch
+      :exit, {:noproc, _} -> :ok
+      :exit, {:normal, _} -> :ok
     end
-  catch
-    :exit, {:noproc, _} -> :ok
-    :exit, {:normal, _} -> :ok
   end
 end

--- a/test/mavlink_util_command_test.exs
+++ b/test/mavlink_util_command_test.exs
@@ -20,9 +20,7 @@ defmodule XMAVLink.Util.CommandTest do
         connection_strings: []
       })
 
-    on_exit(fn ->
-      if Process.alive?(router), do: GenServer.stop(router)
-    end)
+    on_exit(fn -> stop_router(router) end)
 
     {:ok, router: router}
   end
@@ -125,5 +123,14 @@ defmodule XMAVLink.Util.CommandTest do
     for table <- [:messages, :systems, :params, :sessions], :ets.info(table) != :undefined do
       :ets.delete(table)
     end
+  end
+
+  defp stop_router(router) do
+    if Process.alive?(router) do
+      GenServer.stop(router)
+    end
+  catch
+    :exit, {:noproc, _} -> :ok
+    :exit, {:normal, _} -> :ok
   end
 end


### PR DESCRIPTION
## Summary

- Adds `XMAVLink.Signing.sign_outbound/2` to sign unsigned MAVLink 2 frames with the next per-connection timestamp.
- Updates router forwarding to sign frames on signing-enabled connections and store the updated signing timestamp in router connection state.
- Keeps MAVLink 1 outbound frames unsigned and forwards already signed MAVLink 2 frames unchanged.
- Adds focused signing/router coverage for timestamp increments and outbound UDP signing behavior.
- Updates signing/security/spec docs to reflect outbound signing support and leave timestamp persistence plus `SETUP_SIGNING` handling as remaining #47 work.

Refs #47.

## Validation

- `mix format`
- `mix test test/mavlink_signing_test.exs test/mavlink_router_test.exs test/mavlink_udp_connection_test.exs`
- `mix test`
- `mix compile --warnings-as-errors --force`
- `mix dialyzer`
- `git diff --check`