### PR TITLE
Complete MAVLink 2 signing follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   and reject unsigned MAVLink 2 frames by default while signing is enabled.
 - Added outbound router signing for unsigned MAVLink 2 frames sent over
   signing-enabled connections, with per-connection timestamp increments.
+- Added MAVLink 2 signing timestamp load/save callbacks so applications can
+  persist local signing timestamps across restarts.
+- Made inbound `SETUP_SIGNING` frames local-only so key material is not
+  forwarded between MAVLink links by generic routing.
 
 ## 0.11.1 - 2026-05-08
 

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -23,24 +23,33 @@ state needed for replay protection by tracking the last accepted timestamp per
 streams more than 6,000,000 ticks behind the local signing timestamp.
 
 Routers accept a `:signing` configuration with `:secret_key`, `:link_id`,
-`:timestamp`, and optional `:accept_unsigned`. Receive paths seed each
-connection with that policy. Configured signed MAVLink 2 frames are verified
-before dialect unpacking, delivered to subscribers, forwarded through the normal
-routing logic, and recorded for replay protection. Unsigned MAVLink 2 inbound
-frames are rejected by default while signing is enabled unless
-`accept_unsigned: true` is set. MAVLink 1 frames remain accepted under a signing
-policy. When signing is not configured, signed MAVLink 2 frames still return
-`:signed_frame_unsupported`.
+`:timestamp`, optional `:accept_unsigned`, and optional timestamp persistence
+callbacks. Receive paths seed each connection with that policy. Configured
+signed MAVLink 2 frames are verified before dialect unpacking, delivered to
+subscribers, forwarded through the normal routing logic, and recorded for replay
+protection. Unsigned MAVLink 2 inbound frames are rejected by default while
+signing is enabled unless `accept_unsigned: true` is set. MAVLink 1 frames
+remain accepted under a signing policy. When signing is not configured, signed
+MAVLink 2 frames still return `:signed_frame_unsupported`.
 
 Outbound routing signs unsigned MAVLink 2 frames on signing-enabled
 connections, updates that connection's local timestamp after each signed send,
 and leaves MAVLink 1 frames unsigned. Already signed MAVLink 2 frames are
-forwarded with their existing signature rather than being re-signed.
+forwarded with their existing signature rather than being re-signed. If a
+timestamp save callback is configured and the local timestamp advances, the
+callback must succeed before a signed inbound frame is accepted or an outbound
+signed frame is emitted.
 
 Unknown incompatible flags are still rejected. If a frame has both the signing
 flag and unsupported incompatible flags, XMAVLink consumes the known 13-byte
 signature trailer when present so stream transports keep frame boundaries, but
 the packet is not accepted.
+
+`SETUP_SIGNING` frames carry key material. Inbound `SETUP_SIGNING` frames are
+delivered to local subscribers but are not forwarded from one MAVLink connection
+to another by generic routing. Locally originated `SETUP_SIGNING` frames are
+still routed normally so applications can build an intentional provisioning
+flow, but XMAVLink does not automate key provisioning or key rotation.
 
 ## Signature Frame Shape
 
@@ -66,14 +75,21 @@ Signing is currently configured per router and copied into each connection:
   sign unsigned outbound MAVLink 2 frames on each connection.
 - `accept_unsigned: false | true`: explicit policy for unsigned frames when
   signing is enabled. The policy helper defaults to reject.
+- `timestamp_load: fun | {module, function, args}`: optional zero-arity callback
+  that returns a previously saved timestamp, `{:ok, timestamp}`, or `nil` when
+  no timestamp has been saved yet. Loaded timestamps are combined with the
+  configured or current timestamp by taking the maximum value. `:error`,
+  `{:error, reason}`, invalid timestamps, or callback failures reject the
+  signing configuration.
+- `timestamp_save: fun | {module, function, args}`: optional one-arity callback
+  that receives each advanced local timestamp and returns `:ok` or
+  `{:ok, result}`. MFA callbacks receive the timestamp appended to `args`.
+  Save failures return `:timestamp_save_failed` to the caller and prevent that
+  state-advancing frame from being accepted or emitted.
 
-## Required Follow-Up Work
+## Operational Notes
 
-1. Persistence hooks:
-   - expose timestamp load/save integration points;
-   - document that applications must store keys and timestamps securely.
-2. `SETUP_SIGNING` handling:
-   - avoid forwarding `SETUP_SIGNING` from a secure link to other links;
-   - document any explicit provisioning workflow XMAVLink supports.
-
-Each step should land with focused tests before #47 is closed.
+Applications are responsible for storing shared keys and persisted timestamps
+securely. Timestamp persistence callbacks should write to durable storage before
+returning `:ok`; otherwise XMAVLink will treat the save as failed and reject
+the state-advancing frame.

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -24,14 +24,17 @@ Supported runtime scope:
 - MAVLink 2 signed-frame boundary parsing and signature trailer
   representation. Configured inbound signed frames are authenticated before
   unpacking and routed with replay protection, and unsigned outbound MAVLink 2
-  frames are signed on signing-enabled connections.
+  frames are signed on signing-enabled connections. Applications can configure
+  timestamp load/save callbacks for local signing timestamp persistence. Inbound
+  `SETUP_SIGNING` frames are delivered locally but not forwarded between MAVLink
+  connections.
 - MAVLink 1 frames for existing users and legacy links.
 - Serial, `udpin`, `udpout`, and outbound TCP (`tcpout`) transports.
 - Generated dialect modules from trusted MAVLink XML build inputs.
 
 Known non-goals for 1.0 unless separately implemented:
 
-- Signing timestamp persistence.
+- Automatic `SETUP_SIGNING` key provisioning.
 - TCP server (`tcpin`) transport.
 - Treating untrusted XML dialect files as safe input.
 - Full `mavgen` feature parity for XML validation, WIP filtering, and every
@@ -42,7 +45,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Area | Status | Notes |
 | --- | --- | --- |
 | MAVLink 2 frame shape | Supported | Parses and emits the v2 header, 24-bit message id, payload, checksum, and compatible flags. Unsupported incompatible flags are discarded. |
-| MAVLink 2 signing | Partial | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Configured inbound signed frames are verified before unpacking and routed with per-connection replay checks. Unsigned MAVLink 2 inbound frames are rejected by default while signing is enabled unless explicitly accepted. Unsigned outbound MAVLink 2 frames are signed on signing-enabled connections with per-connection timestamp increments. Timestamp persistence remains follow-up work. See #47 and `MAVLINK2_SIGNING.md`. |
+| MAVLink 2 signing | Supported with provisioning caveat | Signed-frame boundaries and the 13-byte signature trailer are parsed and represented. Configured inbound signed frames are verified before unpacking and routed with per-connection replay checks. Unsigned MAVLink 2 inbound frames are rejected by default while signing is enabled unless explicitly accepted. Unsigned outbound MAVLink 2 frames are signed on signing-enabled connections with per-connection timestamp increments. Optional timestamp load/save callbacks let applications persist local signing timestamps. Inbound `SETUP_SIGNING` frames are local-only; XMAVLink does not automate key provisioning. See `MAVLINK2_SIGNING.md`. |
 | MAVLink 2 payload truncation | Supported | Outbound payloads trim trailing zero bytes while preserving a non-empty all-zero payload's first byte; inbound v2 payloads are padded back to known dialect length before unpacking. |
 | MAVLink 2 future extension bytes | Supported | Generated v2 unpack clauses now ignore trailing extension bytes that are unknown to the local dialect. This preserves extension-field forward compatibility. |
 | MAVLink 2 extension CRC behavior | Supported | `CRC_EXTRA` generation excludes extension fields, matching the serialization guide. |
@@ -52,7 +55,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Field ordering | Supported | Base fields are stably sorted by native type size; extension fields remain in XML declaration order. |
 | Unknown message handling | Partial | Unknown known-shape frames are forwarded as broadcast when the message id is not present in the dialect. Unknown messages cannot expose target fields because the payload cannot be decoded. |
 | Compatible flags | Supported | MAVLink 2 compatible flags are retained and otherwise ignored. |
-| Incompatible flags | Partial | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed, but full signing support is tracked separately. |
+| Incompatible flags | Supported | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed when present so stream boundaries stay aligned. |
 | Routing unchanged packets | Supported with signing caveat | Forwarding generally uses the original raw frame bytes. Unsigned MAVLink 2 frames sent over signing-enabled connections are signed for that outbound link; already signed MAVLink 2 frames are forwarded unchanged. |
 | Target inference | Supported | Generated metadata classifies broadcast, system, component, and system-component targets from `target_system` and `target_component` fields. |
 | Route reset after reboot | Partial | Routing learns source system/component locations but does not yet clear routes on `SYSTEM_TIME.time_boot_ms` decrease. |
@@ -86,6 +89,11 @@ Known non-goals for 1.0 unless separately implemented:
   unsigned MAVLink 2 frames by default while signing is enabled.
 - Outbound router signing can sign unsigned MAVLink 2 frames on signing-enabled
   connections while leaving MAVLink 1 frames unsigned.
+- Signing policy can load and save local signing timestamps through application
+  callbacks, and rejects state-advancing frames when configured persistence
+  fails.
+- Inbound `SETUP_SIGNING` frames are delivered locally but not forwarded between
+  MAVLink connections by generic routing.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -95,8 +103,6 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #47: Continue MAVLink 2 packet signing with timestamp persistence hooks and
-  `SETUP_SIGNING` handling.
 - #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
   known system/component.
 - #53: Align XML parser/generator validation with `mavgen` for missing

--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ rejected by default while signing is enabled unless `accept_unsigned: true` is
 set. Unsigned outbound MAVLink 2 frames sent over a signing-enabled connection
 are signed with a monotonically incremented per-connection timestamp. MAVLink 1
 inbound and outbound frames remain unsigned and accepted under a signing policy.
-MAVLink 2 frames with other incompatible flags are discarded. Supported
-configured transports are serial, UDP client (`udpout`), UDP server (`udpin`),
-and TCP client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
+Applications can configure timestamp load/save callbacks to preserve local
+signing timestamps across restarts. Inbound `SETUP_SIGNING` frames are delivered
+locally but are not forwarded between MAVLink links by generic routing. MAVLink
+2 frames with other incompatible flags are discarded. Supported configured
+transports are serial, UDP client (`udpout`), UDP server (`udpin`), and TCP
+client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,12 @@ Current trust boundaries:
   while signing is enabled unless `accept_unsigned: true` is set. MAVLink 1
   inbound frames remain accepted under a signing policy. Unsigned outbound
   MAVLink 2 frames sent over signing-enabled connections are signed with a
-  monotonically incremented per-connection timestamp. Timestamp persistence
-  hooks are not wired yet. Frames with other incompatible MAVLink 2 flags are
-  discarded.
+  monotonically incremented per-connection timestamp. Applications can configure
+  timestamp load/save hooks to preserve local signing timestamps across
+  restarts. Frames with other incompatible MAVLink 2 flags are discarded.
+- `SETUP_SIGNING` frames carry key material. Inbound `SETUP_SIGNING` frames are
+  delivered locally for application handling but are not forwarded from one
+  MAVLink connection to another by the generic router.
 - UDP listeners should be exposed only to trusted networks unless the application
   adds network-level filtering or validates peers at a higher layer.
 - Utility processes are opt-in. When enabled, `CacheManager` subscribes to

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -30,6 +30,8 @@ defmodule XMAVLink.Router do
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
 
+  @setup_signing_message_id 256
+
   @typedoc """
   Represents the state of the XMAVLink.Router. Initial values should be set in config.exs.
 
@@ -908,6 +910,17 @@ defmodule XMAVLink.Router do
       )
       |> track_connection_worker(connection_key, connection)
     }
+  end
+
+  # SETUP_SIGNING carries key material. Inbound provisioning messages are
+  # delivered locally for application handling, but never bridged to another
+  # MAVLink connection by generic routing.
+  defp route(
+         {:ok, source_connection_key, frame = %Frame{message_id: @setup_signing_message_id},
+          state = %Router{connections: connections}}
+       )
+       when source_connection_key != :local do
+    forward_and_update(:local, connections.local, frame, state)
   end
 
   # Broadcast un-targeted messages to all connections except the

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -5,6 +5,8 @@ defmodule XMAVLink.Signing do
   This module validates parsed signed frames against a shared key, tracks
   inbound replay state by `{source_system, source_component, link_id}`, and
   signs unsigned outbound MAVLink 2 frames with a per-connection timestamp.
+  Optional timestamp load/save callbacks let applications preserve the local
+  signing timestamp across restarts.
   """
 
   alias XMAVLink.Frame
@@ -17,16 +19,26 @@ defmodule XMAVLink.Signing do
   defstruct secret_key: nil,
             link_id: nil,
             timestamp: nil,
+            timestamp_load: nil,
+            timestamp_save: nil,
             accept_unsigned: false,
             stream_timestamps: %{}
 
+  @type timestamp :: 0..281_474_976_710_655
   @type stream_key :: {0..255, 0..255, 0..255}
+  @type timestamp_load_result ::
+          timestamp | {:ok, timestamp | nil} | nil | :error | {:error, term}
+  @type timestamp_save_result :: :ok | {:ok, term} | :error | {:error, term}
+  @type timestamp_load :: (-> timestamp_load_result) | {module, atom, [term]}
+  @type timestamp_save :: (timestamp -> timestamp_save_result) | {module, atom, [term]}
   @type t :: %Signing{
           secret_key: <<_::256>>,
           link_id: 0..255,
-          timestamp: 0..281_474_976_710_655,
+          timestamp: timestamp,
+          timestamp_load: timestamp_load | nil,
+          timestamp_save: timestamp_save | nil,
           accept_unsigned: boolean,
-          stream_timestamps: %{stream_key() => 0..281_474_976_710_655}
+          stream_timestamps: %{stream_key() => timestamp}
         }
 
   @type new_error ::
@@ -35,8 +47,11 @@ defmodule XMAVLink.Signing do
           | :invalid_link_id
           | :invalid_secret_key
           | :invalid_timestamp
+          | :invalid_timestamp_load
+          | :invalid_timestamp_save
           | :missing_link_id
           | :missing_secret_key
+          | :timestamp_load_failed
 
   @type validate_error ::
           :invalid_mavlink_2_frame
@@ -45,6 +60,7 @@ defmodule XMAVLink.Signing do
           | :signature_replay
           | :signature_too_old
           | :signed_frame_unsupported
+          | :timestamp_save_failed
           | :unsigned_frame
           | :unsigned_frame_rejected
 
@@ -59,6 +75,7 @@ defmodule XMAVLink.Signing do
           | :mavlink_1_not_signable
           | :missing_crc_extra
           | :missing_mavlink_2_raw
+          | :timestamp_save_failed
           | :timestamp_exhausted
           | :unsupported_incompatible_flags
 
@@ -78,7 +95,10 @@ defmodule XMAVLink.Signing do
   defp new_keyword(opts) do
     with {:ok, secret_key} <- fetch_secret_key(opts),
          {:ok, link_id} <- fetch_link_id(opts),
-         {:ok, timestamp} <- validate_timestamp(Keyword.get(opts, :timestamp, now_timestamp())),
+         {:ok, timestamp_load} <- validate_timestamp_load(Keyword.get(opts, :timestamp_load)),
+         {:ok, timestamp_save} <- validate_timestamp_save(Keyword.get(opts, :timestamp_save)),
+         {:ok, timestamp} <-
+           initial_timestamp(Keyword.get_lazy(opts, :timestamp, &now_timestamp/0), timestamp_load),
          {:ok, accept_unsigned} <-
            validate_accept_unsigned(Keyword.get(opts, :accept_unsigned, false)) do
       {:ok,
@@ -86,6 +106,8 @@ defmodule XMAVLink.Signing do
          secret_key: secret_key,
          link_id: link_id,
          timestamp: timestamp,
+         timestamp_load: timestamp_load,
+         timestamp_save: timestamp_save,
          accept_unsigned: accept_unsigned
        }}
     end
@@ -129,20 +151,30 @@ defmodule XMAVLink.Signing do
         signing = %Signing{}
       )
       when is_integer(timestamp) do
-    {:ok, frame, %Signing{signing | timestamp: max(signing.timestamp, timestamp)}}
+    signing
+    |> update_timestamp(max(signing.timestamp, timestamp))
+    |> persist_if_timestamp_changed(signing)
+    |> case do
+      {:ok, updated_signing} -> {:ok, frame, updated_signing}
+      {:error, reason} -> {:error, reason, signing}
+    end
   end
 
   def sign_outbound(frame = %Frame{version: 2}, signing = %Signing{}) do
     with {:ok, timestamp} <- next_outbound_timestamp(signing),
          {:ok, signed_frame} <-
-           Frame.sign_frame(frame, signing.secret_key, signing.link_id, timestamp) do
-      {:ok, signed_frame, %Signing{signing | timestamp: timestamp}}
+           Frame.sign_frame(frame, signing.secret_key, signing.link_id, timestamp),
+         {:ok, updated_signing} <-
+           signing
+           |> update_timestamp(timestamp)
+           |> persist_if_timestamp_changed(signing) do
+      {:ok, signed_frame, updated_signing}
     else
       {:error, reason} -> {:error, reason, signing}
     end
   end
 
-  @spec now_timestamp() :: 0..281_474_976_710_655
+  @spec now_timestamp() :: timestamp
   def now_timestamp do
     timestamp =
       (System.os_time(:microsecond) - @mavlink_epoch_unix_microseconds)
@@ -155,8 +187,10 @@ defmodule XMAVLink.Signing do
 
   defp validate_signed_inbound(frame, signing) do
     with :ok <- Frame.validate_signature(frame, signing.secret_key),
-         :ok <- validate_inbound_timestamp(frame, signing) do
-      {:ok, frame, record_inbound_timestamp(frame, signing)}
+         :ok <- validate_inbound_timestamp(frame, signing),
+         updated_signing = record_inbound_timestamp(frame, signing),
+         {:ok, persisted_signing} <- persist_if_timestamp_changed(updated_signing, signing) do
+      {:ok, frame, persisted_signing}
     else
       {:error, reason} -> {:error, reason, signing}
     end
@@ -192,6 +226,20 @@ defmodule XMAVLink.Signing do
     do: {:error, :timestamp_exhausted}
 
   defp next_outbound_timestamp(%Signing{timestamp: timestamp}), do: {:ok, timestamp + 1}
+
+  defp update_timestamp(signing = %Signing{}, timestamp),
+    do: %Signing{signing | timestamp: timestamp}
+
+  defp persist_if_timestamp_changed(updated_signing, %Signing{timestamp: same_timestamp})
+       when updated_signing.timestamp == same_timestamp,
+       do: {:ok, updated_signing}
+
+  defp persist_if_timestamp_changed(updated_signing, _previous_signing) do
+    case save_timestamp(updated_signing.timestamp_save, updated_signing.timestamp) do
+      :ok -> {:ok, updated_signing}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   defp record_inbound_timestamp(
          frame = %Frame{signature: %{timestamp: timestamp}},
@@ -238,6 +286,77 @@ defmodule XMAVLink.Signing do
     end
   end
 
+  defp initial_timestamp(configured_timestamp, timestamp_load) do
+    with {:ok, configured_timestamp} <- validate_timestamp(configured_timestamp),
+         {:ok, loaded_timestamp} <- load_timestamp(timestamp_load),
+         {:ok, timestamp} <- resolve_initial_timestamp(configured_timestamp, loaded_timestamp) do
+      {:ok, timestamp}
+    end
+  end
+
+  defp resolve_initial_timestamp(configured_timestamp, nil), do: {:ok, configured_timestamp}
+
+  defp resolve_initial_timestamp(configured_timestamp, loaded_timestamp) do
+    case validate_timestamp(loaded_timestamp) do
+      {:ok, loaded_timestamp} -> {:ok, max(configured_timestamp, loaded_timestamp)}
+      {:error, :invalid_timestamp} -> {:error, :timestamp_load_failed}
+    end
+  end
+
+  defp load_timestamp(nil), do: {:ok, nil}
+
+  defp load_timestamp(timestamp_load) do
+    timestamp_load
+    |> call_timestamp_load()
+    |> normalize_timestamp_load_result()
+  end
+
+  defp call_timestamp_load(timestamp_load) when is_function(timestamp_load, 0) do
+    safe_call(fn -> timestamp_load.() end)
+  end
+
+  defp call_timestamp_load({module, function, args}) do
+    safe_call(fn -> apply(module, function, args) end)
+  end
+
+  defp save_timestamp(nil, _timestamp), do: :ok
+
+  defp save_timestamp(timestamp_save, timestamp) do
+    timestamp_save
+    |> call_timestamp_save(timestamp)
+    |> normalize_timestamp_save_result()
+  end
+
+  defp call_timestamp_save(timestamp_save, timestamp) when is_function(timestamp_save, 1) do
+    safe_call(fn -> timestamp_save.(timestamp) end)
+  end
+
+  defp call_timestamp_save({module, function, args}, timestamp) do
+    safe_call(fn -> apply(module, function, args ++ [timestamp]) end)
+  end
+
+  defp safe_call(fun) do
+    try do
+      {:ok, fun.()}
+    rescue
+      _exception -> {:error, :callback_failed}
+    catch
+      _kind, _reason -> {:error, :callback_failed}
+    end
+  end
+
+  defp normalize_timestamp_load_result({:ok, nil}), do: {:ok, nil}
+  defp normalize_timestamp_load_result({:ok, {:ok, timestamp}}), do: {:ok, timestamp}
+
+  defp normalize_timestamp_load_result({:ok, timestamp}) when is_integer(timestamp),
+    do: {:ok, timestamp}
+
+  defp normalize_timestamp_load_result(_result), do: {:error, :timestamp_load_failed}
+
+  defp normalize_timestamp_save_result({:ok, :ok}), do: :ok
+  defp normalize_timestamp_save_result({:ok, {:ok, _result}}), do: :ok
+  defp normalize_timestamp_save_result(_result), do: {:error, :timestamp_save_failed}
+
   defp validate_timestamp(timestamp)
        when is_integer(timestamp) and timestamp in 0..@signature_timestamp_max,
        do: {:ok, timestamp}
@@ -248,4 +367,26 @@ defmodule XMAVLink.Signing do
     do: {:ok, accept_unsigned}
 
   defp validate_accept_unsigned(_accept_unsigned), do: {:error, :invalid_accept_unsigned}
+
+  defp validate_timestamp_load(nil), do: {:ok, nil}
+
+  defp validate_timestamp_load(timestamp_load) when is_function(timestamp_load, 0),
+    do: {:ok, timestamp_load}
+
+  defp validate_timestamp_load({module, function, args} = timestamp_load)
+       when is_atom(module) and is_atom(function) and is_list(args),
+       do: {:ok, timestamp_load}
+
+  defp validate_timestamp_load(_timestamp_load), do: {:error, :invalid_timestamp_load}
+
+  defp validate_timestamp_save(nil), do: {:ok, nil}
+
+  defp validate_timestamp_save(timestamp_save) when is_function(timestamp_save, 1),
+    do: {:ok, timestamp_save}
+
+  defp validate_timestamp_save({module, function, args} = timestamp_save)
+       when is_atom(module) and is_atom(function) and is_list(args),
+       do: {:ok, timestamp_save}
+
+  defp validate_timestamp_save(_timestamp_save), do: {:error, :invalid_timestamp_save}
 end

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -729,12 +729,83 @@ defmodule XMAVLink.Test.Router do
       state = :sys.get_state(router_pid)
       refute Map.has_key?(state.routes, {1, 1})
     end
+
+    test "signed SETUP_SIGNING frames are delivered locally but not forwarded between links" do
+      {:ok, trap_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, trap_port} = :inet.port(trap_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:#{trap_port}"],
+            signing: [
+              secret_key: @secret_key,
+              link_id: @link_id,
+              timestamp: @local_timestamp
+            ]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(trap_socket)
+        stop_router(router_pid)
+      end)
+
+      udpout_socket = wait_for_udpout_socket(router_pid)
+
+      send(
+        router_pid,
+        {:udp, udpout_socket, {10, 42, 0, 1}, trap_port,
+         signed_heartbeat_frame(@valid_timestamp, 2, 1).mavlink_2_raw}
+      )
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{2, 1}] == udpout_socket
+
+      assert :ok =
+               Router.subscribe(router_pid,
+                 message: Common.Message.SetupSigning,
+                 as_frame: true
+               )
+
+      setup_signing_frame =
+        signed_setup_signing_frame(
+          source_system: 3,
+          source_component: 1,
+          target_system: 2,
+          target_component: 1,
+          timestamp: @valid_timestamp + 1
+        )
+
+      send(
+        router_pid,
+        {:udp, :setup_signing_socket, {127, 0, 0, 1}, 14_551, setup_signing_frame.mavlink_2_raw}
+      )
+
+      assert_receive %Frame{
+                       source_system: 3,
+                       source_component: 1,
+                       message: %Common.Message.SetupSigning{
+                         target_system: 2,
+                         target_component: 1
+                       }
+                     },
+                     200
+
+      refute_receive {:udp, ^trap_socket, _, _, _}, 50
+    end
   end
 
   describe "outbound signing policy" do
     test "signs outbound MAVLink 2 frames on signing-enabled UDP connections" do
       {udp_socket, udp_port} = open_udp_socket()
       :ok = :inet.setopts(udp_socket, active: true)
+      parent = self()
 
       {:ok, router_pid} =
         Router.start_link(
@@ -747,7 +818,11 @@ defmodule XMAVLink.Test.Router do
             signing: [
               secret_key: @secret_key,
               link_id: @link_id,
-              timestamp: @local_timestamp
+              timestamp: @local_timestamp,
+              timestamp_save: fn timestamp ->
+                send(parent, {:saved_router_timestamp, timestamp})
+                :ok
+              end
             ]
           },
           []
@@ -768,6 +843,8 @@ defmodule XMAVLink.Test.Router do
       assert frame.signature.link_id == @link_id
       assert frame.signature.timestamp == @local_timestamp + 1
       assert :ok = Frame.validate_signature(frame, @secret_key)
+      next_timestamp = @local_timestamp + 1
+      assert_receive {:saved_router_timestamp, ^next_timestamp}
 
       state = :sys.get_state(router_pid)
       assert state.connections[udpout_socket].signing.timestamp == @local_timestamp + 1
@@ -777,6 +854,8 @@ defmodule XMAVLink.Test.Router do
       assert_receive {:udp, ^udp_socket, {127, 0, 0, 1}, _source_port, raw}, 500
       assert {%Frame{} = frame, <<>>} = Frame.binary_to_frame_and_tail(raw)
       assert frame.signature.timestamp == @local_timestamp + 2
+      next_timestamp = @local_timestamp + 2
+      assert_receive {:saved_router_timestamp, ^next_timestamp}
 
       state = :sys.get_state(router_pid)
       assert state.connections[udpout_socket].signing.timestamp == @local_timestamp + 2
@@ -1016,20 +1095,67 @@ defmodule XMAVLink.Test.Router do
     }
   end
 
-  defp signed_heartbeat_frame(timestamp \\ @valid_timestamp) do
-    {:ok, frame} = Frame.sign_frame(unsigned_heartbeat_frame(), @secret_key, @link_id, timestamp)
+  defp signed_heartbeat_frame(
+         timestamp \\ @valid_timestamp,
+         source_system \\ 1,
+         source_component \\ 1
+       ) do
+    {:ok, frame} =
+      Frame.sign_frame(
+        unsigned_heartbeat_frame(source_system, source_component),
+        @secret_key,
+        @link_id,
+        timestamp
+      )
+
     frame
   end
 
-  defp unsigned_heartbeat_frame do
+  defp unsigned_heartbeat_frame(source_system \\ 1, source_component \\ 1) do
     {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
       XMAVLink.Message.pack(sample_heartbeat(), 2)
 
     Frame.pack_frame(%Frame{
       version: 2,
       sequence_number: 7,
-      source_system: 1,
-      source_component: 1,
+      source_system: source_system,
+      source_component: source_component,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
+  end
+
+  defp signed_setup_signing_frame(opts) do
+    timestamp = Keyword.fetch!(opts, :timestamp)
+
+    {:ok, frame} =
+      Frame.sign_frame(
+        setup_signing_frame(opts),
+        @secret_key,
+        @link_id,
+        timestamp
+      )
+
+    frame
+  end
+
+  defp setup_signing_frame(opts) do
+    message = %Common.Message.SetupSigning{
+      target_system: Keyword.fetch!(opts, :target_system),
+      target_component: Keyword.fetch!(opts, :target_component),
+      secret_key: :binary.bin_to_list(@secret_key),
+      initial_timestamp: Keyword.fetch!(opts, :timestamp)
+    }
+
+    {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
+      XMAVLink.Message.pack(message, 2)
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 8,
+      source_system: Keyword.fetch!(opts, :source_system),
+      source_component: Keyword.fetch!(opts, :source_component),
       message_id: message_id,
       payload: payload,
       crc_extra: crc_extra

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -4,6 +4,11 @@ defmodule XMAVLink.Test.Signing do
   alias XMAVLink.Frame
   alias XMAVLink.Signing
 
+  defmodule TimestampStore do
+    def load(agent), do: Agent.get(agent, & &1)
+    def save(agent, timestamp), do: Agent.update(agent, fn _stored_timestamp -> timestamp end)
+  end
+
   @secret_key :binary.copy(<<42>>, 32)
   @wrong_secret_key :binary.copy(<<43>>, 32)
   @link_id 9
@@ -19,6 +24,8 @@ defmodule XMAVLink.Test.Signing do
                 secret_key: @secret_key,
                 link_id: @link_id,
                 timestamp: @local_timestamp,
+                timestamp_load: nil,
+                timestamp_save: nil,
                 accept_unsigned: true,
                 stream_timestamps: %{}
               }} =
@@ -28,6 +35,46 @@ defmodule XMAVLink.Test.Signing do
                  timestamp: @local_timestamp,
                  accept_unsigned: true
                )
+    end
+
+    test "loads persisted signing timestamp when configured" do
+      assert {:ok, %Signing{timestamp: @valid_timestamp}} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp: @local_timestamp,
+                 timestamp_load: fn -> {:ok, @valid_timestamp} end
+               )
+
+      assert {:ok, %Signing{timestamp: @valid_timestamp}} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp: @valid_timestamp,
+                 timestamp_load: fn -> @local_timestamp end
+               )
+    end
+
+    test "supports MFA timestamp load and save callbacks" do
+      {:ok, agent} = Agent.start(fn -> @valid_timestamp end)
+      on_exit(fn -> Agent.stop(agent) end)
+
+      assert {:ok, signing} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp: @local_timestamp,
+                 timestamp_load: {TimestampStore, :load, [agent]},
+                 timestamp_save: {TimestampStore, :save, [agent]}
+               )
+
+      assert signing.timestamp == @valid_timestamp
+
+      assert {:ok, _signed_frame, updated_signing} =
+               Signing.sign_outbound(unsigned_frame(), signing)
+
+      assert updated_signing.timestamp == @valid_timestamp + 1
+      assert Agent.get(agent, & &1) == @valid_timestamp + 1
     end
 
     test "rejects invalid signing policy inputs" do
@@ -46,6 +93,34 @@ defmodule XMAVLink.Test.Signing do
                  accept_unsigned: :sometimes
                )
 
+      assert {:error, :invalid_timestamp_load} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp_load: fn _timestamp -> @local_timestamp end
+               )
+
+      assert {:error, :invalid_timestamp_save} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp_save: fn -> :ok end
+               )
+
+      assert {:error, :timestamp_load_failed} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp_load: fn -> -1 end
+               )
+
+      assert {:error, :timestamp_load_failed} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 timestamp_load: fn -> raise "failed" end
+               )
+
       assert {:error, :invalid_options} = Signing.new([1, 2])
       assert {:error, :invalid_options} = Signing.new(:invalid)
     end
@@ -53,7 +128,16 @@ defmodule XMAVLink.Test.Signing do
 
   describe "validate_inbound/2" do
     test "accepts valid signed frames and records replay state" do
-      signing = signing()
+      parent = self()
+
+      signing =
+        signing(
+          timestamp_save: fn timestamp ->
+            send(parent, {:saved_timestamp, timestamp})
+            :ok
+          end
+        )
+
       frame = signed_frame(@valid_timestamp)
 
       assert {:ok, ^frame, updated_signing} = Signing.validate_inbound(frame, signing)
@@ -63,6 +147,15 @@ defmodule XMAVLink.Test.Signing do
       assert updated_signing.stream_timestamps[
                {frame.source_system, frame.source_component, @link_id}
              ] == @valid_timestamp
+
+      assert_receive {:saved_timestamp, @valid_timestamp}
+    end
+
+    test "rejects valid signed frames when advanced timestamp save fails" do
+      signing = signing(timestamp_save: fn _timestamp -> {:error, :disk_full} end)
+
+      assert {:error, :timestamp_save_failed, ^signing} =
+               Signing.validate_inbound(signed_frame(@valid_timestamp), signing)
     end
 
     test "rejects repeated or older timestamps for the same signed stream" do
@@ -152,7 +245,15 @@ defmodule XMAVLink.Test.Signing do
   describe "sign_outbound/2" do
     test "signs unsigned MAVLink 2 frames with the next local timestamp" do
       frame = unsigned_frame()
-      signing = signing()
+      parent = self()
+
+      signing =
+        signing(
+          timestamp_save: fn timestamp ->
+            send(parent, {:saved_timestamp, timestamp})
+            :ok
+          end
+        )
 
       assert {:ok, signed_frame, updated_signing} = Signing.sign_outbound(frame, signing)
       assert Frame.signed?(signed_frame)
@@ -160,12 +261,16 @@ defmodule XMAVLink.Test.Signing do
       assert signed_frame.signature.timestamp == @local_timestamp + 1
       assert updated_signing.timestamp == @local_timestamp + 1
       assert :ok = Frame.validate_signature(signed_frame, @secret_key)
+      next_timestamp = @local_timestamp + 1
+      assert_receive {:saved_timestamp, ^next_timestamp}
 
       assert {:ok, newer_frame, newer_signing} =
                Signing.sign_outbound(unsigned_frame(), updated_signing)
 
       assert newer_frame.signature.timestamp == @local_timestamp + 2
       assert newer_signing.timestamp == @local_timestamp + 2
+      next_timestamp = @local_timestamp + 2
+      assert_receive {:saved_timestamp, ^next_timestamp}
     end
 
     test "leaves MAVLink 1 frames unsigned and unchanged" do
@@ -186,18 +291,37 @@ defmodule XMAVLink.Test.Signing do
     end
 
     test "leaves already signed frames unchanged and catches up local timestamp" do
-      signing = signing()
+      parent = self()
+
+      signing =
+        signing(
+          timestamp_save: fn timestamp ->
+            send(parent, {:saved_timestamp, timestamp})
+            :ok
+          end
+        )
+
       signed_frame = signed_frame(@valid_timestamp)
 
       assert {:ok, ^signed_frame, updated_signing} =
                Signing.sign_outbound(signed_frame, signing)
 
       assert updated_signing.timestamp == @valid_timestamp
+      assert_receive {:saved_timestamp, @valid_timestamp}
 
       newer_signing = %{signing | timestamp: @valid_timestamp + 1}
 
       assert {:ok, ^signed_frame, ^newer_signing} =
                Signing.sign_outbound(signed_frame, newer_signing)
+
+      refute_receive {:saved_timestamp, _timestamp}, 50
+    end
+
+    test "rejects outbound signing when advanced timestamp save fails" do
+      signing = signing(timestamp_save: fn _timestamp -> :error end)
+
+      assert {:error, :timestamp_save_failed, ^signing} =
+               Signing.sign_outbound(unsigned_frame(), signing)
     end
 
     test "rejects outbound signing when the timestamp space is exhausted" do
@@ -208,12 +332,17 @@ defmodule XMAVLink.Test.Signing do
     end
   end
 
-  defp signing do
+  defp signing(opts \\ []) do
     {:ok, signing} =
       Signing.new(
-        secret_key: @secret_key,
-        link_id: @link_id,
-        timestamp: @local_timestamp
+        Keyword.merge(
+          [
+            secret_key: @secret_key,
+            link_id: @link_id,
+            timestamp: @local_timestamp
+          ],
+          opts
+        )
       )
 
     signing


### PR DESCRIPTION
## Summary

- Add MAVLink 2 signing timestamp load/save callbacks so applications can preserve local signing timestamps across restarts.
- Persist advanced local timestamps before accepting inbound signed frames or emitting outbound signed frames, and report `:timestamp_save_failed` when configured persistence fails.
- Keep inbound `SETUP_SIGNING` frames local-only so key material is not forwarded between MAVLink links by generic routing, while preserving deliberate local-origin provisioning flows.
- Update signing, security, spec-alignment, README, and changelog docs.

Closes #47.

## Validation

- `mix format`
- `mix test test/mavlink_signing_test.exs test/mavlink_router_test.exs`
- `mix test`
- `mix compile --warnings-as-errors --force`
- `mix dialyzer`
- `git diff --check`