### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.12.0 - 2026-05-08
+
 - Added MAVLink 2 signed-frame parsing and signature trailer representation.
 - Added a low-level MAVLink 2 frame signing helper for already packed frames.
 - Added reusable MAVLink 2 signature validation and inbound replay-policy

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.11.1",
+      version: "0.12.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Bump the package version from `0.11.1` to `0.12.0` after completing the MAVLink 2 signing follow-ups.
- Move the accumulated signing changelog entries into a dated `0.12.0` section.

## Validation

- `mix format`
- `mix test`
- `mix compile --warnings-as-errors --force`
- `git diff --check`