### PR TITLE
Clear learned routes when SYSTEM_TIME decreases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added router route invalidation when a `SYSTEM_TIME.time_boot_ms` decrease
+  indicates a remote system rebooted.
+
 ## 0.12.0 - 2026-05-08
 
 - Added MAVLink 2 signed-frame parsing and signature trailer representation.

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -58,7 +58,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Incompatible flags | Supported | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed when present so stream boundaries stay aligned. |
 | Routing unchanged packets | Supported with signing caveat | Forwarding generally uses the original raw frame bytes. Unsigned MAVLink 2 frames sent over signing-enabled connections are signed for that outbound link; already signed MAVLink 2 frames are forwarded unchanged. |
 | Target inference | Supported | Generated metadata classifies broadcast, system, component, and system-component targets from `target_system` and `target_component` fields. |
-| Route reset after reboot | Partial | Routing learns source system/component locations but does not yet clear routes on `SYSTEM_TIME.time_boot_ms` decrease. |
+| Route reset after reboot | Supported | Routing tracks `SYSTEM_TIME.time_boot_ms` per source system/component and clears learned routes for that system when the same source reports a lower boot time. |
 | XML includes | Partial | Includes are recursive and deterministic, but missing include errors and duplicate handling are not yet aligned with `mavgen`. |
 | Enum merging | Partial | Matching enum names are merged and sorted by value. Duplicate enum entries are not rejected yet. |
 | Duplicate message ids | Unsupported validation | The parser/generator does not currently reject duplicate message ids across includes. |
@@ -94,6 +94,9 @@ Known non-goals for 1.0 unless separately implemented:
   fails.
 - Inbound `SETUP_SIGNING` frames are delivered locally but not forwarded between
   MAVLink connections by generic routing.
+- Learned routes are cleared for a remote system when the same
+  system/component reports a lower `SYSTEM_TIME.time_boot_ms`, preventing stale
+  targeted forwarding after reboot.
 - Unsupported signed MAVLink 2 frames consume the 13-byte signature trailer when
   present, preventing TCP/serial stream buffers from treating signature bytes as
   a new frame prefix.
@@ -103,8 +106,6 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #52: Add route invalidation when `SYSTEM_TIME.time_boot_ms` decreases for a
-  known system/component.
 - #53: Align XML parser/generator validation with `mavgen` for missing
   includes, duplicate message ids, duplicate enum entries, and reserved names.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.11.1"}
+     {:xmavlink, "~> 0.12.0"}
    ]
  end
  ```

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -30,6 +30,7 @@ defmodule XMAVLink.Router do
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
 
+  @system_time_message_id 2
   @setup_signing_message_id 256
 
   @typedoc """
@@ -56,6 +57,9 @@ defmodule XMAVLink.Router do
                         contains the system/component id, subscriber list and next sequence number.
   - routes:             A map from a {system id, component id} tuple to the connection key a message from that
                         system/component was last received on. Used to forward messages to that system/component.
+  - system_time_boot_ms:
+                        A map from a {system id, component id} tuple to the last SYSTEM_TIME.time_boot_ms seen
+                        from that source. Used to clear stale learned routes when a remote system reboots.
   """
   defstruct [
     # Registered router name, if any
@@ -77,7 +81,9 @@ defmodule XMAVLink.Router do
     # %{socket|port|local: XMAVLink.*_Connection}
     connections: %{},
     # Connection key last observed for each MAVLink address
-    routes: %{}
+    routes: %{},
+    # Last SYSTEM_TIME.time_boot_ms observed for each MAVLink address
+    system_time_boot_ms: %{}
   ]
 
   # Can't used qualified type as map key
@@ -102,7 +108,8 @@ defmodule XMAVLink.Router do
           connection_workers: %{connection_key() => pid},
           connection_worker_monitors: %{reference => pid},
           connections: %{connection_key() => mavlink_connection()},
-          routes: %{mavlink_address() => connection_key()}
+          routes: %{mavlink_address() => connection_key()},
+          system_time_boot_ms: %{mavlink_address() => non_neg_integer}
         }
 
   defguardp is_router_ref(router)
@@ -857,8 +864,10 @@ defmodule XMAVLink.Router do
             source_system: source_system,
             source_component: source_component
           }},
-         state = %Router{routes: routes, connections: connections}
+         state = %Router{}
        ) do
+    state = track_system_time(frame, source_connection_key, state)
+
     {
       :ok,
       source_connection_key,
@@ -871,18 +880,18 @@ defmodule XMAVLink.Router do
         routes:
           case source_connection_key do
             :local ->
-              routes
+              state.routes
 
             _ ->
               Map.put(
-                routes,
+                state.routes,
                 {source_system, source_component},
                 source_connection_key
               )
           end,
         connections:
           Map.put(
-            connections,
+            state.connections,
             source_connection_key,
             source_connection
           )
@@ -910,6 +919,52 @@ defmodule XMAVLink.Router do
       )
       |> track_connection_worker(connection_key, connection)
     }
+  end
+
+  defp track_system_time(_frame, :local, state), do: state
+
+  defp track_system_time(
+         %Frame{
+           message_id: @system_time_message_id,
+           source_system: source_system,
+           source_component: source_component,
+           message: %{time_boot_ms: time_boot_ms}
+         },
+         _source_connection_key,
+         state = %Router{system_time_boot_ms: system_time_boot_ms}
+       )
+       when is_integer(time_boot_ms) do
+    source = {source_system, source_component}
+
+    state =
+      case Map.fetch(system_time_boot_ms, source) do
+        {:ok, previous_time_boot_ms} when time_boot_ms < previous_time_boot_ms ->
+          clear_system_routes(source_system, state)
+
+        _ ->
+          state
+      end
+
+    %Router{
+      state
+      | system_time_boot_ms: Map.put(state.system_time_boot_ms, source, time_boot_ms)
+    }
+  end
+
+  defp track_system_time(_frame, _source_connection_key, state), do: state
+
+  defp clear_system_routes(source_system, state = %Router{}) do
+    %Router{
+      state
+      | routes: reject_system_keys(state.routes, source_system),
+        system_time_boot_ms: reject_system_keys(state.system_time_boot_ms, source_system)
+    }
+  end
+
+  defp reject_system_keys(map, source_system) do
+    map
+    |> Enum.reject(fn {{system, _component}, _value} -> system == source_system end)
+    |> Map.new()
   end
 
   # SETUP_SIGNING carries key material. Inbound provisioning messages are

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -801,6 +801,78 @@ defmodule XMAVLink.Test.Router do
     end
   end
 
+  describe "route reboot handling" do
+    test "clears learned system routes when SYSTEM_TIME time_boot_ms decreases" do
+      {:ok, router_socket} = :gen_udp.open(0, [:binary, active: false])
+      {:ok, old_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, old_peer_port} = :inet.port(old_peer_socket)
+      {:ok, new_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, new_peer_port} = :inet.port(new_peer_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(router_socket)
+        :gen_udp.close(old_peer_socket)
+        :gen_udp.close(new_peer_socket)
+        stop_router(router_pid)
+      end)
+
+      address = {127, 0, 0, 1}
+      old_route = {router_socket, address, old_peer_port}
+      new_route = {router_socket, address, new_peer_port}
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, old_peer_port,
+         system_time_frame(10_000, 2, 1).mavlink_2_raw}
+      )
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, old_peer_port,
+         unsigned_heartbeat_frame(2, 42).mavlink_2_raw}
+      )
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{2, 1}] == old_route
+      assert state.routes[{2, 42}] == old_route
+      assert state.system_time_boot_ms[{2, 1}] == 10_000
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, new_peer_port,
+         system_time_frame(2_000, 2, 1).mavlink_2_raw}
+      )
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{2, 1}] == new_route
+      refute Map.has_key?(state.routes, {2, 42})
+      assert state.system_time_boot_ms == %{{2, 1} => 2_000}
+
+      assert_receive {:udp, ^old_peer_socket, _, _, _}, 200
+      flush_udp(old_peer_socket)
+      flush_udp(new_peer_socket)
+
+      assert :ok = Router.pack_and_send(router_pid, param_request_list(2, 42), 2)
+      refute_receive {:udp, ^old_peer_socket, _, _, _}, 50
+
+      assert :ok = Router.pack_and_send(router_pid, param_request_list(2, 1), 2)
+      assert_receive {:udp, ^new_peer_socket, _, _, _}, 200
+      refute_receive {:udp, ^old_peer_socket, _, _, _}, 50
+    end
+  end
+
   describe "outbound signing policy" do
     test "signs outbound MAVLink 2 frames on signing-enabled UDP connections" do
       {udp_socket, udp_port} = open_udp_socket()
@@ -1095,6 +1167,33 @@ defmodule XMAVLink.Test.Router do
     }
   end
 
+  defp param_request_list(target_system, target_component) do
+    %Common.Message.ParamRequestList{
+      target_system: target_system,
+      target_component: target_component
+    }
+  end
+
+  defp system_time_frame(time_boot_ms, source_system, source_component) do
+    message = %Common.Message.SystemTime{
+      time_unix_usec: 0,
+      time_boot_ms: time_boot_ms
+    }
+
+    {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
+      XMAVLink.Message.pack(message, 2)
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 9,
+      source_system: source_system,
+      source_component: source_component,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
+  end
+
   defp signed_heartbeat_frame(
          timestamp \\ @valid_timestamp,
          source_system \\ 1,
@@ -1166,6 +1265,14 @@ defmodule XMAVLink.Test.Router do
     {:ok, socket} = :gen_udp.open(0, [:binary, active: false])
     {:ok, port} = :inet.port(socket)
     {socket, port}
+  end
+
+  defp flush_udp(socket) do
+    receive do
+      {:udp, ^socket, _, _, _} -> flush_udp(socket)
+    after
+      0 -> :ok
+    end
   end
 
   defp open_tcp_listener do


### PR DESCRIPTION
## Summary

- Track the last `SYSTEM_TIME.time_boot_ms` observed per source system/component.
- Clear learned routes for that source system when the same source reports a lower boot time, then learn the current route.
- Add router coverage proving stale targeted forwarding to the old link stops after reboot detection.
- Update the spec-alignment note, changelog, and README dependency snippet for the already-published `0.12.0` release.

Closes #52.

## Validation

- `mix format`
- `mix test test/mavlink_router_test.exs`
- `mix test`
- `mix compile --warnings-as-errors --force`
- `mix dialyzer`
- `git diff --check`

## Release note

This is patch-release material after merge. I kept the implementation PR focused; a separate `0.12.1` release PR should update both `mix.exs` and the README dependency snippet together.