### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.12.1 - 2026-05-08
+
 - Added router route invalidation when a `SYSTEM_TIME.time_boot_ms` decrease
   indicates a remote system rebooted.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.12.0"}
+     {:xmavlink, "~> 0.12.1"}
    ]
  end
  ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.12.0",
+      version: "0.12.1",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Bump the package version from `0.12.0` to `0.12.1` after the route invalidation fix.
- Move the route invalidation changelog entry into a dated `0.12.1` section.
- Update the README dependency snippet to `~> 0.12.1` alongside `mix.exs`.

## Validation

- `mix format`
- `mix test`
- `mix compile --warnings-as-errors --force`
- `git diff --check`