### PR TITLE
[codex] Add remote forwarding toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.13.0 - 2026-05-11
+
+- Added `remote_forwarding: false` router/application configuration for
+  endpoint or GCS use cases that should receive remote MAVLink traffic locally
+  without forwarding it between remote links.
+
+## 0.12.2 - 2026-05-11
+
+- Hardened MAVLink XML generator validation for duplicate or conflicting
+  message module names.
+
 ## 0.12.1 - 2026-05-08
 
 - Added router route invalidation when a `SYSTEM_TIME.time_boot_ms` decrease

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.12.2"}
+     {:xmavlink, "~> 0.13.0"}
    ]
  end
  ```
@@ -146,6 +146,25 @@ config :xmavlink,
   connections: ["tcpout:127.0.0.1:5760"],
   connection_retry_ms: 500
 ```
+
+### Remote Forwarding
+
+By default, XMAVLink behaves as a router: frames received from one remote link
+may be forwarded to other remote links as well as local subscribers. For
+endpoint or GCS applications that should receive vehicle traffic without
+bridging it between links, disable remote forwarding:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["udpin:0.0.0.0:14550"],
+  remote_forwarding: false
+```
+
+With `remote_forwarding: false`, inbound remote frames are still decoded,
+learned for routing, and delivered to local subscribers. Local messages sent
+with `XMAVLink.Router.pack_and_send/2` or `/3` can still be forwarded to learned
+remote vehicles.
 
 ### DNS Hostname Support
 

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -70,6 +70,8 @@ defmodule XMAVLink.Router do
     connection_strings: [],
     # Supervised connection retry delay
     connection_retry_ms: 1_000,
+    # Whether remote inbound frames may be forwarded to other remote links
+    remote_forwarding: true,
     # Subscription cache name for restart restoration, if any
     subscription_cache: nil,
     # Per-connection MAVLink 2 signing policy seed
@@ -102,6 +104,7 @@ defmodule XMAVLink.Router do
           dialect: module | nil,
           connection_strings: [String.t()],
           connection_retry_ms: non_neg_integer,
+          remote_forwarding: boolean,
           signing: Signing.t() | nil,
           subscription_cache: router_name | nil,
           connection_supervisor: pid | nil,
@@ -147,6 +150,11 @@ defmodule XMAVLink.Router do
                         Retry delay for configured connection workers after
                         open failures or TCP/serial disconnects. Defaults to
                         1000 ms.
+  - remote_forwarding:
+                        Whether frames received from remote links are forwarded
+                        to other remote links. Defaults to true. Set false for
+                        endpoint/GCS use cases that should receive remote
+                        traffic locally without bridging it between links.
 
   - opts:               Standard GenServer options. Pass `:name` to register
                         a non-default router, or `name: nil` in the args map to
@@ -161,6 +169,7 @@ defmodule XMAVLink.Router do
             optional(:connection_strings) => [String.t()],
             optional(:connections) => [String.t()],
             optional(:connection_retry_ms) => non_neg_integer,
+            optional(:remote_forwarding) => boolean,
             optional(:signing) => keyword() | nil
           },
           [{atom, any}]
@@ -414,15 +423,21 @@ defmodule XMAVLink.Router do
     args = Map.new(args)
     connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
     connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
+    remote_forwarding = Map.get(args, :remote_forwarding, true)
     signing = normalize_signing!(Map.get(args, :signing))
 
     if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
       raise ArgumentError, "connection_retry_ms must be a non-negative integer"
     end
 
+    if not is_boolean(remote_forwarding) do
+      raise ArgumentError, "remote_forwarding must be a boolean"
+    end
+
     args
     |> Map.put(:connection_strings, connection_strings)
     |> Map.put(:connection_retry_ms, connection_retry_ms)
+    |> Map.put(:remote_forwarding, remote_forwarding)
     |> Map.put(:signing, signing)
   end
 
@@ -519,6 +534,7 @@ defmodule XMAVLink.Router do
        dialect: args.dialect,
        connection_strings: args.connection_strings,
        connection_retry_ms: args.connection_retry_ms,
+       remote_forwarding: args.remote_forwarding,
        connection_supervisor: connection_supervisor,
        subscription_cache: subscription_cache,
        signing: args.signing,
@@ -984,8 +1000,11 @@ defmodule XMAVLink.Router do
          {:ok, source_connection_key, frame = %Frame{target: :broadcast},
           state = %Router{connections: connections}}
        ) do
+    forward_remote? = source_connection_key == :local or state.remote_forwarding
+
     Enum.reduce(connections, state, fn {connection_key, connection}, routed_state ->
-      if match?(:local, connection_key) or !match?(^connection_key, source_connection_key) do
+      if connection_key == :local or
+           (forward_remote? and connection_key != source_connection_key) do
         forward_and_update(connection_key, connection, frame, routed_state)
       else
         routed_state
@@ -1016,6 +1035,7 @@ defmodule XMAVLink.Router do
     recipients =
       matching_system_components(target_system, target_component, state)
       |> Enum.reject(fn key -> key == source_connection_key end)
+      |> remote_forwarding_recipients(source_connection_key, state)
 
     if match?(
          {^recipients, ^source_system, ^source_component},
@@ -1056,6 +1076,18 @@ defmodule XMAVLink.Router do
         |> Enum.map(fn {_, ck} -> ck end)
     ]
   end
+
+  defp remote_forwarding_recipients(recipients, :local, _state), do: recipients
+
+  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
+         remote_forwarding: true
+       }),
+       do: recipients
+
+  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
+         remote_forwarding: false
+       }),
+       do: Enum.filter(recipients, &(&1 == :local))
 
   defp forward_and_update(_connection_key, nil, _frame, state), do: state
 

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -30,6 +30,7 @@ defmodule XMAVLink.Supervisor do
             component: Application.get_env(:xmavlink, :component_id),
             connection_strings: Application.get_env(:xmavlink, :connections),
             connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000),
+            remote_forwarding: Application.get_env(:xmavlink, :remote_forwarding, true),
             signing: Application.get_env(:xmavlink, :signing)
           }
         }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.12.2",
+      version: "0.13.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -46,6 +46,9 @@ defmodule XMAVLink.Mixfile do
         # Utility processes are opt-in because CacheManager actively subscribes
         # to MAVLink traffic and requests vehicle parameter lists.
         utilities: false,
+        # Keep router behavior by default. Set false for endpoint/GCS use cases
+        # that should receive remote traffic without bridging remote links.
+        remote_forwarding: true,
         connections: []
       ],
       mod: {XMAVLink.Application, []},

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -165,6 +165,21 @@ defmodule XMAVLink.Test.Router do
       end
     end
 
+    test "rejects invalid remote forwarding config" do
+      assert_raise ArgumentError, ~r/remote_forwarding/, fn ->
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: APM.Dialect,
+            connection_strings: [],
+            remote_forwarding: :nope
+          },
+          []
+        )
+      end
+    end
+
     test "rejects invalid signing config" do
       assert_raise ArgumentError, ~r/invalid signing config: :invalid_secret_key/, fn ->
         Router.start_link(
@@ -489,6 +504,143 @@ defmodule XMAVLink.Test.Router do
                    fn ->
                      Router.pack_and_send({:global, :missing_router}, sample_heartbeat())
                    end
+    end
+  end
+
+  describe "remote forwarding" do
+    test "can be disabled while keeping local delivery and local outbound sends" do
+      {:ok, router_socket} = :gen_udp.open(0, [:binary, active: false])
+      {:ok, first_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, first_peer_port} = :inet.port(first_peer_socket)
+      {:ok, second_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, second_peer_port} = :inet.port(second_peer_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            remote_forwarding: false
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(router_socket)
+        :gen_udp.close(first_peer_socket)
+        :gen_udp.close(second_peer_socket)
+        stop_router(router_pid)
+      end)
+
+      assert :ok = Router.subscribe(router_pid, message: Common.Message.Heartbeat, as_frame: true)
+
+      address = {127, 0, 0, 1}
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, second_peer_port,
+         packed_remote_frame(sample_heartbeat(), 3, 1).mavlink_2_raw}
+      )
+
+      assert_receive %Frame{
+                       source_system: 3,
+                       source_component: 1,
+                       message: %Common.Message.Heartbeat{}
+                     },
+                     200
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, first_peer_port,
+         packed_remote_frame(sample_heartbeat(), 2, 1).mavlink_2_raw}
+      )
+
+      assert_receive %Frame{
+                       source_system: 2,
+                       source_component: 1,
+                       message: %Common.Message.Heartbeat{}
+                     },
+                     200
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{2, 1}] == {router_socket, address, first_peer_port}
+      assert state.routes[{3, 1}] == {router_socket, address, second_peer_port}
+
+      refute_receive {:udp, ^second_peer_socket, _, _, _}, 50
+
+      assert :ok = Router.pack_and_send(router_pid, param_request_list(3, 1), 2)
+      assert_receive {:udp, ^second_peer_socket, _, _, _}, 200
+      refute_receive {:udp, ^first_peer_socket, _, _, _}, 50
+
+      Router.unsubscribe(router_pid)
+    end
+
+    test "does not forward remote targeted frames to other remote links when disabled" do
+      {:ok, router_socket} = :gen_udp.open(0, [:binary, active: false])
+      {:ok, source_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, source_peer_port} = :inet.port(source_peer_socket)
+      {:ok, target_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, target_peer_port} = :inet.port(target_peer_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            remote_forwarding: false
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(router_socket)
+        :gen_udp.close(source_peer_socket)
+        :gen_udp.close(target_peer_socket)
+        stop_router(router_pid)
+      end)
+
+      assert :ok =
+               Router.subscribe(router_pid,
+                 message: Common.Message.ParamRequestList,
+                 as_frame: true
+               )
+
+      address = {127, 0, 0, 1}
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, target_peer_port,
+         packed_remote_frame(sample_heartbeat(), 3, 1).mavlink_2_raw}
+      )
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{3, 1}] == {router_socket, address, target_peer_port}
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, source_peer_port,
+         packed_remote_frame(param_request_list(3, 1), 2, 1).mavlink_2_raw}
+      )
+
+      assert_receive %Frame{
+                       source_system: 2,
+                       source_component: 1,
+                       target_system: 3,
+                       target_component: 1,
+                       message: %Common.Message.ParamRequestList{}
+                     },
+                     200
+
+      _state = :sys.get_state(router_pid)
+      refute_receive {:udp, ^target_peer_socket, _, _, _}, 50
+
+      Router.unsubscribe(router_pid)
     end
   end
 
@@ -1172,6 +1324,32 @@ defmodule XMAVLink.Test.Router do
       target_system: target_system,
       target_component: target_component
     }
+  end
+
+  defp packed_remote_frame(message, source_system, source_component) do
+    {:ok, message_id, {:ok, crc_extra, _expected_length, target}, payload} =
+      XMAVLink.Message.pack(message, 2)
+
+    {target_system, target_component} =
+      if target != :broadcast do
+        {message.target_system, Map.get(message, :target_component, 0)}
+      else
+        {0, 0}
+      end
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 7,
+      source_system: source_system,
+      source_component: source_component,
+      target_system: target_system,
+      target_component: target_component,
+      target: target,
+      message: message,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
   end
 
   defp system_time_frame(time_boot_ms, source_system, source_component) do

--- a/test/mavlink_supervisor_test.exs
+++ b/test/mavlink_supervisor_test.exs
@@ -5,15 +5,18 @@ defmodule XMAVLink.SupervisorTest do
     previous_router_name = Application.get_env(:xmavlink, :router_name)
     previous_heartbeat = Application.get_env(:xmavlink, :heartbeat)
     previous_connection_retry_ms = Application.get_env(:xmavlink, :connection_retry_ms)
+    previous_remote_forwarding = Application.get_env(:xmavlink, :remote_forwarding)
 
     Application.put_env(:xmavlink, :router_name, nil)
     Application.put_env(:xmavlink, :connection_retry_ms, 250)
+    Application.put_env(:xmavlink, :remote_forwarding, false)
     Application.put_env(:xmavlink, :heartbeat, interval_ms: 1000, message: sample_heartbeat())
 
     on_exit(fn ->
       restore_env(:router_name, previous_router_name)
       restore_env(:heartbeat, previous_heartbeat)
       restore_env(:connection_retry_ms, previous_connection_retry_ms)
+      restore_env(:remote_forwarding, previous_remote_forwarding)
     end)
 
     assert {:ok, {_supervisor_flags, children}} = XMAVLink.Supervisor.init([])
@@ -21,7 +24,7 @@ defmodule XMAVLink.SupervisorTest do
     assert %{
              start:
                {XMAVLink.Router, :start_link,
-                [%{name: XMAVLink.Router, connection_retry_ms: 250}]}
+                [%{name: XMAVLink.Router, connection_retry_ms: 250, remote_forwarding: false}]}
            } =
              Enum.find(children, &match?(%{id: XMAVLink.Router}, &1))
 


### PR DESCRIPTION
## Summary

- Add `remote_forwarding` router/application configuration, defaulting to the existing router behavior.
- When `remote_forwarding: false`, remote inbound frames are still decoded, learned, and delivered locally, but are not bridged to other remote links.
- Keep local outbound sends working against learned remote routes, document the endpoint/GCS configuration, and bump the package version to `0.13.0`.

Closes #12.

## Validation

- `mix format`
- `mix format --check-formatted`
- `git diff --check`
- `mix test test/mavlink_router_test.exs test/mavlink_supervisor_test.exs`
- `mix test`