### PR TITLE
[codex] Bump version and toolchain

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -91,8 +91,8 @@ jobs:
         include:
           - elixir: 1.18.4
             otp: 27.3.4.3
-          - elixir: 1.19.4
-            otp: 28.4.2
+          - elixir: 1.19.5
+            otp: 28.5
 
     steps:
       - uses: actions/checkout@v7
@@ -154,8 +154,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.18.4
-          otp-version: 27.3.4.3
+          elixir-version: 1.19.5
+          otp-version: 28.5
 
       - name: Install OS dependencies
         run: |
@@ -168,9 +168,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-dialyzer-1.18.4-27.3.4.3-${{ hashFiles('mix.exs', 'mix.lock') }}
+          key: ${{ runner.os }}-dialyzer-1.19.5-28.5-${{ hashFiles('mix.exs', 'mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-dialyzer-1.18.4-27.3.4.3-
+            ${{ runner.os }}-dialyzer-1.19.5-28.5-
 
       - name: Install Mix tools and dependencies
         run: |
@@ -212,8 +212,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.18.4
-          otp-version: 27.3.4.3
+          elixir-version: 1.19.5
+          otp-version: 28.5
 
       - name: Install OS dependencies
         run: |
@@ -226,9 +226,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-hex-publish-1.18.4-27.3.4.3-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-hex-publish-1.19.5-28.5-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-hex-publish-1.18.4-27.3.4.3-
+            ${{ runner.os }}-hex-publish-1.19.5-28.5-
 
       - name: Install Mix tools and dependencies
         run: |

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -91,8 +91,8 @@ jobs:
         include:
           - elixir: 1.18.4
             otp: 27.3.4.3
-          - elixir: 1.19.5
-            otp: 28.5
+          - elixir: 1.20.1
+            otp: 29.0.2
 
     steps:
       - uses: actions/checkout@v7
@@ -154,8 +154,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.19.5
-          otp-version: 28.5
+          elixir-version: 1.20.1
+          otp-version: 29.0.2
 
       - name: Install OS dependencies
         run: |
@@ -168,9 +168,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-dialyzer-1.19.5-28.5-${{ hashFiles('mix.exs', 'mix.lock') }}
+          key: ${{ runner.os }}-dialyzer-1.20.1-29.0.2-${{ hashFiles('mix.exs', 'mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-dialyzer-1.19.5-28.5-
+            ${{ runner.os }}-dialyzer-1.20.1-29.0.2-
 
       - name: Install Mix tools and dependencies
         run: |
@@ -212,8 +212,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.19.5
-          otp-version: 28.5
+          elixir-version: 1.20.1
+          otp-version: 29.0.2
 
       - name: Install OS dependencies
         run: |
@@ -226,9 +226,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-hex-publish-1.19.5-28.5-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-hex-publish-1.20.1-29.0.2-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-hex-publish-1.19.5-28.5-
+            ${{ runner.os }}-hex-publish-1.20.1-29.0.2-
 
       - name: Install Mix tools and dependencies
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.4
-erlang 27.3.4.3
+elixir 1.19.5-otp-28
+erlang 28.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.5-otp-28
-erlang 28.5
+elixir 1.20.1-otp-29
+erlang 29.0.2

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -500,7 +500,7 @@ defmodule XMAVLink.Frame do
        when is_binary(raw) and byte_size(raw) >= 12 + @mavlink_2_signature_length do
     signed_packet_size = byte_size(raw) - 6
 
-    <<signed_packet_without_signature::binary-size(signed_packet_size),
+    <<signed_packet_without_signature::binary-size(^signed_packet_size),
       signature::binary-size(6)>> = raw
 
     {:ok, signed_packet_without_signature, signature}

--- a/lib/mix/tasks/mavlink_task.ex
+++ b/lib/mix/tasks/mavlink_task.ex
@@ -123,9 +123,6 @@ defmodule Mix.Tasks.Xmavlink do
 
     defmodule #{module_name} do
 
-      import String, only: [replace_trailing: 3]
-      import XMAVLink.Utils, only: [unpack_array: 2, unpack_float: 1]
-
       import Bitwise
 
       @moduledoc #{moduledoc}
@@ -497,7 +494,7 @@ defmodule Mix.Tasks.Xmavlink do
 
   # Unpack Message Fields
   defp unpack_field_code_fragment(%{name: name, ordinality: 1, enum: "", type: "float"}, _) do
-    "unpack_float(#{downcase(name)}_f)"
+    "XMAVLink.Utils.unpack_float(#{downcase(name)}_f)"
   end
 
   defp unpack_field_code_fragment(%{name: name, ordinality: 1, enum: "", type: "double"}, _) do
@@ -530,19 +527,19 @@ defmodule Mix.Tasks.Xmavlink do
   end
 
   defp unpack_field_code_fragment(%{name: name, type: "char"}, _) do
-    ~s[replace_trailing(#{downcase(name)}_f, <<0>>, "")]
+    ~s[String.replace_trailing(#{downcase(name)}_f, <<0>>, "")]
   end
 
   defp unpack_field_code_fragment(%{name: name, type: "float"}, _) do
-    "unpack_array(#{downcase(name)}_f, fn(<<elem::binary-size(4),rest::binary>>) -> {unpack_float(elem), rest} end)"
+    "XMAVLink.Utils.unpack_array(#{downcase(name)}_f, fn(<<elem::binary-size(4),rest::binary>>) -> {XMAVLink.Utils.unpack_float(elem), rest} end)"
   end
 
   defp unpack_field_code_fragment(%{name: name, type: "double"}, _) do
-    "unpack_array(#{downcase(name)}_f, fn(<<elem::binary-size(8),rest::binary>>) -> {XMAVLink.Utils.unpack_double(elem), rest} end)"
+    "XMAVLink.Utils.unpack_array(#{downcase(name)}_f, fn(<<elem::binary-size(8),rest::binary>>) -> {XMAVLink.Utils.unpack_double(elem), rest} end)"
   end
 
   defp unpack_field_code_fragment(%{name: name, type: type}, _) do
-    "unpack_array(#{downcase(name)}_f, fn(<<elem::#{type_to_binary(type).pattern},rest::binary>>) ->  {elem, rest} end)"
+    "XMAVLink.Utils.unpack_array(#{downcase(name)}_f, fn(<<elem::#{type_to_binary(type).pattern},rest::binary>>) ->  {elem, rest} end)"
   end
 
   # Pack Message Fields

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.13.0",
+      version: "0.13.1",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/mavlink_frame_test.exs
+++ b/test/mavlink_frame_test.exs
@@ -257,7 +257,7 @@ defmodule XMAVLink.Test.Frame do
   defp corrupt_mavlink_2_checksum(%Frame{mavlink_2_raw: raw} = frame) do
     checksum_offset = byte_size(raw) - 2
 
-    <<prefix::binary-size(checksum_offset), checksum::little-unsigned-integer-size(16)>> = raw
+    <<prefix::binary-size(^checksum_offset), checksum::little-unsigned-integer-size(16)>> = raw
 
     %Frame{
       frame
@@ -269,7 +269,7 @@ defmodule XMAVLink.Test.Frame do
   defp corrupt_signature(%Frame{mavlink_2_raw: raw} = frame) do
     signature_offset = byte_size(raw) - 6
 
-    <<prefix::binary-size(signature_offset), signature_head, signature_tail::binary-size(5)>> =
+    <<prefix::binary-size(^signature_offset), signature_head, signature_tail::binary-size(5)>> =
       raw
 
     %Frame{


### PR DESCRIPTION
## Summary

- Bump the package version from `0.13.0` to `0.13.1` so the recently merged dependency updates can be published.
- Bump local tool pins to Elixir `1.20.1` on OTP `29.0.2`.
- Update CI's newer matrix entry, Dialyzer job, and Hex publish job to use Elixir `1.20.1` / OTP `29.0.2` while keeping the minimum compatibility matrix entry for Elixir `1.18.4` / OTP `27.3.4.3`.
- Clean up Elixir 1.20 warnings in bitstring matches and generated dialect output.

## Impact

No runtime behavior changes. This updates release metadata, the default development/CI toolchain, and warning compatibility for Elixir 1.20.

## Validation

- `mise exec -- mix deps.get`
- `mise exec -- mix format --check-formatted`
- `MIX_ENV=test mise exec -- mix deps.unlock --check-unused`
- `MIX_ENV=test mise exec -- mix compile --warnings-as-errors`
- `MIX_ENV=test mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `MIX_ENV=test mise exec -- mix test --warnings-as-errors`