### PR TITLE
[codex] Prepare xmavlink 0.14.0 architecture refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+## 0.14.0 - 2026-06-24
+
+### Breaking Changes
+
+- Formalized utility scoping around `XMAVLink.Util.Context`. Utility callers
+  that need non-default ETS table names should pass `context: context` instead
+  of relying on hard-coded global table names.
+- Direct utility ETS table access should migrate from fixed names such as
+  `:messages`, `:systems`, `:params`, and `:sessions` to
+  `XMAVLink.Util.Tables.name/2` or `XMAVLink.Util.Context.tables`.
+
+### Added
+
+- Added `XMAVLink.Router.send_message/1..3`, a synchronous send API that
+  returns delivery metadata while preserving the existing `pack_and_send`
+  APIs.
+- Added `XMAVLink.Util.Context` and `context: context` utility options so
+  cache, focus, parameter, arm/disarm, and SITL helpers can be scoped by
+  router, dialect, and table namespace.
+- Added internal router architecture modules for configuration normalization,
+  connection-string parsing, route selection, transport behaviour contracts,
+  shared inbound frame parsing, and generated dialect behaviour contracts.
+
+### Fixed
+
+- Fixed local MAVLink sequence numbers to wrap after the full `0..255` range.
+- Deduplicated targeted route recipients when multiple learned MAVLink
+  addresses resolve to the same connection.
+- Updated the `XMAVLink.Message` invalid-term fallback to stay compatible with
+  warnings-as-errors while preserving `Protocol.UndefinedError` for unknown
+  message structs.
+
 ## 0.13.0 - 2026-05-11
 
 - Added `remote_forwarding: false` router/application configuration for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Fixed
 
 - Fixed local MAVLink sequence numbers to wrap after the full `0..255` range.
+- Preserved utility focus independently for each scoped utility context.
 - Deduplicated targeted route recipients when multiple learned MAVLink
   addresses resolve to the same connection.
 - Updated the `XMAVLink.Message` invalid-term fallback to stay compatible with

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.13.0"}
+     {:xmavlink, "~> 0.14.0"}
    ]
  end
  ```
@@ -394,13 +394,32 @@ children = [
 Pass `auto_param_request: false` to `XMAVLink.Util.Supervisor` for the same
 behavior when supervising utilities explicitly.
 
-The current utility API is scoped to one configured router per VM. It uses
-global process names and ETS tables for IEx-friendly helpers, so applications
-that need multiple independent routers should use the core `XMAVLink.Router`
-API directly or keep utility usage limited to one selected router.
+As of `0.14.0`, utility helpers are scoped through
+`XMAVLink.Util.Context`. A context identifies the router, generated dialect, and
+ETS table namespace used by cache, focus, parameter, arm/disarm, and SITL
+helpers:
+
+```elixir
+context =
+  XMAVLink.Util.Context.new(
+    router: MyApp.VehicleRouter,
+    dialect: Common,
+    table_prefix: :vehicle_a
+  )
+
+XMAVLink.Util.CacheManager.mavs(context: context)
+XMAVLink.Util.CacheManager.msg({1, 1, 2}, Common.Message.Heartbeat, context: context)
+XMAVLink.Util.ParamSet.param_set(1, 1, 2, "SYSID_THISMAV", 2.0, context: context)
+```
+
+The default context still uses the configured `:xmavlink` router and dialect,
+with the historical table names `:messages`, `:systems`, `:params`, and
+`:sessions`. Applications that read utility ETS tables directly should migrate
+to `XMAVLink.Util.Context.new/1` and `XMAVLink.Util.Tables.name/2` instead of
+hard-coding those names.
 
 Command helpers such as arm/disarm and parameter setting use bounded retry
-loops by default. Pass `:retries`, `:retry_interval_ms`, or `:router` in the
+loops by default. Pass `:retries`, `:retry_interval_ms`, or `:context` in the
 options when a helper needs different behavior. Parameter queries return maps
 keyed by MAVLink parameter names as strings. `XMAVLink.Util.SITL.forward_rc/2`
 also accepts `:destination_address` when the SITL RC input is not on loopback.

--- a/lib/mavlink/application.ex
+++ b/lib/mavlink/application.ex
@@ -26,7 +26,14 @@ defmodule XMAVLink.Application do
 
       opts when is_list(opts) ->
         if Keyword.keyword?(opts) do
-          [{XMAVLink.Util.Supervisor, Keyword.put_new(opts, :router, router_name)}]
+          opts =
+            if Keyword.has_key?(opts, :context) do
+              opts
+            else
+              Keyword.put_new(opts, :router, router_name)
+            end
+
+          [{XMAVLink.Util.Supervisor, opts}]
         else
           invalid_utilities_config!(opts)
         end

--- a/lib/mavlink/connection/inbound.ex
+++ b/lib/mavlink/connection/inbound.ex
@@ -1,0 +1,118 @@
+defmodule XMAVLink.Connection.Inbound do
+  @moduledoc false
+
+  require Logger
+
+  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
+
+  @mavlink_2_signature_flag 0x01
+  @mavlink_2_signature_length 13
+  @smallest_mavlink_message 8
+
+  def datagram(raw, connection, connection_key, dialect, log_prefix, failure_description \\ nil) do
+    case binary_to_frame_and_tail(raw) do
+      :not_a_frame ->
+        Logger.debug("#{log_prefix}: Not a frame #{inspect(raw)}")
+        {:error, :not_a_frame, connection_key, connection}
+
+      {nil, _rest} ->
+        reason = frame_parse_error(raw)
+        Logger.debug("#{log_prefix}: #{parse_error_message(reason)}")
+        {:error, reason, connection_key, connection}
+
+      {received_frame, _rest} ->
+        validate_frame(
+          received_frame,
+          connection,
+          connection_key,
+          dialect,
+          log_prefix,
+          failure_description
+        )
+    end
+  end
+
+  def stream(raw, connection, buffer, socket, dialect, log_prefix) do
+    case binary_to_frame_and_tail(buffer <> raw) do
+      :not_a_frame ->
+        if byte_size(buffer) + byte_size(raw) > 0 do
+          Logger.debug("#{log_prefix}: Not a frame #{inspect(buffer <> raw)}")
+        end
+
+        {:error, :not_a_frame, socket, struct(connection, buffer: <<>>)}
+
+      {nil, rest} ->
+        {:error, :incomplete_frame, socket, struct(connection, buffer: rest)}
+
+      {received_frame, rest} ->
+        if byte_size(rest) >= @smallest_mavlink_message do
+          resend_stream_message(socket)
+        end
+
+        connection = struct(connection, buffer: rest)
+        validate_frame(received_frame, connection, socket, dialect, log_prefix)
+    end
+  end
+
+  defp validate_frame(
+         received_frame,
+         connection,
+         connection_key,
+         dialect,
+         log_prefix,
+         failure_description \\ nil
+       ) do
+    case validate_and_unpack(received_frame, dialect, connection.signing) do
+      {:ok, valid_frame, signing} ->
+        {:ok, connection_key, struct(connection, signing: signing), valid_frame}
+
+      {:unknown_message, signing} ->
+        Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
+
+        {:ok, connection_key, struct(connection, signing: signing),
+         struct(received_frame, target: :broadcast)}
+
+      {:error, reason, signing} ->
+        Logger.debug(
+          "#{log_prefix}: frame received#{failure_description(failure_description)} failed: #{Atom.to_string(reason)}"
+        )
+
+        {:error, reason, connection_key, struct(connection, signing: signing)}
+    end
+  end
+
+  defp frame_parse_error(
+         raw =
+           <<0xFD, payload_length::unsigned-integer-size(8),
+             incompatible_flags::unsigned-integer-size(8), _rest::binary>>
+       )
+       when incompatible_flags != 0 do
+    complete_length =
+      payload_length + 12 +
+        if Bitwise.band(incompatible_flags, @mavlink_2_signature_flag) != 0 do
+          @mavlink_2_signature_length
+        else
+          0
+        end
+
+    if byte_size(raw) >= complete_length do
+      :incompatible_flags
+    else
+      :incomplete_frame
+    end
+  end
+
+  defp frame_parse_error(_raw), do: :incomplete_frame
+
+  defp parse_error_message(:incompatible_flags), do: "Incompatible MAVLink 2 frame"
+  defp parse_error_message(:incomplete_frame), do: "Incomplete MAVLink frame"
+
+  defp failure_description(nil), do: ""
+  defp failure_description(description), do: " #{description}"
+
+  defp resend_stream_message(socket) when is_port(socket),
+    do: send(self(), {:tcp, socket, <<>>})
+
+  defp resend_stream_message(port) when is_binary(port),
+    do: send(self(), {:circuits_uart, port, <<>>})
+end

--- a/lib/mavlink/connection_spec.ex
+++ b/lib/mavlink/connection_spec.ex
@@ -1,0 +1,67 @@
+defmodule XMAVLink.ConnectionSpec do
+  @moduledoc false
+
+  import XMAVLink.Utils, only: [parse_positive_integer: 1, resolve_address: 1]
+
+  alias XMAVLink.SerialConnection
+  alias XMAVLink.TCPOutConnection
+  alias XMAVLink.UDPInConnection
+  alias XMAVLink.UDPOutConnection
+
+  @type t :: %{
+          required(:transport) => module,
+          required(:tokens) => [term]
+        }
+
+  @spec parse(String.t()) :: t
+  def parse(connection_string) when is_binary(connection_string),
+    do: connection_string |> String.split([":", ","]) |> parse_tokens()
+
+  defp parse_tokens(tokens = ["udpin" | _]),
+    do: %{transport: UDPInConnection, tokens: validate_address_and_port(tokens)}
+
+  defp parse_tokens(tokens = ["udpout" | _]),
+    do: %{transport: UDPOutConnection, tokens: validate_address_and_port(tokens)}
+
+  defp parse_tokens(tokens = ["tcpout" | _]),
+    do: %{transport: TCPOutConnection, tokens: validate_address_and_port(tokens)}
+
+  defp parse_tokens(tokens = ["serial" | _]),
+    do: %{transport: SerialConnection, tokens: validate_port_and_baud(tokens)}
+
+  defp parse_tokens([invalid_protocol | _]),
+    do: raise(ArgumentError, message: "invalid protocol #{invalid_protocol}")
+
+  defp validate_address_and_port([protocol, address, port]) do
+    case {resolve_address(address), parse_positive_integer(port)} do
+      {{:error, reason}, _} ->
+        raise ArgumentError,
+          message: "invalid address #{address}: #{inspect(reason)}"
+
+      {_, :error} ->
+        raise ArgumentError, message: "invalid port #{port}"
+
+      {{:ok, parsed_address}, parsed_port} ->
+        [protocol, parsed_address, parsed_port]
+    end
+  end
+
+  defp validate_address_and_port([protocol | _]),
+    do: raise(ArgumentError, message: "invalid #{protocol} connection string")
+
+  defp validate_port_and_baud(["serial", port, baud]) do
+    case {is_binary(port), parse_positive_integer(baud)} do
+      {false, _} ->
+        raise ArgumentError, message: "Invalid port #{port}"
+
+      {_, :error} ->
+        raise ArgumentError, message: "invalid baud rate #{baud}"
+
+      {true, parsed_baud} ->
+        ["serial", port, parsed_baud]
+    end
+  end
+
+  defp validate_port_and_baud(["serial" | _]),
+    do: raise(ArgumentError, message: "invalid serial connection string")
+end

--- a/lib/mavlink/connection_spec.ex
+++ b/lib/mavlink/connection_spec.ex
@@ -50,14 +50,11 @@ defmodule XMAVLink.ConnectionSpec do
     do: raise(ArgumentError, message: "invalid #{protocol} connection string")
 
   defp validate_port_and_baud(["serial", port, baud]) do
-    case {is_binary(port), parse_positive_integer(baud)} do
-      {false, _} ->
-        raise ArgumentError, message: "Invalid port #{port}"
-
-      {_, :error} ->
+    case parse_positive_integer(baud) do
+      :error ->
         raise ArgumentError, message: "invalid baud rate #{baud}"
 
-      {true, parsed_baud} ->
+      parsed_baud ->
         ["serial", port, parsed_baud]
     end
   end

--- a/lib/mavlink/dialect.ex
+++ b/lib/mavlink/dialect.ex
@@ -1,0 +1,23 @@
+defmodule XMAVLink.Dialect do
+  @moduledoc """
+  Behaviour implemented by generated MAVLink dialect modules.
+
+  The generator already emits these functions for each dialect. This behaviour
+  makes the runtime contract explicit without changing generated module names
+  or message structs.
+  """
+
+  @type target :: :broadcast | :system | :system_component | :component
+
+  @callback mavlink_version() :: non_neg_integer
+  @callback mavlink_dialect() :: non_neg_integer
+  @callback describe(atom) :: String.t()
+  @callback describe_params(atom) :: XMAVLink.Types.param_description_list()
+  @callback encode(atom | integer, atom) :: integer
+  @callback decode(integer, atom) :: atom | integer
+  @callback msg_attributes(XMAVLink.Types.message_id()) ::
+              {:ok, XMAVLink.Types.crc_extra(), pos_integer, target}
+              | {:error, :unknown_message_id}
+  @callback unpack(XMAVLink.Types.message_id(), XMAVLink.Types.version(), binary) ::
+              {:ok, XMAVLink.Message.t()} | {:error, :unknown_message}
+end

--- a/lib/mavlink/local_connection.ex
+++ b/lib/mavlink/local_connection.ex
@@ -207,7 +207,7 @@ defmodule XMAVLink.LocalConnection do
         initial_sequence_number(local_connection, source_identity)
       )
 
-    next_sequence_number = rem(sequence_number + 1, 255)
+    next_sequence_number = rem(sequence_number + 1, 256)
 
     updated_connection = %LocalConnection{
       local_connection

--- a/lib/mavlink/message.ex
+++ b/lib/mavlink/message.ex
@@ -1,4 +1,6 @@
 defprotocol XMAVLink.Message do
+  @fallback_to_any true
+
   @spec pack(XMAVLink.Message.t(), 1 | 2) ::
           {
             :ok,
@@ -15,8 +17,11 @@ defprotocol XMAVLink.Message do
   def pack(message, version)
 end
 
-defimpl XMAVLink.Message,
-  for: [Atom, BitString, Float, Function, Integer, List, Map, PID, Port, Reference, Tuple] do
+defimpl XMAVLink.Message, for: Any do
+  def pack(not_a_message = %{__struct__: _}, _) do
+    raise Protocol.UndefinedError, protocol: XMAVLink.Message, value: not_a_message
+  end
+
   def pack(not_a_message, _),
     do: {:error, "pack(): #{inspect(not_a_message)} is not a MAVLink message"}
 end

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -16,13 +16,15 @@ defmodule XMAVLink.Router do
   use GenServer
   require Logger
 
-  import XMAVLink.Utils, only: [resolve_address: 1, parse_positive_integer: 1]
   alias XMAVLink.Types
+  alias XMAVLink.ConnectionSpec
   alias XMAVLink.ConnectionSupervisor
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
   alias XMAVLink.Message
   alias XMAVLink.Router
+  alias XMAVLink.Router.Config
+  alias XMAVLink.Router.Routing
   alias XMAVLink.Signing
   alias XMAVLink.LocalConnection
   alias XMAVLink.SerialConnection
@@ -30,7 +32,6 @@ defmodule XMAVLink.Router do
   alias XMAVLink.UDPInConnection
   alias XMAVLink.UDPOutConnection
 
-  @system_time_message_id 2
   @setup_signing_message_id 256
 
   @typedoc """
@@ -175,7 +176,7 @@ defmodule XMAVLink.Router do
           [{atom, any}]
         ) :: {:ok, pid}
   def start_link(args, opts \\ []) do
-    args = normalize_start_args(args)
+    args = Config.normalize!(args)
     name = Keyword.get(opts, :name, Map.get(args, :name, __MODULE__))
 
     GenServer.start_link(__MODULE__, Map.put(args, :name, name), start_options(opts, name))
@@ -183,7 +184,7 @@ defmodule XMAVLink.Router do
 
   @doc false
   def child_spec(args) do
-    args = normalize_start_args(args)
+    args = Config.normalize!(args)
     name = Map.get(args, :name, __MODULE__)
 
     %{
@@ -359,39 +360,85 @@ defmodule XMAVLink.Router do
   @spec pack_and_send(router_ref, Message.t(), Types.version(), keyword) ::
           :ok | {:error, :protocol_undefined}
   def pack_and_send(router, message, version, opts) when is_router_ref(router) do
+    case build_frame(message, version, opts) do
+      {:ok, frame} ->
+        # Resolve all router target shapes before dispatch so missing global/via
+        # names fail fast instead of being silently dropped by GenServer.cast/2.
+        dispatch_local(router, frame)
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def pack_and_send(invalid_router, _message, _version, _opts),
+    do: invalid_router_ref!(invalid_router)
+
+  @doc """
+  Synchronously pack, route, and send a MAVLink message.
+
+  This is the structured alternative to `pack_and_send/2..4`. Pass `:version`
+  in `opts` to select MAVLink 1 or 2, and pass `:source_system` plus
+  `:source_component` to override the router's local identity for this message.
+
+  The success reply includes the selected recipient connection keys. Connection
+  keys are internal runtime identifiers, but they are useful for observability
+  and tests.
+  """
+  @spec send_message(Message.t()) :: {:ok, Routing.delivery()} | {:error, term}
+  def send_message(message), do: send_message(__MODULE__, message, [])
+
+  @spec send_message(Message.t(), keyword) :: {:ok, Routing.delivery()} | {:error, term}
+  def send_message(message, opts) when is_map(message) and is_list(opts),
+    do: send_message(__MODULE__, message, opts)
+
+  @spec send_message(router_ref, Message.t()) :: {:ok, Routing.delivery()} | {:error, term}
+  def send_message(router, message) when is_router_ref(router) and is_map(message),
+    do: send_message(router, message, [])
+
+  @spec send_message(router_ref, Message.t(), keyword) ::
+          {:ok, Routing.delivery()} | {:error, term}
+  def send_message(router, message, opts) when is_router_ref(router) and is_map(message) do
+    version = Keyword.get(opts, :version, 2)
+
+    with {:ok, frame} <- build_frame(message, version, opts) do
+      call_local(router, frame)
+    end
+  end
+
+  def send_message(invalid_router, _message, _opts), do: invalid_router_ref!(invalid_router)
+
+  defp build_frame(message, version, opts) do
     source_identity = source_identity!(opts)
 
-    # We can only pack payload at this point because we need router state to get source
-    # system/component and sequence number for frame
     try do
-      {:ok, message_id, {:ok, crc_extra, _, target}, payload} = Message.pack(message, version)
+      case Message.pack(message, version) do
+        {:ok, message_id, {:ok, crc_extra, _, target}, payload} ->
+          {target_system, target_component} =
+            if target != :broadcast do
+              {message.target_system, Map.get(message, :target_component, 0)}
+            else
+              {0, 0}
+            end
 
-      {target_system, target_component} =
-        if target != :broadcast do
-          {message.target_system, Map.get(message, :target_component, 0)}
-        else
-          {0, 0}
-        end
+          {:ok,
+           struct(Frame,
+             version: version,
+             message_id: message_id,
+             source_system: source_identity[:source_system],
+             source_component: source_identity[:source_component],
+             target_system: target_system,
+             target_component: target_component,
+             target: target,
+             message: message,
+             payload: payload,
+             crc_extra: crc_extra
+           )}
 
-      # Resolve all router target shapes before dispatch so missing global/via
-      # names fail fast instead of being silently dropped by GenServer.cast/2.
-      dispatch_local(
-        router,
-        struct(Frame,
-          version: version,
-          message_id: message_id,
-          source_system: source_identity[:source_system],
-          source_component: source_identity[:source_component],
-          target_system: target_system,
-          target_component: target_component,
-          target: target,
-          message: message,
-          payload: payload,
-          crc_extra: crc_extra
-        )
-      )
-
-      :ok
+        {:error, reason} ->
+          {:error, reason}
+      end
     rescue
       # Need to catch Protocol.UndefinedError - happens with SimState (Common) and Simstate (APM)
       # messages because non-case-sensitive filesystems (including OSX thanks @noobz) can't tell
@@ -402,13 +449,17 @@ defmodule XMAVLink.Router do
     end
   end
 
-  def pack_and_send(invalid_router, _message, _version, _opts),
-    do: invalid_router_ref!(invalid_router)
-
   defp dispatch_local(router, frame) do
     case GenServer.whereis(router) do
       nil -> router_not_running!(router)
       pid -> send(pid, {:local, frame})
+    end
+  end
+
+  defp call_local(router, frame) do
+    case GenServer.whereis(router) do
+      nil -> router_not_running!(router)
+      pid -> GenServer.call(pid, {:local, frame})
     end
   end
 
@@ -418,35 +469,6 @@ defmodule XMAVLink.Router do
     do: raise(ArgumentError, "router child_spec requires :id when :name is nil")
 
   defp child_id(_args, name), do: name
-
-  defp normalize_start_args(args) do
-    args = Map.new(args)
-    connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
-    connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
-    remote_forwarding = Map.get(args, :remote_forwarding, true)
-    signing = normalize_signing!(Map.get(args, :signing))
-
-    if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
-      raise ArgumentError, "connection_retry_ms must be a non-negative integer"
-    end
-
-    if not is_boolean(remote_forwarding) do
-      raise ArgumentError, "remote_forwarding must be a boolean"
-    end
-
-    args
-    |> Map.put(:connection_strings, connection_strings)
-    |> Map.put(:connection_retry_ms, connection_retry_ms)
-    |> Map.put(:remote_forwarding, remote_forwarding)
-    |> Map.put(:signing, signing)
-  end
-
-  defp normalize_signing!(signing) do
-    case Signing.new(signing) do
-      {:ok, signing} -> signing
-      {:error, reason} -> raise ArgumentError, "invalid signing config: #{inspect(reason)}"
-    end
-  end
 
   defp start_options(opts, nil), do: Keyword.delete(opts, :name)
 
@@ -477,9 +499,14 @@ defmodule XMAVLink.Router do
   end
 
   defp route_local(frame, state) do
+    {state, _delivery} = route_local_with_delivery(frame, state)
+    state
+  end
+
+  defp route_local_with_delivery(frame, state) do
     LocalConnection.handle_info({:local, frame}, state.connections.local, state.dialect)
     |> update_route_info(state)
-    |> route
+    |> route_with_delivery()
   end
 
   defp source_identity!(opts) do
@@ -522,7 +549,7 @@ defmodule XMAVLink.Router do
     {:ok, connection_supervisor} = ConnectionSupervisor.start_link()
 
     local_connection = LocalConnection.new(args.system, args.component, subscription_cache)
-    connection_specs = Enum.map(args.connection_strings, &connection_spec/1)
+    connection_specs = Enum.map(args.connection_strings, &ConnectionSpec.parse/1)
 
     for connection_spec <- connection_specs do
       start_connection_worker(connection_supervisor, connection_spec, args.connection_retry_ms)
@@ -540,6 +567,12 @@ defmodule XMAVLink.Router do
        signing: args.signing,
        connections: %{local: local_connection}
      }}
+  end
+
+  @impl true
+  def handle_call({:local, frame}, _from, state) do
+    {state, delivery} = route_local_with_delivery(frame, state)
+    {:reply, {:ok, delivery}, state}
   end
 
   @impl true
@@ -772,53 +805,6 @@ defmodule XMAVLink.Router do
     )
   end
 
-  defp connection_spec(connection_string) when is_binary(connection_string),
-    do: connection_spec(String.split(connection_string, [":", ","]))
-
-  defp connection_spec(tokens = ["udpin" | _]),
-    do: %{transport: UDPInConnection, tokens: validate_address_and_port(tokens)}
-
-  defp connection_spec(tokens = ["udpout" | _]),
-    do: %{transport: UDPOutConnection, tokens: validate_address_and_port(tokens)}
-
-  defp connection_spec(tokens = ["tcpout" | _]),
-    do: %{transport: TCPOutConnection, tokens: validate_address_and_port(tokens)}
-
-  defp connection_spec(tokens = ["serial" | _]),
-    do: %{transport: SerialConnection, tokens: validate_port_and_baud(tokens)}
-
-  defp connection_spec([invalid_protocol | _]),
-    do: raise(ArgumentError, message: "invalid protocol #{invalid_protocol}")
-
-  # Parse network connection strings
-  defp validate_address_and_port([protocol, address, port]) do
-    case {resolve_address(address), parse_positive_integer(port)} do
-      {{:error, reason}, _} ->
-        raise ArgumentError,
-          message: "invalid address #{address}: #{inspect(reason)}"
-
-      {_, :error} ->
-        raise ArgumentError, message: "invalid port #{port}"
-
-      {{:ok, parsed_address}, parsed_port} ->
-        [protocol, parsed_address, parsed_port]
-    end
-  end
-
-  # Parse serial port connection string
-  defp validate_port_and_baud(["serial", port, baud]) do
-    case {is_binary(port), parse_positive_integer(baud)} do
-      {false, _} ->
-        raise ArgumentError, message: "Invalid port #{port}"
-
-      {_, :error} ->
-        raise ArgumentError, message: "invalid baud rate #{baud}"
-
-      {true, parsed_baud} ->
-        ["serial", port, parsed_baud]
-    end
-  end
-
   defp reconnect_worker(nil), do: :ok
   defp reconnect_worker(worker), do: ConnectionWorker.reconnect(worker)
 
@@ -855,198 +841,90 @@ defmodule XMAVLink.Router do
     end)
   end
 
-  # A handle_info() received an error and wants us to forget the borked connection
-  defp remove_connection(
-         connection_key,
-         state = %Router{connections: connections, routes: routes, connection_workers: workers}
-       ) do
-    struct(state,
-      connections: Map.delete(connections, connection_key),
-      connection_workers: Map.delete(workers, connection_key),
-      routes:
-        routes
-        |> Enum.reject(fn {_mavlink_address, route_connection_key} ->
-          route_connection_key == connection_key
-        end)
-        |> Map.new()
-    )
+  defp remove_connection(connection_key, state = %Router{}) do
+    Routing.remove_connection(connection_key, state)
   end
 
-  # Map system/component ids to connections on which they have been seen for targeted messages
-  # Keep a list of all connections we have received messages from for broadcast messages
-  defp update_route_info(
-         {:ok, source_connection_key, source_connection,
-          frame = %Frame{
-            source_system: source_system,
-            source_component: source_component
-          }},
-         state = %Router{}
-       ) do
-    state = track_system_time(frame, source_connection_key, state)
+  defp update_route_info(result, state) do
+    case Routing.update_route_info(result, state) do
+      {:ok, source_connection_key, frame, state} ->
+        {:ok, source_connection_key, frame,
+         track_connection_worker(
+           state,
+           source_connection_key,
+           state.connections[source_connection_key]
+         )}
 
-    {
-      :ok,
-      source_connection_key,
-      frame,
-      state
-      |> struct(
-        # Don't add system/components from local connection to routes because local
-        # automatically matches everything in matching_system_components() and we
-        # don't want to receive messages twice
-        routes:
-          case source_connection_key do
-            :local ->
-              state.routes
-
-            _ ->
-              Map.put(
-                state.routes,
-                {source_system, source_component},
-                source_connection_key
-              )
-          end,
-        connections:
-          Map.put(
-            state.connections,
-            source_connection_key,
-            source_connection
-          )
-      )
-      |> track_connection_worker(source_connection_key, source_connection)
-    }
+      {:error, reason, state} ->
+        {:error, reason, track_workers_for_connections(state)}
+    end
   end
 
-  # Connection state still needs to be updated if there is an error
-  defp update_route_info(
-         {:error, reason, connection_key, connection},
-         state = %Router{connections: connections}
-       ) do
-    {
-      :error,
-      reason,
-      state
-      |> struct(
-        connections:
-          Map.put(
-            connections,
-            connection_key,
-            connection
-          )
-      )
-      |> track_connection_worker(connection_key, connection)
-    }
+  defp track_workers_for_connections(state) do
+    Enum.reduce(state.connections, state, fn {connection_key, connection}, updated_state ->
+      track_connection_worker(updated_state, connection_key, connection)
+    end)
   end
 
-  defp track_system_time(_frame, :local, state), do: state
-
-  defp track_system_time(
-         %Frame{
-           message_id: @system_time_message_id,
-           source_system: source_system,
-           source_component: source_component,
-           message: %{time_boot_ms: time_boot_ms}
-         },
-         _source_connection_key,
-         state = %Router{system_time_boot_ms: system_time_boot_ms}
-       )
-       when is_integer(time_boot_ms) do
-    source = {source_system, source_component}
-
-    state =
-      case Map.fetch(system_time_boot_ms, source) do
-        {:ok, previous_time_boot_ms} when time_boot_ms < previous_time_boot_ms ->
-          clear_system_routes(source_system, state)
-
-        _ ->
-          state
-      end
-
-    %Router{
-      state
-      | system_time_boot_ms: Map.put(state.system_time_boot_ms, source, time_boot_ms)
-    }
-  end
-
-  defp track_system_time(_frame, _source_connection_key, state), do: state
-
-  defp clear_system_routes(source_system, state = %Router{}) do
-    %Router{
-      state
-      | routes: reject_system_keys(state.routes, source_system),
-        system_time_boot_ms: reject_system_keys(state.system_time_boot_ms, source_system)
-    }
-  end
-
-  defp reject_system_keys(map, source_system) do
-    map
-    |> Enum.reject(fn {{system, _component}, _value} -> system == source_system end)
-    |> Map.new()
+  defp route(result) do
+    {state, _delivery} = route_with_delivery(result)
+    state
   end
 
   # SETUP_SIGNING carries key material. Inbound provisioning messages are
   # delivered locally for application handling, but never bridged to another
   # MAVLink connection by generic routing.
-  defp route(
+  defp route_with_delivery(
          {:ok, source_connection_key, frame = %Frame{message_id: @setup_signing_message_id},
           state = %Router{connections: connections}}
        )
        when source_connection_key != :local do
-    forward_and_update(:local, connections.local, frame, state)
+    recipients = [:local]
+
+    {
+      forward_and_update(:local, connections.local, frame, state),
+      Routing.delivery(source_connection_key, recipients, frame, state)
+    }
   end
 
-  # Broadcast un-targeted messages to all connections except the
-  # source we received the message from, unless it was local
-  defp route(
-         {:ok, source_connection_key, frame = %Frame{target: :broadcast},
-          state = %Router{connections: connections}}
+  defp route_with_delivery(
+         {:ok, source_connection_key, frame = %Frame{target: :broadcast}, state = %Router{}}
        ) do
-    forward_remote? = source_connection_key == :local or state.remote_forwarding
+    recipients = Routing.broadcast_recipients(source_connection_key, state)
 
-    Enum.reduce(connections, state, fn {connection_key, connection}, routed_state ->
-      if connection_key == :local or
-           (forward_remote? and connection_key != source_connection_key) do
-        forward_and_update(connection_key, connection, frame, routed_state)
-      else
-        routed_state
-      end
-    end)
+    {
+      forward_to_recipients(recipients, frame, state),
+      Routing.delivery(source_connection_key, recipients, frame, state)
+    }
   end
 
-  # Only send targeted messages to observed system/components and local.
-  # Excludes the source connection so we never echo a frame back to the
-  # connection we received it from — symmetric with the broadcast clause
-  # above. Without this, a frame received via udpout from sysid=N gets
-  # the route `routes[{N, _}] = source_socket` registered, then any
-  # targeted frame with target_system=0 (wildcard) — e.g. TIMESYNC,
-  # which the dialect classifies as `:system_component` even with target
-  # fields set to 0 — would have the source-socket connection in
-  # recipients and forward back out the udpout.
-  # Log warning if a message sent locally cannot reach its remote destination
-  defp route(
+  defp route_with_delivery(
          {:ok, source_connection_key,
           frame = %Frame{
-            source_system: source_system,
-            source_component: source_component,
             target_system: target_system,
             target_component: target_component,
             message: %{__struct__: message_type}
-          }, state = %Router{connections: connections}}
+          }, state = %Router{}}
        ) do
     recipients =
-      matching_system_components(target_system, target_component, state)
-      |> Enum.reject(fn key -> key == source_connection_key end)
-      |> remote_forwarding_recipients(source_connection_key, state)
+      Routing.targeted_recipients(target_system, target_component, source_connection_key, state)
 
-    if match?(
-         {^recipients, ^source_system, ^source_component},
-         {[:local], connections.local.system, connections.local.component}
-       ) do
-      :ok =
-        Logger.debug(
-          "Could not send message #{Atom.to_string(message_type)} to #{target_system}/#{target_component}: destination unreachable"
-        )
+    delivery = Routing.delivery(source_connection_key, recipients, frame, state)
+
+    if delivery.unreachable? do
+      Logger.debug(
+        "Could not send message #{Atom.to_string(message_type)} to #{target_system}/#{target_component}: destination unreachable"
+      )
     end
 
+    {forward_to_recipients(recipients, frame, state), delivery}
+  end
+
+  defp route_with_delivery({:error, reason, state = %Router{}}) do
+    {state, {:error, reason}}
+  end
+
+  defp forward_to_recipients(recipients, frame, state) do
     Enum.reduce(recipients, state, fn connection_key, routed_state ->
       forward_and_update(
         connection_key,
@@ -1056,38 +934,6 @@ defmodule XMAVLink.Router do
       )
     end)
   end
-
-  # Swallow any errors from the handle_info |> update_connection_info pipeline
-  defp route({:error, _reason, state = %Router{}}), do: state
-
-  # Known system/components matching target with 0 wildcard
-  # Always include local connection because we get to snoop
-  # on everybody's messages
-  defp matching_system_components(q_system, q_component, %Router{routes: routes}) do
-    [
-      :local
-      | Enum.filter(
-          routes,
-          fn {{sid, cid}, _} ->
-            (q_system == 0 or q_system == sid) and
-              (q_component == 0 or q_component == cid)
-          end
-        )
-        |> Enum.map(fn {_, ck} -> ck end)
-    ]
-  end
-
-  defp remote_forwarding_recipients(recipients, :local, _state), do: recipients
-
-  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
-         remote_forwarding: true
-       }),
-       do: recipients
-
-  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
-         remote_forwarding: false
-       }),
-       do: Enum.filter(recipients, &(&1 == :local))
 
   defp forward_and_update(_connection_key, nil, _frame, state), do: state
 

--- a/lib/mavlink/router/config.ex
+++ b/lib/mavlink/router/config.ex
@@ -1,0 +1,53 @@
+defmodule XMAVLink.Router.Config do
+  @moduledoc false
+
+  alias XMAVLink.Signing
+
+  @type router_name :: XMAVLink.Router.router_name()
+
+  @spec from_application_env() :: map
+  def from_application_env do
+    router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+
+    normalize!(%{
+      name: router_name,
+      dialect: Application.get_env(:xmavlink, :dialect),
+      system: Application.get_env(:xmavlink, :system_id),
+      component: Application.get_env(:xmavlink, :component_id),
+      connection_strings: Application.get_env(:xmavlink, :connections),
+      connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000),
+      remote_forwarding: Application.get_env(:xmavlink, :remote_forwarding, true),
+      signing: Application.get_env(:xmavlink, :signing)
+    })
+  end
+
+  @spec normalize!(map | keyword) :: map
+  def normalize!(args) do
+    args = Map.new(args)
+    connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
+    connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
+    remote_forwarding = Map.get(args, :remote_forwarding, true)
+    signing = normalize_signing!(Map.get(args, :signing))
+
+    if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
+      raise ArgumentError, "connection_retry_ms must be a non-negative integer"
+    end
+
+    if not is_boolean(remote_forwarding) do
+      raise ArgumentError, "remote_forwarding must be a boolean"
+    end
+
+    args
+    |> Map.put(:connection_strings, connection_strings)
+    |> Map.put(:connection_retry_ms, connection_retry_ms)
+    |> Map.put(:remote_forwarding, remote_forwarding)
+    |> Map.put(:signing, signing)
+  end
+
+  defp normalize_signing!(signing) do
+    case Signing.new(signing) do
+      {:ok, signing} -> signing
+      {:error, reason} -> raise ArgumentError, "invalid signing config: #{inspect(reason)}"
+    end
+  end
+end

--- a/lib/mavlink/router/routing.ex
+++ b/lib/mavlink/router/routing.ex
@@ -1,0 +1,188 @@
+defmodule XMAVLink.Router.Routing do
+  @moduledoc false
+
+  alias XMAVLink.Frame
+  alias XMAVLink.Router
+
+  @system_time_message_id 2
+
+  @type delivery :: %{
+          source_connection: Router.connection_key(),
+          recipients: [Router.connection_key()],
+          remote_recipients: [Router.connection_key()],
+          target: XMAVLink.Dialect.target() | nil,
+          message_id: XMAVLink.Types.message_id(),
+          unreachable?: boolean
+        }
+
+  def update_route_info(
+        {:ok, source_connection_key, source_connection,
+         frame = %Frame{
+           source_system: source_system,
+           source_component: source_component
+         }},
+        state = %Router{}
+      ) do
+    state = %Router{} = track_system_time(frame, source_connection_key, state)
+
+    {
+      :ok,
+      source_connection_key,
+      frame,
+      %Router{
+        state
+        | routes:
+            put_learned_route(
+              state.routes,
+              source_connection_key,
+              source_system,
+              source_component
+            ),
+          connections: Map.put(state.connections, source_connection_key, source_connection)
+      }
+    }
+  end
+
+  def update_route_info(
+        {:error, reason, connection_key, connection},
+        state = %Router{connections: connections}
+      ) do
+    {:error, reason,
+     %Router{state | connections: Map.put(connections, connection_key, connection)}}
+  end
+
+  def remove_connection(
+        connection_key,
+        state = %Router{connections: connections, routes: routes, connection_workers: workers}
+      ) do
+    %Router{
+      state
+      | connections: Map.delete(connections, connection_key),
+        connection_workers: Map.delete(workers, connection_key),
+        routes:
+          routes
+          |> Enum.reject(fn {_mavlink_address, route_connection_key} ->
+            route_connection_key == connection_key
+          end)
+          |> Map.new()
+    }
+  end
+
+  def broadcast_recipients(source_connection_key, %Router{connections: connections} = state) do
+    forward_remote? = source_connection_key == :local or state.remote_forwarding
+
+    connections
+    |> Enum.flat_map(fn
+      {:local, _connection} ->
+        [:local]
+
+      {connection_key, _connection}
+      when forward_remote? and connection_key != source_connection_key ->
+        [connection_key]
+
+      _ ->
+        []
+    end)
+    |> uniq()
+  end
+
+  def targeted_recipients(target_system, target_component, source_connection_key, state) do
+    target_system
+    |> matching_system_components(target_component, state)
+    |> Enum.reject(fn key -> key == source_connection_key end)
+    |> remote_forwarding_recipients(source_connection_key, state)
+    |> uniq()
+  end
+
+  def delivery(source_connection_key, recipients, frame, state) do
+    remote_recipients = Enum.reject(recipients, &(&1 == :local))
+
+    %{
+      source_connection: source_connection_key,
+      recipients: recipients,
+      remote_recipients: remote_recipients,
+      target: frame.target,
+      message_id: frame.message_id,
+      unreachable?: unreachable?(source_connection_key, recipients, frame, state)
+    }
+  end
+
+  defp put_learned_route(routes, :local, _source_system, _source_component), do: routes
+
+  defp put_learned_route(routes, source_connection_key, source_system, source_component),
+    do: Map.put(routes, {source_system, source_component}, source_connection_key)
+
+  defp track_system_time(_frame, :local, state), do: state
+
+  defp track_system_time(
+         %Frame{
+           message_id: @system_time_message_id,
+           source_system: source_system,
+           source_component: source_component,
+           message: %{time_boot_ms: time_boot_ms}
+         },
+         _source_connection_key,
+         state = %Router{system_time_boot_ms: system_time_boot_ms}
+       )
+       when is_integer(time_boot_ms) do
+    source = {source_system, source_component}
+
+    state =
+      case Map.fetch(system_time_boot_ms, source) do
+        {:ok, previous_time_boot_ms} when time_boot_ms < previous_time_boot_ms ->
+          clear_system_routes(source_system, state)
+
+        _ ->
+          state
+      end
+
+    %Router{state | system_time_boot_ms: Map.put(state.system_time_boot_ms, source, time_boot_ms)}
+  end
+
+  defp track_system_time(_frame, _source_connection_key, state), do: state
+
+  defp clear_system_routes(source_system, state = %Router{}) do
+    %Router{
+      state
+      | routes: reject_system_keys(state.routes, source_system),
+        system_time_boot_ms: reject_system_keys(state.system_time_boot_ms, source_system)
+    }
+  end
+
+  defp reject_system_keys(map, source_system) do
+    map
+    |> Enum.reject(fn {{system, _component}, _value} -> system == source_system end)
+    |> Map.new()
+  end
+
+  defp matching_system_components(q_system, q_component, %Router{routes: routes}) do
+    [
+      :local
+      | routes
+        |> Enum.filter(fn {{sid, cid}, _} ->
+          (q_system == 0 or q_system == sid) and
+            (q_component == 0 or q_component == cid)
+        end)
+        |> Enum.map(fn {_, ck} -> ck end)
+    ]
+  end
+
+  defp remote_forwarding_recipients(recipients, :local, _state), do: recipients
+
+  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
+         remote_forwarding: true
+       }),
+       do: recipients
+
+  defp remote_forwarding_recipients(recipients, _source_connection_key, %Router{
+         remote_forwarding: false
+       }),
+       do: Enum.filter(recipients, &(&1 == :local))
+
+  defp unreachable?(:local, recipients, %Frame{target: target}, _state) when target != :broadcast,
+    do: recipients == [] or recipients == [:local]
+
+  defp unreachable?(_source_connection_key, _recipients, _frame, _state), do: false
+
+  defp uniq(values), do: Enum.uniq(values)
+end

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -3,15 +3,14 @@ defmodule XMAVLink.SerialConnection do
   XMAVLink.Router delegate for Serial connections
   """
 
-  @smallest_mavlink_message 8
+  @behaviour XMAVLink.Transport
 
   require Logger
 
+  alias XMAVLink.Connection.Inbound
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
   alias Circuits.UART
-
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
 
   defstruct port: nil,
             baud: nil,
@@ -34,47 +33,14 @@ defmodule XMAVLink.SerialConnection do
         receiving_connection = %XMAVLink.SerialConnection{buffer: buffer},
         dialect
       ) do
-    case binary_to_frame_and_tail(buffer <> raw) do
-      :not_a_frame ->
-        # Noise or malformed frame
-        if byte_size(buffer) + byte_size(raw) > 0 do
-          :ok =
-            Logger.debug("SerialConnection.handle_info: Not a frame: #{inspect(buffer <> raw)}")
-        end
-
-        {:error, :not_a_frame, port, struct(receiving_connection, buffer: <<>>)}
-
-      {nil, rest} ->
-        {:error, :incomplete_frame, port, struct(receiving_connection, buffer: rest)}
-
-      {received_frame, rest} ->
-        # Rest could include a complete message, return later to try emptying the buffer
-        if byte_size(rest) >= @smallest_mavlink_message,
-          do: send(self(), {:circuits_uart, port, <<>>})
-
-        connection = struct(receiving_connection, buffer: rest)
-
-        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
-          {:ok, valid_frame, signing} ->
-            {:ok, port, struct(connection, signing: signing), valid_frame}
-
-          {:unknown_message, signing} ->
-            # We re-broadcast valid frames with unknown messages
-            :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
-
-            {:ok, port, struct(connection, signing: signing),
-             struct(received_frame, target: :broadcast)}
-
-          {:error, reason, signing} ->
-            :ok =
-              Logger.debug(
-                "SerialConnection.handle_info: frame received failed: #{Atom.to_string(reason)}"
-              )
-
-            {:error, reason, port, struct(connection, signing: signing)}
-        end
-    end
+    Inbound.stream(
+      raw,
+      receiving_connection,
+      buffer,
+      port,
+      dialect,
+      "SerialConnection.handle_info"
+    )
   end
 
   def open(["serial", port, baud], controlling_process) do

--- a/lib/mavlink/supervisor.ex
+++ b/lib/mavlink/supervisor.ex
@@ -10,6 +10,7 @@ defmodule XMAVLink.Supervisor do
   @impl true
   def init(_) do
     router_name = Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+    router_config = XMAVLink.Router.Config.from_application_env()
 
     children =
       [
@@ -21,19 +22,7 @@ defmodule XMAVLink.Supervisor do
           # How many serial ports might you need?
           max_overflow: 10
         ),
-        {
-          XMAVLink.Router,
-          %{
-            name: router_name,
-            dialect: Application.get_env(:xmavlink, :dialect),
-            system: Application.get_env(:xmavlink, :system_id),
-            component: Application.get_env(:xmavlink, :component_id),
-            connection_strings: Application.get_env(:xmavlink, :connections),
-            connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000),
-            remote_forwarding: Application.get_env(:xmavlink, :remote_forwarding, true),
-            signing: Application.get_env(:xmavlink, :signing)
-          }
-        }
+        {XMAVLink.Router, router_config}
       ] ++ heartbeat_child_specs(router_name)
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -4,13 +4,12 @@ defmodule XMAVLink.TCPOutConnection do
   Typically used to connect to SITL on port 5760
   """
 
-  @smallest_mavlink_message 8
+  @behaviour XMAVLink.Transport
 
   require Logger
+  alias XMAVLink.Connection.Inbound
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
-
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
 
   defstruct socket: nil, address: nil, port: nil, buffer: <<>>, worker: nil, signing: nil
 
@@ -28,46 +27,14 @@ defmodule XMAVLink.TCPOutConnection do
         receiving_connection = %XMAVLink.TCPOutConnection{buffer: buffer},
         dialect
       ) do
-    case binary_to_frame_and_tail(buffer <> raw) do
-      :not_a_frame ->
-        # Noise or malformed frame
-        if byte_size(buffer) + byte_size(raw) > 0 do
-          :ok =
-            Logger.debug("TCPOutConnection.handle_info: Not a frame #{inspect(buffer <> raw)}")
-        end
-
-        {:error, :not_a_frame, socket, struct(receiving_connection, buffer: <<>>)}
-
-      {nil, rest} ->
-        {:error, :incomplete_frame, socket, struct(receiving_connection, buffer: rest)}
-
-      {received_frame, rest} ->
-        # Rest could be a message, return later to try emptying the buffer
-        if byte_size(rest) >= @smallest_mavlink_message, do: send(self(), {:tcp, socket, <<>>})
-
-        connection = struct(receiving_connection, buffer: rest)
-
-        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
-          {:ok, valid_frame, signing} ->
-            {:ok, socket, struct(connection, signing: signing), valid_frame}
-
-          {:unknown_message, signing} ->
-            # We re-broadcast valid frames with unknown messages
-            :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
-
-            {:ok, socket, struct(connection, signing: signing),
-             struct(received_frame, target: :broadcast)}
-
-          {:error, reason, signing} ->
-            :ok =
-              Logger.debug(
-                "TCPOutConnection.handle_info: frame received failed: #{Atom.to_string(reason)}"
-              )
-
-            {:error, reason, socket, struct(connection, signing: signing)}
-        end
-    end
+    Inbound.stream(
+      raw,
+      receiving_connection,
+      buffer,
+      socket,
+      dialect,
+      "TCPOutConnection.handle_info"
+    )
   end
 
   def open(["tcpout", address, port], controlling_process) do

--- a/lib/mavlink/transport.ex
+++ b/lib/mavlink/transport.ex
@@ -1,0 +1,17 @@
+defmodule XMAVLink.Transport do
+  @moduledoc """
+  Behaviour for connection transport delegates used by `XMAVLink.ConnectionWorker`.
+
+  Transport modules own external resources such as sockets or UART handles and
+  expose pure-ish frame handling helpers to the router.
+  """
+
+  @type tokens :: [term]
+  @type connection_key :: term
+  @type connection :: struct
+
+  @callback open(tokens, pid) ::
+              {:ok, connection_key | nil, connection} | {:error, term}
+  @callback close(connection) :: term
+  @callback forward(connection, XMAVLink.Frame.t()) :: term
+end

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -3,14 +3,13 @@ defmodule XMAVLink.UDPInConnection do
   MXAVLink.Router delegate for UDP connections
   """
 
-  require Logger
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
+  @behaviour XMAVLink.Transport
 
+  require Logger
+
+  alias XMAVLink.Connection.Inbound
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
-
-  @mavlink_2_signature_flag 0x01
-  @mavlink_2_signature_length 13
 
   defstruct address: nil,
             port: nil,
@@ -36,46 +35,16 @@ defmodule XMAVLink.UDPInConnection do
   end
 
   def handle_info({:udp, socket, source_addr, source_port, raw}, receiving_connection, dialect) do
-    case binary_to_frame_and_tail(raw) do
-      :not_a_frame ->
-        # Noise or malformed frame
-        :ok = Logger.debug("UDPInConnection.handle_info: Not a frame #{inspect(raw)}")
-        {:error, :not_a_frame, {socket, source_addr, source_port}, receiving_connection}
+    connection_key = {socket, source_addr, source_port}
 
-      {nil, _rest} ->
-        reason = frame_parse_error(raw)
-        :ok = Logger.debug("UDPInConnection.handle_info: #{parse_error_message(reason)}")
-        {:error, reason, {socket, source_addr, source_port}, receiving_connection}
-
-      # UDP sends frame per packet, so ignore rest
-      {received_frame, _rest} ->
-        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
-          {:ok, valid_frame, signing} ->
-            # Include address and port in connection key because multiple
-            # clients can connect to a UDP "in" port.
-            {:ok, {socket, source_addr, source_port},
-             struct(receiving_connection, signing: signing), valid_frame}
-
-          {:unknown_message, signing} ->
-            # We re-broadcast valid frames with unknown messages
-            :ok =
-              Logger.debug("rebroadcasting unknown message with id #{received_frame.message_id}")
-
-            {:ok, {socket, source_addr, source_port},
-             struct(receiving_connection, signing: signing),
-             struct(received_frame, target: :broadcast)}
-
-          {:error, reason, signing} ->
-            :ok =
-              Logger.debug(
-                "UDPInConnection.handle_info: frame received from " <>
-                  "#{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port} failed: #{Atom.to_string(reason)}"
-              )
-
-            {:error, reason, {socket, source_addr, source_port},
-             struct(receiving_connection, signing: signing)}
-        end
-    end
+    Inbound.datagram(
+      raw,
+      receiving_connection,
+      connection_key,
+      dialect,
+      "UDPInConnection.handle_info",
+      "from #{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port}"
+    )
   end
 
   def handle_info({:udp, socket, source_addr, source_port, raw}, nil, dialect, worker) do
@@ -99,32 +68,6 @@ defmodule XMAVLink.UDPInConnection do
       dialect
     )
   end
-
-  defp frame_parse_error(
-         raw =
-           <<0xFD, payload_length::unsigned-integer-size(8),
-             incompatible_flags::unsigned-integer-size(8), _rest::binary>>
-       )
-       when incompatible_flags != 0 do
-    complete_length =
-      payload_length + 12 +
-        if Bitwise.band(incompatible_flags, @mavlink_2_signature_flag) != 0 do
-          @mavlink_2_signature_length
-        else
-          0
-        end
-
-    if byte_size(raw) >= complete_length do
-      :incompatible_flags
-    else
-      :incomplete_frame
-    end
-  end
-
-  defp frame_parse_error(_raw), do: :incomplete_frame
-
-  defp parse_error_message(:incompatible_flags), do: "Incompatible MAVLink 2 frame"
-  defp parse_error_message(:incomplete_frame), do: "Incomplete MAVLink frame"
 
   def open(["udpin", address, port], controlling_process) do
     # Do not add to connections, we don't want to forward to ourselves

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -3,13 +3,12 @@ defmodule XMAVLink.UDPOutConnection do
   XMAVLink.Router delegate for UDP connections
   """
 
+  @behaviour XMAVLink.Transport
+
   require Logger
-  import XMAVLink.Frame, only: [binary_to_frame_and_tail: 1, validate_and_unpack: 3]
+  alias XMAVLink.Connection.Inbound
   alias XMAVLink.ConnectionWorker
   alias XMAVLink.Frame
-
-  @mavlink_2_signature_flag 0x01
-  @mavlink_2_signature_length 13
 
   defstruct address: nil,
             port: nil,
@@ -35,47 +34,14 @@ defmodule XMAVLink.UDPOutConnection do
   end
 
   def handle_info({:udp, socket, source_addr, source_port, raw}, receiving_connection, dialect) do
-    case binary_to_frame_and_tail(raw) do
-      :not_a_frame ->
-        # Noise or malformed frame
-        :ok = Logger.debug("UDPOutConnection.handle_info: Not a frame #{inspect(raw)}")
-        {:error, :not_a_frame, socket, receiving_connection}
-
-      {nil, _rest} ->
-        reason = frame_parse_error(raw)
-        :ok = Logger.debug("UDPOutConnection.handle_info: #{parse_error_message(reason)}")
-        {:error, reason, socket, receiving_connection}
-
-      # UDP sends frame per packet, so ignore rest
-      {received_frame, _rest} ->
-        case validate_and_unpack(received_frame, dialect, receiving_connection.signing) do
-          {:ok, valid_frame, signing} ->
-            # A udpout connection is single-target, single-socket. Key it by
-            # the bare `socket` so update_route_info/2 updates the existing
-            # connection entry rather than creating a sibling under
-            # `{socket, source_addr, source_port}` — which would cause the
-            # broadcast `route/1` clause to forward back out the same UDPOut
-            # (echo) when the reply's source IP differs from the configured
-            # target (NAT / masquerade / kube-proxy DNAT).
-            {:ok, socket, struct(receiving_connection, signing: signing), valid_frame}
-
-          {:unknown_message, signing} ->
-            # We re-broadcast valid frames with unknown messages
-            :ok = Logger.debug("relaying unknown message with id #{received_frame.message_id}")
-
-            {:ok, socket, struct(receiving_connection, signing: signing),
-             struct(received_frame, target: :broadcast)}
-
-          {:error, reason, signing} ->
-            :ok =
-              Logger.debug(
-                "UDPOutConnection.handle_info: frame received from " <>
-                  "#{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port} failed: #{Atom.to_string(reason)}"
-              )
-
-            {:error, reason, socket, struct(receiving_connection, signing: signing)}
-        end
-    end
+    Inbound.datagram(
+      raw,
+      receiving_connection,
+      socket,
+      dialect,
+      "UDPOutConnection.handle_info",
+      "from #{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port}"
+    )
   end
 
   def open(["udpout", address, port], controlling_process) do
@@ -102,32 +68,6 @@ defmodule XMAVLink.UDPOutConnection do
   def close(%XMAVLink.UDPOutConnection{socket: socket}) do
     :gen_udp.close(socket)
   end
-
-  defp frame_parse_error(
-         raw =
-           <<0xFD, payload_length::unsigned-integer-size(8),
-             incompatible_flags::unsigned-integer-size(8), _rest::binary>>
-       )
-       when incompatible_flags != 0 do
-    complete_length =
-      payload_length + 12 +
-        if Bitwise.band(incompatible_flags, @mavlink_2_signature_flag) != 0 do
-          @mavlink_2_signature_length
-        else
-          0
-        end
-
-    if byte_size(raw) >= complete_length do
-      :incompatible_flags
-    else
-      :incomplete_frame
-    end
-  end
-
-  defp frame_parse_error(_raw), do: :incomplete_frame
-
-  defp parse_error_message(:incompatible_flags), do: "Incompatible MAVLink 2 frame"
-  defp parse_error_message(:incomplete_frame), do: "Incomplete MAVLink frame"
 
   def forward(
         connection = %XMAVLink.UDPOutConnection{

--- a/lib/mavlink_util/arm.ex
+++ b/lib/mavlink_util/arm.ex
@@ -4,48 +4,52 @@ defmodule XMAVLink.Util.Arm do
 
   The helpers are intended for the utility layer's selected router and return
   `:ok` or `{:error, reason}`. Retries are bounded by default; pass
-  `:retries`, `:retry_interval_ms`, or `:router` in the options to override the
-  defaults.
+  `:context`, `:retries`, `:retry_interval_ms`, or `:router` in the options to
+  override the defaults.
   """
 
   @arm_retry_interval 3000
   @arm_retries 5
 
   require Logger
-  alias Common.Message.CommandLong
-  alias Common.Message.Heartbeat
   alias XMAVLink.Util.CacheManager
-  import XMAVLink.Util.CacheManager, only: [msg: 2]
-  import XMAVLink.Util.FocusManager, only: [focus: 0]
+  alias XMAVLink.Util.Context
+  import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def arm(opts \\ []) when is_list(opts) do
-    with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
+    with {:ok, {system_id, component_id, mavlink_version}} <- focus(opts) do
       arm(system_id, component_id, mavlink_version, opts)
     end
   end
 
   def arm(system_id, component_id, mavlink_version, opts \\ []) do
     opts = command_opts(opts, @arm_retry_interval, @arm_retries)
+    heartbeat_module = message_module(opts.dialect, :Heartbeat)
 
-    with {:ok, _, %Heartbeat{system_status: system_status}}
+    with {:ok, _, %{__struct__: ^heartbeat_module, system_status: system_status}}
          when system_status in [
                 :mav_state_standby,
                 :mav_state_active,
                 :mav_state_critical,
                 :mav_state_emergency
               ] <-
-           msg({system_id, component_id, mavlink_version}, Heartbeat),
+           CacheManager.msg({system_id, component_id, mavlink_version}, heartbeat_module,
+             context: opts.context
+           ),
          :ok <-
-           XMAVLink.Router.subscribe(opts.router, message: Heartbeat, source_system: system_id) do
+           XMAVLink.Router.subscribe(opts.router,
+             message: heartbeat_module,
+             source_system: system_id
+           ) do
       try do
         do_arm(system_id, component_id, mavlink_version, opts, opts.attempts)
       after
         XMAVLink.Router.unsubscribe(opts.router)
       end
     else
-      {:ok, _, %Heartbeat{system_status: invalid_system_status}} ->
+      {:ok, _, %{__struct__: ^heartbeat_module, system_status: invalid_system_status}} ->
         Logger.warning(
-          "Cannot arm vehicle #{system_id}.#{component_id}: #{Common.describe(invalid_system_status)}"
+          "Cannot arm vehicle #{system_id}.#{component_id}: #{describe(opts.dialect, invalid_system_status)}"
         )
 
         {:error, :cannot_arm_invalid_vehicle_status}
@@ -60,16 +64,20 @@ defmodule XMAVLink.Util.Arm do
   end
 
   def disarm(opts \\ []) when is_list(opts) do
-    with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
+    with {:ok, {system_id, component_id, mavlink_version}} <- focus(opts) do
       disarm(system_id, component_id, mavlink_version, opts)
     end
   end
 
   def disarm(system_id, component_id, mavlink_version, opts \\ []) do
     opts = command_opts(opts, @arm_retry_interval, @arm_retries)
+    heartbeat_module = message_module(opts.dialect, :Heartbeat)
 
     with :ok <-
-           XMAVLink.Router.subscribe(opts.router, message: Heartbeat, source_system: system_id) do
+           XMAVLink.Router.subscribe(opts.router,
+             message: heartbeat_module,
+             source_system: system_id
+           ) do
       try do
         do_disarm(system_id, component_id, mavlink_version, opts, opts.attempts)
       after
@@ -81,14 +89,16 @@ defmodule XMAVLink.Util.Arm do
   defp do_arm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
 
   defp do_arm(system_id, component_id, mavlink_version, opts, attempts) do
+    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+
     with :ok <-
            XMAVLink.Router.pack_and_send(
              opts.router,
-             arm_command(system_id, component_id, 1.0),
+             arm_command(system_id, component_id, 1.0, opts.dialect),
              mavlink_version
            ) do
       receive do
-        %Heartbeat{base_mode: base_mode} ->
+        %{__struct__: ^heartbeat_module, base_mode: base_mode} ->
           if :mav_mode_flag_safety_armed in base_mode do
             Logger.info("Armed vehicle #{system_id}.#{component_id}")
             :ok
@@ -105,14 +115,16 @@ defmodule XMAVLink.Util.Arm do
   defp do_disarm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
 
   defp do_disarm(system_id, component_id, mavlink_version, opts, attempts) do
+    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+
     with :ok <-
            XMAVLink.Router.pack_and_send(
              opts.router,
-             arm_command(system_id, component_id, 0.0),
+             arm_command(system_id, component_id, 0.0, opts.dialect),
              mavlink_version
            ) do
       receive do
-        %Heartbeat{base_mode: base_mode} ->
+        %{__struct__: ^heartbeat_module, base_mode: base_mode} ->
           if :mav_mode_flag_safety_armed not in base_mode do
             Logger.info("Disarmed vehicle #{system_id}.#{component_id}")
             :ok
@@ -126,8 +138,28 @@ defmodule XMAVLink.Util.Arm do
     end
   end
 
-  defp arm_command(system_id, component_id, arm) do
-    %CommandLong{
+  defp command_opts(opts, retry_interval_ms, retries) do
+    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
+    retries = Keyword.get(opts, :retries, retries)
+
+    %{
+      context: context,
+      router: context.router,
+      dialect: context.dialect,
+      table_prefix: context.table_prefix,
+      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, retry_interval_ms),
+      attempts: attempts(retries)
+    }
+  end
+
+  defp attempts(:infinity), do: :infinity
+  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
+
+  defp next_attempts(:infinity), do: :infinity
+  defp next_attempts(attempts), do: attempts - 1
+
+  defp arm_command(system_id, component_id, arm, dialect) do
+    struct(message_module(dialect, :CommandLong), %{
       command: :mav_cmd_component_arm_disarm,
       confirmation: 1,
       param1: arm,
@@ -139,22 +171,16 @@ defmodule XMAVLink.Util.Arm do
       param7: 0.0,
       target_component: component_id,
       target_system: system_id
-    }
+    })
   end
 
-  defp command_opts(opts, retry_interval_ms, retries) do
-    retries = Keyword.get(opts, :retries, retries)
+  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 
-    %{
-      router: Keyword.get(opts, :router, CacheManager.router()),
-      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, retry_interval_ms),
-      attempts: attempts(retries)
-    }
+  defp describe(dialect, value) do
+    if function_exported?(dialect, :describe, 1) do
+      apply(dialect, :describe, [value])
+    else
+      inspect(value)
+    end
   end
-
-  defp attempts(:infinity), do: :infinity
-  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
-
-  defp next_attempts(:infinity), do: :infinity
-  defp next_attempts(attempts), do: attempts - 1
 end

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -314,7 +314,7 @@ defmodule XMAVLink.Util.CacheManager do
          mavlink_major_version,
          state
        ) do
-    if match_message?(message, state.dialect, :Heartbeat) do
+    if message_module?(message, state.dialect, :Heartbeat) do
       # First time this MAV system seen, create a system record
       :ets.insert(
         state.tables.systems,
@@ -355,7 +355,7 @@ defmodule XMAVLink.Util.CacheManager do
          _,
          state
        ) do
-    if match_message?(param_value_msg, state.dialect, :ParamValue) do
+    if message_module?(param_value_msg, state.dialect, :ParamValue) do
       with [{_, system = %{param_count_loaded: param_count_loaded}}] <-
              :ets.lookup(state.tables.systems, {source_system_id, source_component_id}),
            is_new <-
@@ -432,10 +432,8 @@ defmodule XMAVLink.Util.CacheManager do
 
   defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 
-  defp match_message?(%{__struct__: module}, dialect, name),
+  defp message_module?(%{__struct__: module}, dialect, name),
     do: module == message_module(dialect, name)
-
-  defp match_message?(_message, _dialect, _name), do: false
 
   defp describe(dialect, value) do
     if function_exported?(dialect, :describe, 1) do

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -9,18 +9,17 @@ defmodule XMAVLink.Util.CacheManager do
 
   Using ETS tables allows clients to perform read only API operations directly
   on the tables, preventing this GenServer from becoming a bottleneck.
+
+  Use `XMAVLink.Util.Context` when utility state should be scoped to a
+  specific router, dialect, or ETS table namespace.
   """
 
   use GenServer
   require Logger
+  alias XMAVLink.Util.{Context, Defaults, Tables}
   alias XMAVLink.Util.ParamRequest
-  alias Common.Message.Heartbeat
-  alias Common.Message.ParamValue
-  import XMAVLink.Util.FocusManager, only: [focus: 0]
+  import XMAVLink.Util.FocusManager, only: [focus: 0, focus: 1]
 
-  @messages :messages
-  @systems :systems
-  @params :params
   @one_second_loop :one_second_loop
   @five_second_loop :five_second_loop
   @ten_second_loop :ten_second_loop
@@ -28,8 +27,12 @@ defmodule XMAVLink.Util.CacheManager do
   defstruct one_second_interval_ms: 1_000,
             five_second_interval_ms: 5_000,
             ten_second_interval_ms: 10_000,
+            context: nil,
             router: nil,
-            auto_param_request: true
+            auto_param_request: true,
+            dialect: Defaults.default_dialect(),
+            table_prefix: nil,
+            tables: Tables.names()
 
   # API
 
@@ -37,32 +40,56 @@ defmodule XMAVLink.Util.CacheManager do
     GenServer.start_link(__MODULE__, state, Keyword.put_new(opts, :name, __MODULE__))
   end
 
-  def mavs() do
-    with :ok <- require_table(@systems) do
-      scids = :ets.foldl(fn {scid, _}, acc -> [scid | acc] end, [], @systems)
+  def mavs(opts \\ []) do
+    context = Context.new(opts)
+    systems = context.tables.systems
+
+    with :ok <- require_table(systems) do
+      scids = :ets.foldl(fn {scid, _}, acc -> [scid | acc] end, [], systems)
       Logger.info("Listing #{length(scids)} visible vehicles")
       {:ok, scids}
     end
   end
 
-  def router() do
-    case GenServer.whereis(__MODULE__) do
-      nil ->
-        Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+  def router(opts \\ []) do
+    cond do
+      Keyword.has_key?(opts, :context) or Keyword.has_key?(opts, :router) ->
+        Context.new(opts).router
 
-      pid ->
+      pid = GenServer.whereis(__MODULE__) ->
         GenServer.call(pid, :router)
+
+      true ->
+        Context.new().router
     end
   end
 
-  def msg() do
+  def msg(), do: msg([])
+
+  def msg(opts) when is_list(opts) do
+    with {:ok, scid} <- focus(opts) do
+      msg(scid, opts)
+    end
+  end
+
+  def msg(scid = {_, _, _}), do: msg(scid, [])
+
+  def msg(name) do
     with {:ok, scid} <- focus() do
-      msg(scid)
+      msg(scid, name)
     end
   end
 
-  def msg({system_id, component_id, _}) do
-    with :ok <- require_table(@messages) do
+  def msg(name, opts) when is_atom(name) and is_list(opts) do
+    with {:ok, scid} <- focus(opts) do
+      msg(scid, name, opts)
+    end
+  end
+
+  def msg({system_id, component_id, _}, opts) when is_list(opts) do
+    messages = Context.new(opts).tables.messages
+
+    with :ok <- require_table(messages) do
       {
         :ok,
         :ets.foldl(
@@ -74,22 +101,20 @@ defmodule XMAVLink.Util.CacheManager do
               acc
           end,
           %{},
-          @messages
+          messages
         )
       }
     end
   end
 
-  def msg(name) do
-    with {:ok, scid} <- focus() do
-      msg(scid, name)
-    end
-  end
+  def msg(scid = {_, _, _}, msg_type) when is_atom(msg_type), do: msg(scid, msg_type, [])
 
-  def msg({system_id, component_id, _}, msg_type) when is_atom(msg_type) do
-    with :ok <- require_table(@messages),
+  def msg({system_id, component_id, _}, msg_type, opts) when is_atom(msg_type) do
+    messages = Context.new(opts).tables.messages
+
+    with :ok <- require_table(messages),
          [{_key, {received, message}}] <-
-           :ets.lookup(@messages, {system_id, component_id, msg_type}) do
+           :ets.lookup(messages, {system_id, component_id, msg_type}) do
       Logger.info("Most recent \"#{dequalify_msg_type(msg_type)}\" message")
       {:ok, now() - received, message}
     else
@@ -105,15 +130,15 @@ defmodule XMAVLink.Util.CacheManager do
     end
   end
 
-  def params() do
-    with {:ok, scid} <- focus() do
-      params(scid)
+  def params(), do: params([])
+
+  def params(opts) when is_list(opts) do
+    with {:ok, scid} <- focus(opts) do
+      params(scid, opts)
     end
   end
 
-  def params(scid = {_, _, _}) do
-    params(scid, "")
-  end
+  def params(scid = {_, _, _}), do: params(scid, [])
 
   def params(match) when is_binary(match) do
     with {:ok, scid} <- focus() do
@@ -121,13 +146,30 @@ defmodule XMAVLink.Util.CacheManager do
     end
   end
 
-  def params({system_id, component_id, _mavlink_version}, match) when is_binary(match) do
-    with :ok <- require_table(@params),
+  def params(match, opts) when is_binary(match) and is_list(opts) do
+    with {:ok, scid} <- focus(opts) do
+      params(scid, match, opts)
+    end
+  end
+
+  def params(scid = {_, _, _}, opts) when is_list(opts) do
+    params(scid, "", opts)
+  end
+
+  def params(scid = {_, _, _}, match) when is_binary(match), do: params(scid, match, [])
+
+  def params({system_id, component_id, _mavlink_version}, match, opts) when is_binary(match) do
+    context = Context.new(opts)
+    params = context.tables.params
+    param_value_module = message_module(context.dialect, :ParamValue)
+
+    with :ok <- require_table(params),
          match_upcase <- String.upcase(match),
          param_map when is_map(param_map) <-
            :ets.foldl(
              fn
-               {{^system_id, ^component_id, param_id}, {_, %ParamValue{param_value: param_value}}},
+               {{^system_id, ^component_id, param_id},
+                {_, %{__struct__: ^param_value_module, param_value: param_value}}},
                acc ->
                  if String.contains?(param_id, match_upcase) do
                    Enum.into([{param_id, param_value}], acc)
@@ -139,7 +181,7 @@ defmodule XMAVLink.Util.CacheManager do
                  acc
              end,
              %{},
-             @params
+             params
            ) do
       Logger.info("Listing #{param_map |> Map.keys() |> length} parameters matching \"#{match}\"")
       {:ok, param_map}
@@ -155,12 +197,37 @@ defmodule XMAVLink.Util.CacheManager do
 
   @impl true
   def init(opts) do
-    :ets.new(@messages, [:named_table, :protected, {:read_concurrency, true}, :set])
-    :ets.new(@systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
-    :ets.new(@params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    opts = Map.new(opts)
+    context = Context.new(opts)
 
-    state = __MODULE__ |> struct(opts) |> normalize_router()
-    XMAVLink.Router.subscribe(state.router, as_frame: true)
+    :ets.new(context.tables.messages, [:named_table, :protected, {:read_concurrency, true}, :set])
+
+    :ets.new(context.tables.systems, [
+      :named_table,
+      :protected,
+      {:read_concurrency, true},
+      :ordered_set
+    ])
+
+    :ets.new(context.tables.params, [
+      :named_table,
+      :protected,
+      {:read_concurrency, true},
+      :ordered_set
+    ])
+
+    state =
+      __MODULE__
+      |> struct(
+        opts
+        |> Map.put(:context, context)
+        |> Map.put(:router, context.router)
+        |> Map.put(:dialect, context.dialect)
+        |> Map.put(:table_prefix, context.table_prefix)
+        |> Map.put(:tables, context.tables)
+      )
+
+    XMAVLink.Router.subscribe(state.context.router, as_frame: true)
 
     {
       :ok,
@@ -197,10 +264,13 @@ defmodule XMAVLink.Util.CacheManager do
       ) do
     # Get the previously cached message of this type from the MAV, if any
     previous_message_list =
-      :ets.lookup(@messages, {source_system, source_component, message_type})
+      :ets.lookup(state.tables.messages, {source_system, source_component, message_type})
 
     # Replace with the new message
-    :ets.insert(@messages, {{source_system, source_component, message_type}, {now(), message}})
+    :ets.insert(
+      state.tables.messages,
+      {{source_system, source_component, message_type}, {now(), message}}
+    )
 
     # Delegate any message-specific behaviour to handle_mav_message()
     case previous_message_list do
@@ -240,36 +310,38 @@ defmodule XMAVLink.Util.CacheManager do
          source_system_id,
          source_component_id,
          nil,
-         %Heartbeat{type: type, mavlink_version: mavlink_minor_version},
+         %{type: type, mavlink_version: mavlink_minor_version} = message,
          mavlink_major_version,
          state
        ) do
-    # First time this MAV system seen, create a system record
-    :ets.insert(
-      @systems,
-      {
-        {source_system_id, source_component_id},
-        # TODO System struct
-        %{
-          mavlink_major_version: mavlink_major_version,
-          mavlink_minor_version: mavlink_minor_version,
-          param_count: 0,
-          param_count_loaded: 0
+    if match_message?(message, state.dialect, :Heartbeat) do
+      # First time this MAV system seen, create a system record
+      :ets.insert(
+        state.tables.systems,
+        {
+          {source_system_id, source_component_id},
+          # TODO System struct
+          %{
+            mavlink_major_version: mavlink_major_version,
+            mavlink_minor_version: mavlink_minor_version,
+            param_count: 0,
+            param_count_loaded: 0
+          }
         }
-      }
-    )
+      )
 
-    Logger.info(
-      "First sighting of vehicle #{source_system_id}.#{source_component_id}: #{Common.describe(type)}"
-    )
+      Logger.info(
+        "First sighting of vehicle #{source_system_id}.#{source_component_id}: #{describe(state.dialect, type)}"
+      )
 
-    if state.auto_param_request do
-      spawn_link(ParamRequest, :param_request_list, [
-        source_system_id,
-        source_component_id,
-        mavlink_major_version,
-        [router: state.router]
-      ])
+      if state.auto_param_request do
+        spawn_link(ParamRequest, :param_request_list, [
+          source_system_id,
+          source_component_id,
+          mavlink_major_version,
+          [context: state.context]
+        ])
+      end
     end
 
     state
@@ -279,33 +351,36 @@ defmodule XMAVLink.Util.CacheManager do
          source_system_id,
          source_component_id,
          _,
-         param_value_msg = %ParamValue{param_id: param_id, param_count: param_count},
+         param_value_msg = %{param_id: param_id, param_count: param_count},
          _,
          state
        ) do
-    with [{_, system = %{param_count_loaded: param_count_loaded}}] <-
-           :ets.lookup(@systems, {source_system_id, source_component_id}),
-         is_new <-
-           :ets.lookup(@params, {source_system_id, source_component_id, param_id})
-           |> length
-           |> Kernel.==(0),
-         true <-
-           :ets.insert(
-             @params,
-             {{source_system_id, source_component_id, param_id}, {now(), param_value_msg}}
-           ) do
-      # TODO Hidden parameters can become un-hidden, increasing param_count, in which case we need to spawn param_request_list again.
-      :ets.insert(
-        @systems,
-        {
-          {source_system_id, source_component_id},
-          %{
-            system
-            | param_count: param_count,
-              param_count_loaded: if(is_new, do: param_count_loaded + 1, else: param_count_loaded)
+    if match_message?(param_value_msg, state.dialect, :ParamValue) do
+      with [{_, system = %{param_count_loaded: param_count_loaded}}] <-
+             :ets.lookup(state.tables.systems, {source_system_id, source_component_id}),
+           is_new <-
+             :ets.lookup(state.tables.params, {source_system_id, source_component_id, param_id})
+             |> length
+             |> Kernel.==(0),
+           true <-
+             :ets.insert(
+               state.tables.params,
+               {{source_system_id, source_component_id, param_id}, {now(), param_value_msg}}
+             ) do
+        # TODO Hidden parameters can become un-hidden, increasing param_count, in which case we need to spawn param_request_list again.
+        :ets.insert(
+          state.tables.systems,
+          {
+            {source_system_id, source_component_id},
+            %{
+              system
+              | param_count: param_count,
+                param_count_loaded:
+                  if(is_new, do: param_count_loaded + 1, else: param_count_loaded)
+            }
           }
-        }
-      )
+        )
+      end
     end
 
     state
@@ -355,12 +430,18 @@ defmodule XMAVLink.Util.CacheManager do
     end
   end
 
-  defp normalize_router(state = %{router: nil}) do
-    %{
-      state
-      | router: Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
-    }
-  end
+  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 
-  defp normalize_router(state), do: state
+  defp match_message?(%{__struct__: module}, dialect, name),
+    do: module == message_module(dialect, name)
+
+  defp match_message?(_message, _dialect, _name), do: false
+
+  defp describe(dialect, value) do
+    if function_exported?(dialect, :describe, 1) do
+      apply(dialect, :describe, [value])
+    else
+      inspect(value)
+    end
+  end
 end

--- a/lib/mavlink_util/context.ex
+++ b/lib/mavlink_util/context.ex
@@ -1,0 +1,67 @@
+defmodule XMAVLink.Util.Context do
+  @moduledoc """
+  Utility-layer runtime context.
+
+  Utility helpers use this context to choose the router, dialect, and ETS table
+  namespace they operate on. Pass `context: context` to utility functions when
+  an application has more than one MAVLink runtime or when global ETS table
+  names are not acceptable.
+  """
+
+  alias XMAVLink.Util.{Defaults, Tables}
+
+  @type table_prefix :: atom | String.t() | nil
+
+  @type t :: %__MODULE__{
+          router: GenServer.server(),
+          dialect: module,
+          table_prefix: table_prefix,
+          tables: %{required(atom) => atom}
+        }
+
+  defstruct router: nil,
+            dialect: nil,
+            table_prefix: nil,
+            tables: Tables.names()
+
+  @spec new(keyword | map | t) :: t
+  def new(opts \\ [])
+
+  def new(context = %__MODULE__{}) do
+    %__MODULE__{
+      context
+      | router: context.router || configured_router(),
+        dialect: context.dialect || configured_dialect(),
+        tables: Tables.names(context.table_prefix)
+    }
+  end
+
+  def new(opts) when is_list(opts), do: opts |> Map.new() |> new()
+
+  def new(opts) when is_map(opts) do
+    base = base_context(Map.get(opts, :context))
+
+    router = Map.get(opts, :router, base.router || configured_router())
+    dialect = Map.get(opts, :dialect, base.dialect || configured_dialect())
+    table_prefix = Map.get(opts, :table_prefix, base.table_prefix)
+
+    %__MODULE__{
+      router: router,
+      dialect: dialect,
+      table_prefix: table_prefix,
+      tables: Tables.names(table_prefix)
+    }
+  end
+
+  defp base_context(nil), do: %__MODULE__{}
+  defp base_context(context), do: new(context)
+
+  defp configured_router do
+    Application.get_env(:xmavlink, :router_name, XMAVLink.Router) || XMAVLink.Router
+  end
+
+  defp configured_dialect do
+    Application.get_env(:xmavlink, :dialect, Defaults.default_dialect()) ||
+      Defaults.default_dialect()
+  end
+end

--- a/lib/mavlink_util/defaults.ex
+++ b/lib/mavlink_util/defaults.ex
@@ -1,0 +1,7 @@
+defmodule XMAVLink.Util.Defaults do
+  @moduledoc false
+
+  @default_dialect :"Elixir.Common"
+
+  def default_dialect, do: @default_dialect
+end

--- a/lib/mavlink_util/focus_manager.ex
+++ b/lib/mavlink_util/focus_manager.ex
@@ -137,9 +137,9 @@ defmodule XMAVLink.Util.FocusManager do
       {nil, _monitors} ->
         {:noreply, state}
 
-      {monitored_pid, monitors} ->
-        {session, sessions} = Map.pop(state.sessions, monitored_pid)
-        delete_session(session, monitored_pid)
+      {session_key, monitors} ->
+        {session, sessions} = Map.pop(state.sessions, session_key)
+        delete_session(session, session_pid(session_key))
 
         {:noreply,
          %{
@@ -162,19 +162,20 @@ defmodule XMAVLink.Util.FocusManager do
   end
 
   defp put_focus_session(state, tables, pid, scid) do
-    state = drop_focus_monitor(state, pid)
+    session_key = {pid, tables.sessions}
+    state = drop_focus_monitor(state, session_key)
     ref = Process.monitor(pid)
     :ets.insert(tables.sessions, {pid, scid})
 
     %{
       state
-      | monitors: Map.put(state.monitors, ref, pid),
-        sessions: Map.put(state.sessions, pid, {ref, tables.sessions})
+      | monitors: Map.put(state.monitors, ref, session_key),
+        sessions: Map.put(state.sessions, session_key, {ref, tables.sessions})
     }
   end
 
-  defp drop_focus_monitor(state, pid) do
-    case Map.pop(state.sessions, pid) do
+  defp drop_focus_monitor(state, session_key = {pid, _sessions_table}) do
+    case Map.pop(state.sessions, session_key) do
       {nil, _sessions} ->
         state
 
@@ -200,6 +201,8 @@ defmodule XMAVLink.Util.FocusManager do
       :ets.delete(sessions_table, pid)
     end
   end
+
+  defp session_pid({pid, _sessions_table}), do: pid
 
   defp format({s, c, _}), do: format({s, c})
   defp format({s, c}), do: "#{s}.#{c}"

--- a/lib/mavlink_util/focus_manager.ex
+++ b/lib/mavlink_util/focus_manager.ex
@@ -4,15 +4,20 @@ defmodule XMAVLink.Util.FocusManager do
   zero or more local PIDs. The API uses this to streamline iex sessions
   by letting the user select a MAV to work with and transparently adding
   {system_id, component_id} tuples to call arguments.
+
+  Pass `context: context` to read or write focus in a scoped utility table
+  namespace.
   """
 
   use GenServer
   require Logger
+  alias XMAVLink.Util.{Context, Tables}
 
-  @sessions :sessions
-  @systems :systems
-
-  defstruct monitors: %{}, sessions: %{}
+  defstruct monitors: %{},
+            sessions: %{},
+            context: nil,
+            table_prefix: nil,
+            tables: Tables.names()
 
   # API
   def start_link(state, opts \\ []) do
@@ -23,9 +28,17 @@ defmodule XMAVLink.Util.FocusManager do
     self() |> focus()
   end
 
-  def focus(pid) when is_pid(pid) do
-    with :ok <- require_table(@sessions),
-         [{^pid, scid}] <- :ets.lookup(@sessions, pid) do
+  def focus(opts) when is_list(opts), do: focus(self(), opts)
+
+  def focus(pid) when is_pid(pid), do: focus(pid, [])
+
+  def focus(system_id) when is_integer(system_id), do: focus(system_id, 1)
+
+  def focus(pid, opts) when is_pid(pid) do
+    sessions = Context.new(opts).tables.sessions
+
+    with :ok <- require_table(sessions),
+         [{^pid, scid}] <- :ets.lookup(sessions, pid) do
       if pid == self() do
         Logger.info("Vehicle #{format(scid)}")
       else
@@ -43,10 +56,15 @@ defmodule XMAVLink.Util.FocusManager do
     end
   end
 
-  def focus(system_id, component_id \\ 1) do
+  def focus(system_id, component_id) when is_integer(system_id) do
+    focus(system_id, component_id, [])
+  end
+
+  def focus(system_id, component_id, opts)
+      when is_integer(system_id) and is_integer(component_id) and is_list(opts) do
     with pid when is_pid(pid) <- GenServer.whereis(__MODULE__),
          {:ok, {system_id, component_id, _}} <-
-           GenServer.call(pid, {:focus, {system_id, component_id}}) do
+           GenServer.call(pid, {:focus, {system_id, component_id}, Context.new(opts)}) do
       configure_iex_prompt(system_id, component_id)
     else
       nil -> {:error, :not_started}
@@ -56,13 +74,31 @@ defmodule XMAVLink.Util.FocusManager do
 
   @impl true
   def init(opts) do
-    :ets.new(@sessions, [:named_table, :protected, {:read_concurrency, true}, :set])
-    {:ok, struct(__MODULE__, opts)}
+    opts = Map.new(opts)
+    context = Context.new(opts)
+
+    :ets.new(context.tables.sessions, [:named_table, :protected, {:read_concurrency, true}, :set])
+
+    {:ok,
+     struct(
+       __MODULE__,
+       opts
+       |> Map.put(:context, context)
+       |> Map.put(:table_prefix, context.table_prefix)
+       |> Map.put(:tables, context.tables)
+     )}
   end
 
   @impl true
-  def handle_call({:focus, scid = {system_id, component_id}}, {caller_pid, _}, state) do
-    with :ok <- require_table(@systems),
+  def handle_call(
+        {:focus, scid = {system_id, component_id}, context},
+        {caller_pid, _},
+        state
+      ) do
+    tables = context.tables
+
+    with :ok <- require_table(tables.systems),
+         :ok <- require_writable_table(tables.sessions),
          mavlink_major_version when is_number(mavlink_major_version) <-
            :ets.foldl(
              fn {next_scid, %{mavlink_major_version: mmv}}, acc ->
@@ -73,11 +109,15 @@ defmodule XMAVLink.Util.FocusManager do
                end
              end,
              0,
-             @systems
+             tables.systems
            ) do
       if mavlink_major_version > 0 do
         state =
-          put_focus_session(state, caller_pid, {system_id, component_id, mavlink_major_version})
+          put_focus_session(state, tables, caller_pid, {
+            system_id,
+            component_id,
+            mavlink_major_version
+          })
 
         Logger.info("Set focus to #{format(scid)}")
         {:reply, {:ok, {system_id, component_id, mavlink_major_version}}, state}
@@ -98,13 +138,14 @@ defmodule XMAVLink.Util.FocusManager do
         {:noreply, state}
 
       {monitored_pid, monitors} ->
-        :ets.delete(@sessions, monitored_pid)
+        {session, sessions} = Map.pop(state.sessions, monitored_pid)
+        delete_session(session, monitored_pid)
 
         {:noreply,
          %{
            state
            | monitors: monitors,
-             sessions: Map.delete(state.sessions, monitored_pid)
+             sessions: sessions
          }}
     end
   end
@@ -120,15 +161,15 @@ defmodule XMAVLink.Util.FocusManager do
     :ok
   end
 
-  defp put_focus_session(state, pid, scid) do
+  defp put_focus_session(state, tables, pid, scid) do
     state = drop_focus_monitor(state, pid)
     ref = Process.monitor(pid)
-    :ets.insert(@sessions, {pid, scid})
+    :ets.insert(tables.sessions, {pid, scid})
 
     %{
       state
       | monitors: Map.put(state.monitors, ref, pid),
-        sessions: Map.put(state.sessions, pid, ref)
+        sessions: Map.put(state.sessions, pid, {ref, tables.sessions})
     }
   end
 
@@ -137,14 +178,26 @@ defmodule XMAVLink.Util.FocusManager do
       {nil, _sessions} ->
         state
 
-      {ref, sessions} ->
+      {{ref, sessions_table}, sessions} ->
         Process.demonitor(ref, [:flush])
+        delete_session_table_entry(sessions_table, pid)
 
         %{
           state
           | monitors: Map.delete(state.monitors, ref),
             sessions: sessions
         }
+    end
+  end
+
+  defp delete_session(nil, _pid), do: :ok
+
+  defp delete_session({_ref, sessions_table}, pid),
+    do: delete_session_table_entry(sessions_table, pid)
+
+  defp delete_session_table_entry(sessions_table, pid) do
+    if :ets.info(sessions_table) != :undefined do
+      :ets.delete(sessions_table, pid)
     end
   end
 
@@ -155,6 +208,20 @@ defmodule XMAVLink.Util.FocusManager do
     case :ets.info(table) do
       :undefined -> {:error, :not_started}
       _ -> :ok
+    end
+  end
+
+  defp require_writable_table(table) do
+    case :ets.info(table) do
+      :undefined ->
+        {:error, :not_started}
+
+      _ ->
+        if :ets.info(table, :owner) == self() or :ets.info(table, :protection) == :public do
+          :ok
+        else
+          {:error, :not_started}
+        end
     end
   end
 end

--- a/lib/mavlink_util/param_request.ex
+++ b/lib/mavlink_util/param_request.ex
@@ -4,20 +4,20 @@ defmodule XMAVLink.Util.ParamRequest do
 
   The helper watches `XMAVLink.Util.CacheManager` state and resends
   `PARAM_REQUEST_LIST` while the cached parameter count is not progressing.
-  Retries are bounded by default; pass `:retries`, `:retry_interval_ms`, or
-  `:router` in the options to override the defaults.
+  Retries are bounded by default; pass `:context`, `:retries`,
+  `:retry_interval_ms`, or `:router` in the options to override the defaults.
   """
 
-  @systems :systems
   @param_retry_interval 3000
   @param_retries 10
 
   require Logger
   alias XMAVLink.Util.CacheManager
-  import XMAVLink.Util.FocusManager, only: [focus: 0]
+  alias XMAVLink.Util.Context
+  import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def param_request_list(opts \\ []) when is_list(opts) do
-    with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
+    with {:ok, {system_id, component_id, mavlink_version}} <- focus(opts) do
       Logger.info("Waiting to receive first parameter from vehicle #{system_id}.#{component_id}")
       param_request_list(system_id, component_id, mavlink_version, opts)
     end
@@ -43,9 +43,11 @@ defmodule XMAVLink.Util.ParamRequest do
          last_param_count_loaded,
          opts
        ) do
-    with :ok <- require_table(@systems),
+    systems = opts.context.tables.systems
+
+    with :ok <- require_table(systems),
          [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <-
-           :ets.lookup(@systems, {system_id, component_id}),
+           :ets.lookup(systems, {system_id, component_id}),
          retry <- param_count_loaded == last_param_count_loaded,
          complete <- param_count_loaded == param_count and param_count > 0 do
       cond do
@@ -99,19 +101,23 @@ defmodule XMAVLink.Util.ParamRequest do
   defp maybe_send_param_request(true, system_id, component_id, mavlink_version, opts) do
     XMAVLink.Router.pack_and_send(
       opts.router,
-      %Common.Message.ParamRequestList{
+      struct(message_module(opts.dialect, :ParamRequestList), %{
         target_system: system_id,
         target_component: component_id
-      },
+      }),
       mavlink_version
     )
   end
 
   defp command_opts(opts) do
+    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
     retries = Keyword.get(opts, :retries, @param_retries)
 
     %{
-      router: Keyword.get(opts, :router, CacheManager.router()),
+      context: context,
+      router: context.router,
+      dialect: context.dialect,
+      table_prefix: context.table_prefix,
       retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
       attempts: attempts(retries),
       source_opts: opts
@@ -130,4 +136,6 @@ defmodule XMAVLink.Util.ParamRequest do
       _ -> :ok
     end
   end
+
+  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 end

--- a/lib/mavlink_util/param_set.ex
+++ b/lib/mavlink_util/param_set.ex
@@ -4,22 +4,20 @@ defmodule XMAVLink.Util.ParamSet do
 
   The helper uses the parameter type cached by `XMAVLink.Util.CacheManager`,
   sends `PARAM_SET`, and waits for a matching `PARAM_VALUE` confirmation.
-  Retries are bounded by default; pass `:retries`, `:retry_interval_ms`, or
-  `:router` in the options to override the defaults.
+  Retries are bounded by default; pass `:context`, `:retries`,
+  `:retry_interval_ms`, or `:router` in the options to override the defaults.
   """
 
-  @params :params
   @param_retry_interval 3000
   @param_retries 5
 
   require Logger
   alias XMAVLink.Util.CacheManager
-  alias Common.Message.ParamValue
-  alias Common.Message.ParamSet
-  import XMAVLink.Util.FocusManager, only: [focus: 0]
+  alias XMAVLink.Util.Context
+  import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def param_set(param, new_value, opts \\ []) when is_list(opts) do
-    with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
+    with {:ok, {system_id, component_id, mavlink_version}} <- focus(opts) do
       param_set(system_id, component_id, mavlink_version, param, new_value, opts)
     end
   end
@@ -27,12 +25,20 @@ defmodule XMAVLink.Util.ParamSet do
   def param_set(system_id, component_id, mavlink_version, param, new_value, opts \\ []) do
     param = normalize_param_id(param)
     opts = command_opts(opts)
+    params = opts.context.tables.params
+    param_value_module = message_module(opts.dialect, :ParamValue)
 
-    with :ok <- require_table(@params),
-         [{{^system_id, ^component_id, ^param}, {_time, %ParamValue{param_type: param_type}}}] <-
-           :ets.lookup(@params, {system_id, component_id, param}),
+    with :ok <- require_table(params),
+         [
+           {{^system_id, ^component_id, ^param},
+            {_time, %{__struct__: ^param_value_module, param_type: param_type}}}
+         ] <-
+           :ets.lookup(params, {system_id, component_id, param}),
          :ok <-
-           XMAVLink.Router.subscribe(opts.router, message: ParamValue, source_system: system_id) do
+           XMAVLink.Router.subscribe(opts.router,
+             message: param_value_module,
+             source_system: system_id
+           ) do
       try do
         do_param_set(system_id, component_id, mavlink_version, param, new_value, param_type, opts)
       after
@@ -56,20 +62,22 @@ defmodule XMAVLink.Util.ParamSet do
        do: {:error, :timeout}
 
   defp do_param_set(system_id, component_id, mavlink_version, param, new_value, param_type, opts) do
+    param_value_module = message_module(opts.dialect, :ParamValue)
+
     with :ok <-
            XMAVLink.Router.pack_and_send(
              opts.router,
-             %ParamSet{
+             struct(message_module(opts.dialect, :ParamSet), %{
                target_system: system_id,
                target_component: component_id,
                param_id: param,
                param_value: new_value,
                param_type: param_type
-             },
+             }),
              mavlink_version
            ) do
       receive do
-        %ParamValue{param_id: ^param, param_value: ^new_value} ->
+        %{__struct__: ^param_value_module, param_id: ^param, param_value: ^new_value} ->
           Logger.info(
             "Set #{String.downcase(param)} to #{inspect(new_value)} for vehicle #{system_id}.#{component_id}"
           )
@@ -96,10 +104,14 @@ defmodule XMAVLink.Util.ParamSet do
   defp normalize_param_id(param) when is_binary(param), do: String.upcase(param)
 
   defp command_opts(opts) do
+    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
     retries = Keyword.get(opts, :retries, @param_retries)
 
     %{
-      router: Keyword.get(opts, :router, CacheManager.router()),
+      context: context,
+      router: context.router,
+      dialect: context.dialect,
+      table_prefix: context.table_prefix,
       retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
       attempts: attempts(retries)
     }
@@ -117,4 +129,6 @@ defmodule XMAVLink.Util.ParamSet do
       _ -> :ok
     end
   end
+
+  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 end

--- a/lib/mavlink_util/sitl.ex
+++ b/lib/mavlink_util/sitl.ex
@@ -6,16 +6,15 @@ defmodule XMAVLink.Util.SITL do
   messages and forwards the eight primary channels as little-endian 16-bit
   values to a SITL RC input UDP endpoint. Pass `:router` to target a named
   router and `:destination_address` to forward somewhere other than
-  `{127, 0, 0, 1}`.
+  `{127, 0, 0, 1}`. Pass `:context` to use a scoped utility runtime.
   """
 
   require Logger
   import XMAVLink.Utils, only: [resolve_address: 1]
 
   alias XMAVLink.Util.CacheManager
-  alias Common.Message.RcChannelsRaw
-  alias Common.Message.RequestDataStream
-  import XMAVLink.Util.FocusManager, only: [focus: 0]
+  alias XMAVLink.Util.Context
+  import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   @resend_stream_interval 90
 
@@ -24,19 +23,22 @@ defmodule XMAVLink.Util.SITL do
   def forward_rc(opts, []) when is_list(opts), do: forward_rc(5501, opts)
 
   def forward_rc(sitl_rc_in_port, opts) do
-    with {:ok, {system_id, component_id, mavlink_version}} <- focus() do
+    with {:ok, {system_id, component_id, mavlink_version}} <- focus(opts) do
       forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port, opts)
     end
   end
 
   def forward_rc(system_id, component_id, mavlink_version, sitl_rc_in_port, opts \\ []) do
+    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
+
     Task.start_link(__MODULE__, :_connect, [
       system_id,
       component_id,
       mavlink_version,
       sitl_rc_in_port,
-      Keyword.get(opts, :router, CacheManager.router()),
-      Keyword.get(opts, :destination_address, {127, 0, 0, 1})
+      context.router,
+      Keyword.get(opts, :destination_address, {127, 0, 0, 1}),
+      context.dialect
     ])
   end
 
@@ -46,14 +48,17 @@ defmodule XMAVLink.Util.SITL do
         mavlink_version,
         sitl_rc_in_port,
         router,
-        destination_address
+        destination_address \\ nil,
+        dialect \\ Context.new().dialect
       ) do
+    rc_channels_raw_module = message_module(dialect, :RcChannelsRaw)
+
     with {:ok, destination_address} <- resolve_destination_address(destination_address),
          {:ok, socket} <- :gen_udp.open(0, [:binary, ip: {127, 0, 0, 1}]),
          :ok <-
            XMAVLink.Router.subscribe(
              router,
-             message: RcChannelsRaw,
+             message: rc_channels_raw_module,
              source_system: system_id,
              source_component: component_id
            ) do
@@ -69,7 +74,8 @@ defmodule XMAVLink.Util.SITL do
         socket,
         0,
         router,
-        destination_address
+        destination_address,
+        dialect
       )
     else
       {:error, reason} ->
@@ -89,19 +95,20 @@ defmodule XMAVLink.Util.SITL do
         socket,
         0,
         router,
-        destination_address
+        destination_address,
+        dialect
       ) do
     XMAVLink.Router.pack_and_send(
       router,
-      %RequestDataStream{
+      struct(message_module(dialect, :RequestDataStream), %{
         target_system: system_id,
         # APM Planner sends this, doesn't work with real component id
         target_component: 0,
         # TODO Not a bitmask, where is clue in MAVlink that this field is related?
-        req_stream_id: Common.encode(:mav_data_stream_rc_channels, :mav_data_stream),
+        req_stream_id: apply(dialect, :encode, [:mav_data_stream_rc_channels, :mav_data_stream]),
         req_message_rate: 18,
         start_stop: 1
-      },
+      }),
       mavlink_version
     )
 
@@ -113,7 +120,8 @@ defmodule XMAVLink.Util.SITL do
       socket,
       @resend_stream_interval,
       router,
-      destination_address
+      destination_address,
+      dialect
     )
   end
 
@@ -125,10 +133,14 @@ defmodule XMAVLink.Util.SITL do
         socket,
         count,
         router,
-        destination_address
+        destination_address,
+        dialect
       ) do
+    rc_channels_raw_module = message_module(dialect, :RcChannelsRaw)
+
     receive do
-      %RcChannelsRaw{
+      %{
+        __struct__: ^rc_channels_raw_module,
         chan1_raw: c1,
         chan2_raw: c2,
         chan3_raw: c3,
@@ -162,7 +174,8 @@ defmodule XMAVLink.Util.SITL do
           socket,
           count - 1,
           router,
-          destination_address
+          destination_address,
+          dialect
         )
     end
   end
@@ -176,4 +189,6 @@ defmodule XMAVLink.Util.SITL do
 
   defp resolve_destination_address(address) when is_binary(address), do: resolve_address(address)
   defp resolve_destination_address(_address), do: {:error, :invalid_destination_address}
+
+  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 end

--- a/lib/mavlink_util/supervisor.ex
+++ b/lib/mavlink_util/supervisor.ex
@@ -2,6 +2,7 @@ defmodule XMAVLink.Util.Supervisor do
   @moduledoc false
 
   use Supervisor
+  alias XMAVLink.Util.Context
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -9,12 +10,16 @@ defmodule XMAVLink.Util.Supervisor do
 
   @impl true
   def init(opts) do
-    router = Keyword.get(opts, :router, XMAVLink.Router)
+    context = Context.new(opts)
     auto_param_request = Keyword.get(opts, :auto_param_request, true)
 
     children = [
-      {XMAVLink.Util.FocusManager, %{}},
-      {XMAVLink.Util.CacheManager, %{router: router, auto_param_request: auto_param_request}}
+      {XMAVLink.Util.FocusManager, %{context: context}},
+      {XMAVLink.Util.CacheManager,
+       %{
+         context: context,
+         auto_param_request: auto_param_request
+       }}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/mavlink_util/tables.ex
+++ b/lib/mavlink_util/tables.ex
@@ -1,0 +1,31 @@
+defmodule XMAVLink.Util.Tables do
+  @moduledoc false
+
+  @kinds [:messages, :systems, :params, :sessions]
+
+  def names(opts_or_prefix \\ []) do
+    prefix = prefix(opts_or_prefix)
+
+    Map.new(@kinds, fn kind ->
+      {kind, table_name(kind, prefix)}
+    end)
+  end
+
+  def name(kind, opts_or_prefix \\ []) when kind in @kinds do
+    table_name(kind, prefix(opts_or_prefix))
+  end
+
+  defp table_name(kind, nil), do: kind
+  defp table_name(kind, prefix), do: :"#{prefix}_#{kind}"
+
+  defp prefix(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :context) do
+      {:ok, %{table_prefix: prefix}} -> Keyword.get(opts, :table_prefix, prefix)
+      :error -> Keyword.get(opts, :table_prefix)
+    end
+  end
+
+  defp prefix(%{table_prefix: prefix}), do: prefix
+  defp prefix(nil), do: nil
+  defp prefix(prefix) when is_atom(prefix) or is_binary(prefix), do: prefix
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.13.1",
+      version: "0.14.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -2,6 +2,7 @@ defmodule XMAVLink.Util.CacheManager.Test do
   use ExUnit.Case
 
   alias XMAVLink.Util.CacheManager
+  alias XMAVLink.Util.Context
 
   setup do
     delete_utility_tables()
@@ -82,6 +83,57 @@ defmodule XMAVLink.Util.CacheManager.Test do
            ] = :ets.lookup(:systems, {1, 1})
   end
 
+  test "caches and reads messages from prefixed utility tables" do
+    context = Context.new(router: XMAVLink.Router, dialect: Common, table_prefix: :vehicle_a)
+    tables = context.tables
+    delete_tables(Map.values(tables))
+    create_utility_tables(tables)
+
+    on_exit(fn -> delete_tables(Map.values(tables)) end)
+
+    heartbeat = %Common.Message.Heartbeat{
+      type: :mav_type_quadrotor,
+      autopilot: :mav_autopilot_ardupilotmega,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+
+    frame = %XMAVLink.Frame{
+      message: heartbeat,
+      source_system: 1,
+      source_component: 1,
+      version: 2
+    }
+
+    state = %CacheManager{
+      context: context,
+      router: context.router,
+      auto_param_request: false,
+      dialect: context.dialect,
+      table_prefix: context.table_prefix,
+      tables: context.tables
+    }
+
+    assert {:noreply, ^state} = CacheManager.handle_info(frame, state)
+
+    assert [
+             {{1, 1},
+              %{
+                mavlink_major_version: 2,
+                mavlink_minor_version: 3,
+                param_count: 0,
+                param_count_loaded: 0
+              }}
+           ] = :ets.lookup(tables.systems, {1, 1})
+
+    assert {:ok, [{1, 1}]} = CacheManager.mavs(context: context)
+
+    assert {:ok, _age_ms, ^heartbeat} =
+             CacheManager.msg({1, 1, 2}, Common.Message.Heartbeat, context: context)
+  end
+
   test "one second loop reschedules one second loop" do
     state = %CacheManager{one_second_interval_ms: 1}
 
@@ -117,12 +169,21 @@ defmodule XMAVLink.Util.CacheManager.Test do
     :ets.new(:params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
   end
 
+  defp create_utility_tables(tables) do
+    :ets.new(tables.messages, [:named_table, :protected, {:read_concurrency, true}, :set])
+    :ets.new(tables.systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    :ets.new(tables.params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    :ets.new(tables.sessions, [:named_table, :protected, {:read_concurrency, true}, :set])
+  end
+
   defp delete_utility_tables do
     delete_table(:messages)
     delete_table(:systems)
     delete_table(:params)
     delete_table(:sessions)
   end
+
+  defp delete_tables(tables), do: Enum.each(tables, &delete_table/1)
 
   defp delete_table(table) do
     if :ets.info(table) != :undefined do

--- a/test/focus_manager_test.exs
+++ b/test/focus_manager_test.exs
@@ -54,17 +54,27 @@ defmodule XMAVLink.Util.FocusManager.Test do
   end
 
   test "focus can be scoped to a utility context" do
-    context = Context.new(table_prefix: :vehicle_a)
-    delete_tables(Map.values(context.tables))
-    create_systems_table(context.tables.systems)
-    create_sessions_table(context.tables.sessions)
+    first_context = Context.new(table_prefix: :vehicle_a)
+    second_context = Context.new(table_prefix: :vehicle_b)
+    delete_tables(Map.values(first_context.tables))
+    delete_tables(Map.values(second_context.tables))
+    create_systems_table(first_context.tables.systems)
+    create_systems_table(second_context.tables.systems)
+    create_sessions_table(first_context.tables.sessions)
+    create_sessions_table(second_context.tables.sessions)
 
-    on_exit(fn -> delete_tables(Map.values(context.tables)) end)
+    on_exit(fn ->
+      delete_tables(Map.values(first_context.tables))
+      delete_tables(Map.values(second_context.tables))
+    end)
 
-    :ets.insert(context.tables.systems, {{2, 1}, %{mavlink_major_version: 2}})
+    :ets.insert(first_context.tables.systems, {{2, 1}, %{mavlink_major_version: 2}})
+    :ets.insert(second_context.tables.systems, {{3, 1}, %{mavlink_major_version: 2}})
 
-    assert :ok = FocusManager.focus(2, 1, context: context)
-    assert {:ok, {2, 1, 2}} = FocusManager.focus(context: context)
+    assert :ok = FocusManager.focus(2, 1, context: first_context)
+    assert :ok = FocusManager.focus(3, 1, context: second_context)
+    assert {:ok, {2, 1, 2}} = FocusManager.focus(context: first_context)
+    assert {:ok, {3, 1, 2}} = FocusManager.focus(context: second_context)
     assert {:error, :not_focussed} = FocusManager.focus()
   end
 

--- a/test/focus_manager_test.exs
+++ b/test/focus_manager_test.exs
@@ -2,6 +2,7 @@ defmodule XMAVLink.Util.FocusManager.Test do
   use ExUnit.Case
 
   alias XMAVLink.Util.FocusManager
+  alias XMAVLink.Util.Context
 
   setup do
     delete_table(:sessions)
@@ -52,6 +53,21 @@ defmodule XMAVLink.Util.FocusManager.Test do
     assert_focus_cleared(pid)
   end
 
+  test "focus can be scoped to a utility context" do
+    context = Context.new(table_prefix: :vehicle_a)
+    delete_tables(Map.values(context.tables))
+    create_systems_table(context.tables.systems)
+    create_sessions_table(context.tables.sessions)
+
+    on_exit(fn -> delete_tables(Map.values(context.tables)) end)
+
+    :ets.insert(context.tables.systems, {{2, 1}, %{mavlink_major_version: 2}})
+
+    assert :ok = FocusManager.focus(2, 1, context: context)
+    assert {:ok, {2, 1, 2}} = FocusManager.focus(context: context)
+    assert {:error, :not_focussed} = FocusManager.focus()
+  end
+
   defp assert_focus_cleared(pid, attempts \\ 20)
 
   defp assert_focus_cleared(pid, attempts) when attempts > 0 do
@@ -70,8 +86,18 @@ defmodule XMAVLink.Util.FocusManager.Test do
   end
 
   defp create_systems_table do
-    :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    create_systems_table(:systems)
   end
+
+  defp create_systems_table(table) do
+    :ets.new(table, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+  end
+
+  defp create_sessions_table(table) do
+    :ets.new(table, [:named_table, :public, {:read_concurrency, true}, :set])
+  end
+
+  defp delete_tables(tables), do: Enum.each(tables, &delete_table/1)
 
   defp delete_table(table) do
     if :ets.info(table) != :undefined do

--- a/test/mavlink_application_test.exs
+++ b/test/mavlink_application_test.exs
@@ -51,6 +51,41 @@ defmodule XMAVLink.ApplicationTest do
     assert %XMAVLink.Util.CacheManager{auto_param_request: false} = :sys.get_state(cache_manager)
   end
 
+  test "passes utility context to utility processes" do
+    previous_env =
+      save_env([:dialect, :router_name, :connections, :utilities, :heartbeat, :heartbeats])
+
+    context =
+      XMAVLink.Util.Context.new(
+        router: XMAVLink.Router,
+        dialect: Common,
+        table_prefix: :vehicle_a
+      )
+
+    Application.put_env(:xmavlink, :dialect, Common)
+    Application.put_env(:xmavlink, :router_name, XMAVLink.Router)
+    Application.put_env(:xmavlink, :connections, [])
+    Application.put_env(:xmavlink, :utilities, context: context)
+    Application.delete_env(:xmavlink, :heartbeat)
+    Application.delete_env(:xmavlink, :heartbeats)
+    delete_tables(Map.values(context.tables))
+
+    assert {:ok, supervisor} = XMAVLink.Application.start(:normal, [])
+
+    on_exit(fn ->
+      stop_supervisor(supervisor)
+      cleanup_process(XMAVLink.SubscriptionCache)
+      delete_tables(Map.values(context.tables))
+      restore_env(previous_env)
+    end)
+
+    cache_manager = Process.whereis(XMAVLink.Util.CacheManager)
+
+    assert %XMAVLink.Util.CacheManager{context: ^context} = :sys.get_state(cache_manager)
+    assert :ets.info(context.tables.messages) != :undefined
+    assert :ets.info(:messages) == :undefined
+  end
+
   test "rejects invalid utility options with a clear error" do
     previous_env =
       save_env([:dialect, :router_name, :connections, :utilities, :heartbeat, :heartbeats])
@@ -97,7 +132,11 @@ defmodule XMAVLink.ApplicationTest do
   end
 
   defp delete_utility_tables do
-    for table <- [:messages, :systems, :params, :sessions], :ets.info(table) != :undefined do
+    delete_tables([:messages, :systems, :params, :sessions])
+  end
+
+  defp delete_tables(tables) do
+    for table <- tables, :ets.info(table) != :undefined do
       :ets.delete(table)
     end
   end

--- a/test/mavlink_message_test.exs
+++ b/test/mavlink_message_test.exs
@@ -1,0 +1,18 @@
+defmodule XMAVLink.Test.Message do
+  use ExUnit.Case
+
+  defmodule UnknownStruct do
+    defstruct [:value]
+  end
+
+  test "invalid non-message terms return an explicit pack error" do
+    assert {:error, message} = XMAVLink.Message.pack(:not_a_message, 2)
+    assert message =~ "not a MAVLink message"
+  end
+
+  test "unknown message structs still raise Protocol.UndefinedError" do
+    assert_raise Protocol.UndefinedError, fn ->
+      XMAVLink.Message.pack(%UnknownStruct{}, 2)
+    end
+  end
+end

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -777,6 +777,68 @@ defmodule XMAVLink.Test.Router do
       GenServer.stop(router_pid)
     end
 
+    test "local wildcard targeted sends dedupe learned routes that share a udpout socket" do
+      {:ok, trap_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, trap_port} = :inet.port(trap_socket)
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: ["udpout:127.0.0.1:#{trap_port}"]
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(trap_socket)
+        stop_router(router_pid)
+      end)
+
+      udpout_socket = wait_for_udpout_socket(router_pid)
+      reply_address = {10, 42, 0, 1}
+
+      send(
+        router_pid,
+        {:udp, udpout_socket, reply_address, trap_port,
+         packed_remote_frame(sample_heartbeat(), 2, 1).mavlink_2_raw}
+      )
+
+      send(
+        router_pid,
+        {:udp, udpout_socket, reply_address, trap_port,
+         packed_remote_frame(sample_heartbeat(), 3, 1).mavlink_2_raw}
+      )
+
+      state = :sys.get_state(router_pid)
+      assert state.routes[{2, 1}] == udpout_socket
+      assert state.routes[{3, 1}] == udpout_socket
+      flush_udp(trap_socket)
+
+      assert {:ok, delivery} =
+               Router.send_message(
+                 router_pid,
+                 %Common.Message.Ping{
+                   time_usec: 0,
+                   seq: 1,
+                   target_system: 0,
+                   target_component: 0
+                 },
+                 version: 2
+               )
+
+      assert delivery.source_connection == :local
+      assert delivery.recipients == [udpout_socket]
+      assert delivery.remote_recipients == [udpout_socket]
+      refute delivery.unreachable?
+
+      assert_receive {:udp, ^trap_socket, _, _, _}, 200
+      refute_receive {:udp, ^trap_socket, _, _, _}, 50
+    end
+
     defp wait_for_udpout_socket(router_pid, attempts \\ 50) do
       state = :sys.get_state(router_pid)
 
@@ -1168,6 +1230,64 @@ defmodule XMAVLink.Test.Router do
   end
 
   describe "pack_and_send/3" do
+    test "wraps local MAVLink sequence numbers after 255" do
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 100,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn -> stop_router(router_pid) end)
+
+      assert :ok = Router.subscribe(router_pid, message: Common.Message.Heartbeat, as_frame: true)
+
+      sequence_numbers =
+        for _ <- 0..256 do
+          assert :ok = Router.pack_and_send(router_pid, sample_heartbeat(), 2)
+          assert_receive %XMAVLink.Frame{sequence_number: sequence_number}, 200
+          sequence_number
+        end
+
+      assert Enum.take(sequence_numbers, 256) == Enum.to_list(0..255)
+      assert List.last(sequence_numbers) == 0
+
+      Router.unsubscribe(router_pid)
+    end
+
+    test "send_message/3 reports unreachable local targeted sends" do
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 100,
+            dialect: Common,
+            connection_strings: []
+          },
+          []
+        )
+
+      on_exit(fn -> stop_router(router_pid) end)
+
+      assert {:ok, delivery} =
+               Router.send_message(
+                 router_pid,
+                 param_request_list(42, 1),
+                 version: 2
+               )
+
+      assert delivery.source_connection == :local
+      assert delivery.recipients == []
+      assert delivery.remote_recipients == []
+      assert delivery.unreachable?
+    end
+
     test "can override the local source identity for one message" do
       {:ok, pid} =
         Router.start_link(

--- a/test/mavlink_util_command_test.exs
+++ b/test/mavlink_util_command_test.exs
@@ -3,9 +3,11 @@ defmodule XMAVLink.Util.CommandTest do
 
   alias XMAVLink.Router
   alias XMAVLink.Util.Arm
+  alias XMAVLink.Util.Context
   alias XMAVLink.Util.ParamRequest
   alias XMAVLink.Util.ParamSet
   alias XMAVLink.Util.SITL
+  alias XMAVLink.Util.Tables
 
   setup do
     delete_utility_tables()
@@ -42,6 +44,37 @@ defmodule XMAVLink.Util.CommandTest do
     assert {:error, :timeout} =
              ParamSet.param_set(1, 1, 2, "sysid_thismav", 2.0,
                router: router,
+               retries: 0,
+               retry_interval_ms: 1
+             )
+
+    assert_subscriptions(router, [])
+  end
+
+  test "param_set/6 reads parameter metadata from prefixed utility tables", %{router: router} do
+    context = Context.new(router: router, dialect: Common, table_prefix: :vehicle_a)
+    tables = context.tables
+    delete_tables(Map.values(tables))
+    create_utility_tables(tables)
+
+    on_exit(fn -> delete_tables(Map.values(tables)) end)
+
+    :ets.insert(
+      tables.params,
+      {{1, 1, "SYSID_THISMAV"},
+       {0,
+        %Common.Message.ParamValue{
+          param_id: "SYSID_THISMAV",
+          param_value: 1.0,
+          param_count: 1,
+          param_index: 0,
+          param_type: :mav_param_type_real32
+        }}}
+    )
+
+    assert {:error, :timeout} =
+             ParamSet.param_set(1, 1, 2, "sysid_thismav", 2.0,
+               context: context,
                retries: 0,
                retry_interval_ms: 1
              )
@@ -114,13 +147,23 @@ defmodule XMAVLink.Util.CommandTest do
   end
 
   defp create_utility_tables do
-    :ets.new(:messages, [:named_table, :protected, {:read_concurrency, true}, :set])
-    :ets.new(:systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
-    :ets.new(:params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    create_utility_tables(Tables.names())
+  end
+
+  defp create_utility_tables(tables) do
+    :ets.new(tables.messages, [:named_table, :protected, {:read_concurrency, true}, :set])
+    :ets.new(tables.systems, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
+    :ets.new(tables.params, [:named_table, :protected, {:read_concurrency, true}, :ordered_set])
   end
 
   defp delete_utility_tables do
-    for table <- [:messages, :systems, :params, :sessions], :ets.info(table) != :undefined do
+    delete_tables([:messages, :systems, :params, :sessions])
+  end
+
+  defp delete_tables(tables), do: Enum.each(tables, &delete_table/1)
+
+  defp delete_table(table) do
+    if :ets.info(table) != :undefined do
       :ets.delete(table)
     end
   end

--- a/test/util_context_test.exs
+++ b/test/util_context_test.exs
@@ -1,0 +1,49 @@
+defmodule XMAVLink.Util.ContextTest do
+  use ExUnit.Case
+
+  alias XMAVLink.Util.Context
+  alias XMAVLink.Util.Tables
+
+  test "new/1 normalizes router dialect and prefixed table names" do
+    context =
+      Context.new(
+        router: XMAVLink.Test.Router,
+        dialect: Common,
+        table_prefix: :vehicle_a
+      )
+
+    assert context.router == XMAVLink.Test.Router
+    assert context.dialect == Common
+    assert context.table_prefix == :vehicle_a
+
+    assert context.tables == %{
+             messages: :vehicle_a_messages,
+             systems: :vehicle_a_systems,
+             params: :vehicle_a_params,
+             sessions: :vehicle_a_sessions
+           }
+  end
+
+  test "new/1 allows explicit options to override a base context" do
+    base =
+      Context.new(
+        router: XMAVLink.Test.RouterA,
+        dialect: Common,
+        table_prefix: :vehicle_a
+      )
+
+    context = Context.new(context: base, router: XMAVLink.Test.RouterB, table_prefix: :vehicle_b)
+
+    assert context.router == XMAVLink.Test.RouterB
+    assert context.dialect == Common
+    assert context.table_prefix == :vehicle_b
+    assert context.tables.messages == :vehicle_b_messages
+  end
+
+  test "tables helper accepts context options" do
+    context = Context.new(table_prefix: :vehicle_a)
+
+    assert Tables.name(:systems, context: context) == :vehicle_a_systems
+    assert Tables.names(context: context).params == :vehicle_a_params
+  end
+end


### PR DESCRIPTION
## Summary

Prepare the `0.14.0` release by completing the staged architecture refactor and formalizing scoped utility usage.

- Extract router config, connection parsing, routing, and inbound frame handling into focused modules.
- Add explicit dialect/transport behaviours and `XMAVLink.Router.send_message/1..3` with delivery metadata while preserving `pack_and_send` semantics.
- Add `XMAVLink.Util.Context` so utility helpers can be scoped by router, dialect, and ETS table namespace.
- Update utility helpers, docs, changelog, and package version for `0.14.0`.
- Fix local MAVLink sequence wrap, targeted recipient deduplication, and the message protocol fallback warning.

## Downstream impact

The core router APIs used by known consumers, including `XMAVLink.Router.subscribe/1..2` and `XMAVLink.Router.pack_and_send/2..4`, remain stable. The documented breaking area is utility-layer direct global ETS usage: consumers should migrate to `XMAVLink.Util.Context` and `XMAVLink.Util.Tables` for scoped utility state.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test --warnings-as-errors` -> 150 passed
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`

Note: `/qa-merge` was requested, but no `qa-merge` skill/tool is available in this Codex session. I used the available GitHub publish workflow plus the CI-style checks above.