### PR TITLE
[codex] Add post-0.14 migration docs and utility cache APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Added public utility cache query APIs for listing cached systems, reading the
+  latest cached message, and reading a cached parameter without direct ETS
+  access.
+- Added a `0.14.0` migration guide and a deployment safety checklist.
+
 ## 0.14.0 - 2026-06-24
 
 ### Breaking Changes

--- a/MIGRATING_0_14.md
+++ b/MIGRATING_0_14.md
@@ -1,0 +1,126 @@
+# Migrating to XMAVLink 0.14.0
+
+XMAVLink 0.14.0 keeps the core router API stable while making the utility
+runtime explicit and easier to scope.
+
+## What Stayed Stable
+
+Applications using the router API should not need source changes for normal
+send and subscribe flows:
+
+```elixir
+XMAVLink.Router.subscribe(message: Common.Message.Heartbeat)
+XMAVLink.Router.pack_and_send(heartbeat, 2)
+```
+
+Named routers also continue to work:
+
+```elixir
+XMAVLink.Router.subscribe(MyApp.VehicleRouter, message: Common.Message.Heartbeat)
+XMAVLink.Router.pack_and_send(MyApp.VehicleRouter, message, 2)
+```
+
+## Utility Contexts
+
+Utility helpers now accept `context: context` when an application needs an
+explicit router, dialect, or ETS table namespace.
+
+```elixir
+context =
+  XMAVLink.Util.Context.new(
+    router: MyApp.VehicleRouter,
+    dialect: Common,
+    table_prefix: :vehicle_a
+  )
+
+XMAVLink.Util.CacheManager.list_systems(context: context)
+XMAVLink.Util.CacheManager.latest_message(1, 1, Common.Message.Heartbeat, context: context)
+XMAVLink.Util.ParamSet.param_set(1, 1, 2, "SYSID_THISMAV", 2.0, context: context)
+```
+
+The default context still uses the configured `:xmavlink` router and dialect,
+with the historical table names `:messages`, `:systems`, `:params`, and
+`:sessions`.
+
+## Replace Direct ETS Reads
+
+Prefer public utility APIs over direct ETS access. Direct table reads couple an
+application to internal cache layout and make scoped utility contexts harder to
+adopt.
+
+Before:
+
+```elixir
+:ets.lookup(:params, {1, 1, "SYSID_THISMAV"})
+```
+
+After:
+
+```elixir
+XMAVLink.Util.CacheManager.get_param(1, 1, "SYSID_THISMAV")
+```
+
+For scoped utility state:
+
+```elixir
+XMAVLink.Util.CacheManager.get_param(1, 1, "SYSID_THISMAV", context: context)
+```
+
+The public cache query helpers are:
+
+- `XMAVLink.Util.CacheManager.list_systems/0` and `/1`
+- `XMAVLink.Util.CacheManager.latest_message/3` and `/4`
+- `XMAVLink.Util.CacheManager.get_param/3` and `/4`
+
+If an integration truly needs table names for supervision or migration code,
+use `XMAVLink.Util.Tables` instead of hard-coding names:
+
+```elixir
+XMAVLink.Util.Tables.name(:params, context: context)
+XMAVLink.Util.Tables.names(context: context)
+```
+
+## Utility Supervision
+
+When supervising utilities explicitly, pass the same context used by callers:
+
+```elixir
+children = [
+  {XMAVLink.Router,
+   %{
+     name: MyApp.VehicleRouter,
+     system: 245,
+     component: 250,
+     dialect: Common,
+     connection_strings: ["udpout:127.0.0.1:14550"]
+   }},
+  {XMAVLink.Util.Supervisor, context: context, auto_param_request: false}
+]
+```
+
+Use `auto_param_request: false` on less trusted networks and request
+parameters deliberately after deciding a vehicle should be queried.
+
+## New Send API
+
+`XMAVLink.Router.send_message/1..3` is the structured alternative to
+`pack_and_send/2..4`. It returns delivery metadata instead of only `:ok`.
+
+```elixir
+{:ok, delivery} =
+  XMAVLink.Router.send_message(
+    MyApp.VehicleRouter,
+    %Common.Message.Ping{
+      time_usec: 0,
+      seq: 1,
+      target_system: 42,
+      target_component: 1
+    },
+    version: 2
+  )
+
+delivery.unreachable?
+delivery.recipients
+```
+
+Existing `pack_and_send` calls remain supported.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ for upstream or application-owned dialect files, not arbitrary untrusted XML.
 
 ## Configuring the XMAVLink Application
 
-Add `XMAVLink.Application` with no start arguments to your `mix.exs`. You need to point the application at the dialect you just generated 
+Add the `:xmavlink` OTP application with no start arguments to your `mix.exs`.
+You need to point the application at the dialect you just generated
 and list the connections to other vehicles in `config.exs`:
 
 ```
@@ -416,7 +417,8 @@ The default context still uses the configured `:xmavlink` router and dialect,
 with the historical table names `:messages`, `:systems`, `:params`, and
 `:sessions`. Applications that read utility ETS tables directly should migrate
 to `XMAVLink.Util.Context.new/1` and `XMAVLink.Util.Tables.name/2` instead of
-hard-coding those names.
+hard-coding those names. See [MIGRATING_0_14.md](MIGRATING_0_14.md) for
+examples and public cache query APIs that avoid direct ETS reads.
 
 Command helpers such as arm/disarm and parameter setting use bounded retry
 loops by default. Pass `:retries`, `:retry_interval_ms`, or `:context` in the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,3 +44,20 @@ Current trust boundaries:
   discovery happens on a less trusted network.
 - `mix xmavlink` treats MAVLink XML dialect files as trusted build inputs. Do
   not run the generator on arbitrary untrusted XML.
+
+## Deployment Checklist
+
+- Expose UDP listeners only on trusted networks, VPNs, or filtered interfaces.
+- Prefer MAVLink 2 signing on links where peers are not fully trusted.
+- Keep `accept_unsigned: false` unless a migration or mixed-link deployment
+  explicitly requires unsigned MAVLink 2 frames on a signed connection.
+- Persist signing timestamps with the configured load/save callbacks when
+  restart replay protection matters.
+- Treat signing keys and `SETUP_SIGNING` payloads as secrets.
+- Disable utility `auto_param_request` on less trusted networks and request
+  parameter lists only after a peer is expected.
+- Run routers with `remote_forwarding: false` for endpoint or GCS deployments
+  that should not bridge traffic between remote links.
+- Validate firewall, routing, and serial-device ownership outside XMAVLink;
+  the library parses and routes MAVLink frames but does not authenticate peers
+  at the network layer.

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -93,6 +93,15 @@ defmodule XMAVLink.Router do
   @type mavlink_address :: Types.mavlink_address()
   @type mavlink_connection :: Types.connection()
   @type connection_key :: :local | binary | port | {port, Types.net_address(), Types.net_port()}
+  @typedoc "Delivery metadata returned by `send_message/1..3`."
+  @type delivery :: %{
+          source_connection: connection_key(),
+          recipients: [connection_key()],
+          remote_recipients: [connection_key()],
+          target: XMAVLink.Dialect.target() | nil,
+          message_id: Types.message_id(),
+          unreachable?: boolean
+        }
   @type router_name :: atom | {:global, term} | {:via, module, term}
   @type router_ref :: GenServer.server()
   @type subscribe_query :: [
@@ -386,19 +395,18 @@ defmodule XMAVLink.Router do
   keys are internal runtime identifiers, but they are useful for observability
   and tests.
   """
-  @spec send_message(Message.t()) :: {:ok, Routing.delivery()} | {:error, term}
+  @spec send_message(Message.t()) :: {:ok, delivery()} | {:error, term}
   def send_message(message), do: send_message(__MODULE__, message, [])
 
-  @spec send_message(Message.t(), keyword) :: {:ok, Routing.delivery()} | {:error, term}
+  @spec send_message(Message.t(), keyword) :: {:ok, delivery()} | {:error, term}
   def send_message(message, opts) when is_map(message) and is_list(opts),
     do: send_message(__MODULE__, message, opts)
 
-  @spec send_message(router_ref, Message.t()) :: {:ok, Routing.delivery()} | {:error, term}
+  @spec send_message(router_ref, Message.t()) :: {:ok, delivery()} | {:error, term}
   def send_message(router, message) when is_router_ref(router) and is_map(message),
     do: send_message(router, message, [])
 
-  @spec send_message(router_ref, Message.t(), keyword) ::
-          {:ok, Routing.delivery()} | {:error, term}
+  @spec send_message(router_ref, Message.t(), keyword) :: {:ok, delivery()} | {:error, term}
   def send_message(router, message, opts) when is_router_ref(router) and is_map(message) do
     version = Keyword.get(opts, :version, 2)
 

--- a/lib/mavlink/router/routing.ex
+++ b/lib/mavlink/router/routing.ex
@@ -6,14 +6,7 @@ defmodule XMAVLink.Router.Routing do
 
   @system_time_message_id 2
 
-  @type delivery :: %{
-          source_connection: Router.connection_key(),
-          recipients: [Router.connection_key()],
-          remote_recipients: [Router.connection_key()],
-          target: XMAVLink.Dialect.target() | nil,
-          message_id: XMAVLink.Types.message_id(),
-          unreachable?: boolean
-        }
+  @type delivery :: Router.delivery()
 
   def update_route_info(
         {:ok, source_connection_key, source_connection,

--- a/lib/mavlink/transport.ex
+++ b/lib/mavlink/transport.ex
@@ -1,6 +1,6 @@
 defmodule XMAVLink.Transport do
   @moduledoc """
-  Behaviour for connection transport delegates used by `XMAVLink.ConnectionWorker`.
+  Behaviour for connection transport delegates used by router connection workers.
 
   Transport modules own external resources such as sockets or UART handles and
   expose pure-ish frame handling helpers to the router.

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -40,12 +40,30 @@ defmodule XMAVLink.Util.CacheManager do
     GenServer.start_link(__MODULE__, state, Keyword.put_new(opts, :name, __MODULE__))
   end
 
-  def mavs(opts \\ []) do
-    context = Context.new(opts)
-    systems = context.tables.systems
+  @doc """
+  Return visible MAVLink systems from the utility cache.
+
+  This is the public query API for the utility systems table. Each entry is
+  returned as `{system_component_id, cached_system}` where
+  `system_component_id` is `{system_id, component_id}`.
+  """
+  @spec list_systems(keyword) ::
+          {:ok, [{XMAVLink.Types.mavlink_address(), map}]} | {:error, :not_started}
+  def list_systems(opts \\ []) do
+    systems = Context.new(opts).tables.systems
 
     with :ok <- require_table(systems) do
-      scids = :ets.foldl(fn {scid, _}, acc -> [scid | acc] end, [], systems)
+      entries =
+        :ets.foldl(fn {scid, system}, acc -> [{scid, system} | acc] end, [], systems)
+        |> Enum.sort_by(fn {scid, _system} -> scid end)
+
+      {:ok, entries}
+    end
+  end
+
+  def mavs(opts \\ []) do
+    with {:ok, systems} <- list_systems(opts) do
+      scids = Enum.map(systems, fn {scid, _system} -> scid end)
       Logger.info("Listing #{length(scids)} visible vehicles")
       {:ok, scids}
     end
@@ -110,23 +128,44 @@ defmodule XMAVLink.Util.CacheManager do
   def msg(scid = {_, _, _}, msg_type) when is_atom(msg_type), do: msg(scid, msg_type, [])
 
   def msg({system_id, component_id, _}, msg_type, opts) when is_atom(msg_type) do
-    messages = Context.new(opts).tables.messages
+    case latest_message(system_id, component_id, msg_type, opts) do
+      {:ok, _age_ms, _message} = result ->
+        Logger.info("Most recent \"#{dequalify_msg_type(msg_type)}\" message")
+        result
 
-    with :ok <- require_table(messages),
-         [{_key, {received, message}}] <-
-           :ets.lookup(messages, {system_id, component_id, msg_type}) do
-      Logger.info("Most recent \"#{dequalify_msg_type(msg_type)}\" message")
-      {:ok, now() - received, message}
-    else
       {:error, :not_started} ->
         {:error, :not_started}
 
-      _ ->
+      {:error, :no_such_message} ->
         Logger.warning(
           "Error attempting to retrieve message of type \"#{dequalify_msg_type(msg_type)}\""
         )
 
         {:error, :no_such_message}
+    end
+  end
+
+  @doc """
+  Return the latest cached message for a MAVLink system/component pair.
+
+  The result is `{:ok, age_ms, message}` where `age_ms` is the monotonic age of
+  the cached message at read time.
+  """
+  @spec latest_message(non_neg_integer, non_neg_integer, module, keyword) ::
+          {:ok, non_neg_integer, XMAVLink.Message.t()}
+          | {:error, :not_started | :no_such_message}
+  def latest_message(system_id, component_id, msg_type, opts \\ [])
+      when is_integer(system_id) and is_integer(component_id) and is_atom(msg_type) and
+             is_list(opts) do
+    messages = Context.new(opts).tables.messages
+
+    with :ok <- require_table(messages),
+         [{_key, {received, message}}] <-
+           :ets.lookup(messages, {system_id, component_id, msg_type}) do
+      {:ok, now() - received, message}
+    else
+      {:error, :not_started} -> {:error, :not_started}
+      _ -> {:error, :no_such_message}
     end
   end
 
@@ -192,6 +231,36 @@ defmodule XMAVLink.Util.CacheManager do
       _ ->
         Logger.warning("Error attempting to query params matching \"#{match}\"")
         {:error, :query_failed}
+    end
+  end
+
+  @doc """
+  Return one cached MAVLink parameter by name.
+
+  Parameter names are normalized to uppercase before lookup, matching
+  `XMAVLink.Util.ParamSet` behavior.
+  """
+  @spec get_param(non_neg_integer, non_neg_integer, atom | String.t(), keyword) ::
+          {:ok, non_neg_integer, XMAVLink.Message.t()}
+          | {:error, :not_started | :no_such_param}
+  def get_param(system_id, component_id, param_id, opts \\ [])
+      when is_integer(system_id) and is_integer(component_id) and
+             (is_atom(param_id) or is_binary(param_id)) and is_list(opts) do
+    context = Context.new(opts)
+    params = context.tables.params
+    param = normalize_param_id(param_id)
+    param_value_module = message_module(context.dialect, :ParamValue)
+
+    with :ok <- require_table(params),
+         [
+           {_key,
+            {received, param_value_msg = %{__struct__: ^param_value_module, param_id: ^param}}}
+         ] <-
+           :ets.lookup(params, {system_id, component_id, param}) do
+      {:ok, now() - received, param_value_msg}
+    else
+      {:error, :not_started} -> {:error, :not_started}
+      _ -> {:error, :no_such_param}
     end
   end
 
@@ -422,6 +491,11 @@ defmodule XMAVLink.Util.CacheManager do
     |> String.split(".")
     |> (fn parts -> parts |> Enum.reverse() |> List.first() end).()
   end
+
+  defp normalize_param_id(param) when is_atom(param),
+    do: param |> Atom.to_string() |> String.upcase()
+
+  defp normalize_param_id(param) when is_binary(param), do: String.upcase(param)
 
   defp require_table(table) do
     case :ets.info(table) do

--- a/lib/mavlink_util/supervisor.ex
+++ b/lib/mavlink_util/supervisor.ex
@@ -1,10 +1,18 @@
 defmodule XMAVLink.Util.Supervisor do
-  @moduledoc false
+  @moduledoc """
+  Supervisor for opt-in utility processes.
+
+  Start this supervisor when an application wants `XMAVLink.Util.CacheManager`
+  and `XMAVLink.Util.FocusManager` for a router. Pass `:context` to scope the
+  utility runtime, or pass `:router`, `:dialect`, and `:table_prefix` options
+  that can be normalized by `XMAVLink.Util.Context`.
+  """
 
   use Supervisor
   alias XMAVLink.Util.Context
 
-  def start_link(opts) do
+  @spec start_link(keyword) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
 

--- a/lib/mavlink_util/tables.ex
+++ b/lib/mavlink_util/tables.ex
@@ -1,8 +1,24 @@
 defmodule XMAVLink.Util.Tables do
-  @moduledoc false
+  @moduledoc """
+  Utility ETS table name helpers.
+
+  Most applications should use `XMAVLink.Util.CacheManager` query functions
+  instead of reading ETS tables directly. When an integration needs table names
+  for supervision or migration code, use this module rather than hard-coding
+  global names such as `:messages`, `:systems`, `:params`, and `:sessions`.
+  """
 
   @kinds [:messages, :systems, :params, :sessions]
 
+  @type kind :: :messages | :systems | :params | :sessions
+  @type prefix :: atom | String.t() | nil
+  @type opts_or_prefix ::
+          keyword | %{optional(:table_prefix) => prefix} | XMAVLink.Util.Context.t() | prefix
+
+  @doc """
+  Return all utility table names for a context, prefix, or options.
+  """
+  @spec names(opts_or_prefix) :: %{required(kind) => atom}
   def names(opts_or_prefix \\ []) do
     prefix = prefix(opts_or_prefix)
 
@@ -11,6 +27,10 @@ defmodule XMAVLink.Util.Tables do
     end)
   end
 
+  @doc """
+  Return one utility table name for a context, prefix, or options.
+  """
+  @spec name(kind, opts_or_prefix) :: atom
   def name(kind, opts_or_prefix \\ []) when kind in @kinds do
     table_name(kind, prefix(opts_or_prefix))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule XMAVLink.Mixfile do
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
+      docs: docs(),
       aliases: aliases(),
       deps: deps(),
       dialyzer: [plt_add_apps: [:mix, :xmerl]],
@@ -82,6 +83,7 @@ defmodule XMAVLink.Mixfile do
         "mix.exs",
         "README.md",
         "CHANGELOG.md",
+        "MIGRATING_0_14.md",
         "LICENSE",
         "SECURITY.md",
         "MAVLINK_SPEC_ALIGNMENT.md"
@@ -90,6 +92,29 @@ defmodule XMAVLink.Mixfile do
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/fancydrones/xmavlink"},
       maintainers: ["Roy Veshovda"]
+    ]
+  end
+
+  defp docs() do
+    [
+      main: "readme",
+      extras: [
+        "README.md",
+        "MIGRATING_0_14.md",
+        "CHANGELOG.md",
+        "SECURITY.md",
+        "MAVLINK_SPEC_ALIGNMENT.md"
+      ],
+      groups_for_extras: [
+        Guides: [
+          "MIGRATING_0_14.md",
+          "SECURITY.md",
+          "MAVLINK_SPEC_ALIGNMENT.md"
+        ],
+        Release: [
+          "CHANGELOG.md"
+        ]
+      ]
     ]
   end
 end

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -20,6 +20,34 @@ defmodule XMAVLink.Util.CacheManager.Test do
     assert Enum.sort(mavs) == [{1, 1}, {2, 1}]
   end
 
+  test "list_systems/1 returns cached system metadata" do
+    first = %{mavlink_major_version: 2, param_count: 4, param_count_loaded: 2}
+    second = %{mavlink_major_version: 1, param_count: 0, param_count_loaded: 0}
+    :ets.insert(:systems, {{2, 1}, second})
+    :ets.insert(:systems, {{1, 1}, first})
+
+    assert {:ok, [{{1, 1}, ^first}, {{2, 1}, ^second}]} = CacheManager.list_systems()
+  end
+
+  test "latest_message/4 returns cached message age and struct" do
+    create_messages_table()
+
+    heartbeat = %Common.Message.Heartbeat{
+      type: :mav_type_quadrotor,
+      autopilot: :mav_autopilot_ardupilotmega,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+
+    received_at = :erlang.monotonic_time(:milli_seconds) - 10
+    :ets.insert(:messages, {{1, 1, Common.Message.Heartbeat}, {received_at, heartbeat}})
+
+    assert {:ok, age_ms, ^heartbeat} = CacheManager.latest_message(1, 1, Common.Message.Heartbeat)
+    assert age_ms >= 0
+  end
+
   test "params/2 returns MAVLink parameter names as string keys" do
     :ets.insert(
       :params,
@@ -37,6 +65,22 @@ defmodule XMAVLink.Util.CacheManager.Test do
     assert {:ok, params} = CacheManager.params({1, 1, 2}, "SYSID")
     assert params == %{"SYSID_THISMAV" => 42.0}
     refute Map.has_key?(params, :sysid_thismav)
+  end
+
+  test "get_param/4 returns one cached parameter message" do
+    param = %Common.Message.ParamValue{
+      param_id: "SYSID_THISMAV",
+      param_value: 42.0,
+      param_count: 1,
+      param_index: 0,
+      param_type: :mav_param_type_real32
+    }
+
+    received_at = :erlang.monotonic_time(:milli_seconds) - 10
+    :ets.insert(:params, {{1, 1, "SYSID_THISMAV"}, {received_at, param}})
+
+    assert {:ok, age_ms, ^param} = CacheManager.get_param(1, 1, :sysid_thismav)
+    assert age_ms >= 0
   end
 
   test "msg/2 preserves not-started errors" do
@@ -130,8 +174,11 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
     assert {:ok, [{1, 1}]} = CacheManager.mavs(context: context)
 
+    assert {:ok, [{{1, 1}, %{mavlink_major_version: 2}}]} =
+             CacheManager.list_systems(context: context)
+
     assert {:ok, _age_ms, ^heartbeat} =
-             CacheManager.msg({1, 1, 2}, Common.Message.Heartbeat, context: context)
+             CacheManager.latest_message(1, 1, Common.Message.Heartbeat, context: context)
   end
 
   test "one second loop reschedules one second loop" do


### PR DESCRIPTION
## Summary

Follow up the `0.14.0` release with public-consumer hardening:

- Add public utility cache query APIs so downstream code can avoid direct ETS reads: `list_systems/0..1`, `latest_message/3..4`, and `get_param/3..4`.
- Document `XMAVLink.Util.Tables` and `XMAVLink.Util.Supervisor` as intentional public utility APIs.
- Move `send_message/1..3` delivery metadata to a public `XMAVLink.Router.delivery/0` type so HexDocs do not expose hidden routing internals.
- Add `MIGRATING_0_14.md` with router stability notes, scoped utility context examples, and direct ETS migration examples.
- Add a deployment checklist to `SECURITY.md` and include docs extras in ExDoc/package metadata.

## Downstream impact

This is additive. Existing cache helpers (`mavs`, `msg`, `params`) remain in place, while new query functions provide a clearer public path for consumers that previously reached into ETS tables directly.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test test/cache_manager_test.exs` -> 12 passed
- `mise exec -- mix test --warnings-as-errors` -> 153 passed
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix docs` -> no warnings
- `mise exec -- mix dialyzer` -> passed
