### PR TITLE
[codex] Prepare xmavlink 0.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 ## Unreleased
 
+## 0.14.1 - 2026-06-25
+
 ### Added
 
 - Added public utility cache query APIs for listing cached systems, reading the
   latest cached message, and reading a cached parameter without direct ETS
   access.
 - Added a `0.14.0` migration guide and a deployment safety checklist.
+
+### Tests
+
+- Added deterministic malformed-frame parser coverage and parser
+  resynchronization coverage.
+- Added connection worker lifecycle coverage for close and reconnect behavior.
 
 ## 0.14.0 - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.14.0"}
+     {:xmavlink, "~> 0.14.1"}
    ]
  end
  ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.14.0",
+      version: "0.14.1",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

Prepare the `0.14.1` patch release after the post-`0.14.0` public API/docs and hardening follow-ups.

- Bump package version from `0.14.0` to `0.14.1`.
- Update the README dependency example to `~> 0.14.1`.
- Move the current changelog entries into a dated `0.14.1` section.

## Release contents

- Public utility cache query APIs: `list_systems/0..1`, `latest_message/3..4`, and `get_param/3..4`.
- `0.14.0` migration guide and deployment safety checklist.
- HexDocs public API cleanup for utility supervision, table helpers, and router delivery metadata.
- Parser malformed-frame/resynchronization coverage.
- Connection worker close/reconnect lifecycle coverage.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test --warnings-as-errors` -> 156 passed
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix docs` -> no warnings
- `mise exec -- mix dialyzer` -> passed
