### PR TITLE
[codex] Add typed utility cache structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- Utility cache ETS tables now store typed cache structs for visible systems,
+  latest messages, and parameter values. Use `XMAVLink.Util.CacheManager`
+  query APIs instead of relying on direct ETS payload shapes.
+
 ## 0.14.1 - 2026-06-25
 
 ### Added

--- a/lib/mavlink_util/cache/message.ex
+++ b/lib/mavlink_util/cache/message.ex
@@ -1,0 +1,24 @@
+defmodule XMAVLink.Util.Cache.Message do
+  @moduledoc """
+  Cached latest MAVLink message with monotonic receive time metadata.
+  """
+
+  @enforce_keys [:received_at_ms, :message_type, :message]
+  defstruct [:received_at_ms, :message_type, :message]
+
+  @type t :: %__MODULE__{
+          received_at_ms: integer,
+          message_type: module,
+          message: XMAVLink.Message.t()
+        }
+
+  @spec new(XMAVLink.Message.t(), integer) :: t
+  def new(message = %{__struct__: message_type}, received_at_ms)
+      when is_integer(received_at_ms) do
+    %__MODULE__{
+      received_at_ms: received_at_ms,
+      message_type: message_type,
+      message: message
+    }
+  end
+end

--- a/lib/mavlink_util/cache/param.ex
+++ b/lib/mavlink_util/cache/param.ex
@@ -1,0 +1,23 @@
+defmodule XMAVLink.Util.Cache.Param do
+  @moduledoc """
+  Cached latest MAVLink parameter value with monotonic receive time metadata.
+  """
+
+  @enforce_keys [:received_at_ms, :param_id, :message]
+  defstruct [:received_at_ms, :param_id, :message]
+
+  @type t :: %__MODULE__{
+          received_at_ms: integer,
+          param_id: String.t(),
+          message: XMAVLink.Message.t()
+        }
+
+  @spec new(XMAVLink.Message.t(), integer) :: t
+  def new(message = %{param_id: param_id}, received_at_ms) when is_integer(received_at_ms) do
+    %__MODULE__{
+      received_at_ms: received_at_ms,
+      param_id: param_id,
+      message: message
+    }
+  end
+end

--- a/lib/mavlink_util/cache/system.ex
+++ b/lib/mavlink_util/cache/system.ex
@@ -1,0 +1,23 @@
+defmodule XMAVLink.Util.Cache.System do
+  @moduledoc """
+  Cached metadata for one visible MAVLink system/component.
+  """
+
+  @enforce_keys [:mavlink_major_version, :mavlink_minor_version]
+  defstruct mavlink_major_version: nil,
+            mavlink_minor_version: nil,
+            param_count: 0,
+            param_count_loaded: 0
+
+  @type t :: %__MODULE__{
+          mavlink_major_version: XMAVLink.Types.version(),
+          mavlink_minor_version: non_neg_integer,
+          param_count: non_neg_integer,
+          param_count_loaded: non_neg_integer
+        }
+
+  @spec new(keyword | map) :: t
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(attrs) when is_map(attrs), do: struct!(__MODULE__, attrs)
+end

--- a/lib/mavlink_util/cache_manager.ex
+++ b/lib/mavlink_util/cache_manager.ex
@@ -7,8 +7,9 @@ defmodule XMAVLink.Util.CacheManager do
   - the most recently received messages for each MAV and message type
   - the most recently received set of parameters for each MAV
 
-  Using ETS tables allows clients to perform read only API operations directly
-  on the tables, preventing this GenServer from becoming a bottleneck.
+  Using ETS tables allows read-heavy utility queries without turning this
+  GenServer into a bottleneck. Prefer this module's query functions over direct
+  ETS access; table contents are internal cache structs.
 
   Use `XMAVLink.Util.Context` when utility state should be scoped to a
   specific router, dialect, or ETS table namespace.
@@ -16,6 +17,9 @@ defmodule XMAVLink.Util.CacheManager do
 
   use GenServer
   require Logger
+  alias XMAVLink.Util.Cache.Message, as: CachedMessage
+  alias XMAVLink.Util.Cache.Param, as: CachedParam
+  alias XMAVLink.Util.Cache.System, as: CachedSystem
   alias XMAVLink.Util.{Context, Defaults, Tables}
   alias XMAVLink.Util.ParamRequest
   import XMAVLink.Util.FocusManager, only: [focus: 0, focus: 1]
@@ -48,7 +52,7 @@ defmodule XMAVLink.Util.CacheManager do
   `system_component_id` is `{system_id, component_id}`.
   """
   @spec list_systems(keyword) ::
-          {:ok, [{XMAVLink.Types.mavlink_address(), map}]} | {:error, :not_started}
+          {:ok, [{XMAVLink.Types.mavlink_address(), CachedSystem.t()}]} | {:error, :not_started}
   def list_systems(opts \\ []) do
     systems = Context.new(opts).tables.systems
 
@@ -112,8 +116,11 @@ defmodule XMAVLink.Util.CacheManager do
         :ok,
         :ets.foldl(
           fn
-            {{^system_id, ^component_id, msg_type}, {received, msg}}, acc ->
-              Enum.into([{msg_type, {now() - received, msg}}], acc)
+            {{^system_id, ^component_id, msg_type}, entry}, acc ->
+              case cache_entry(entry) do
+                {:ok, age_ms, message} -> Enum.into([{msg_type, {age_ms, message}}], acc)
+                :error -> acc
+              end
 
             _, acc ->
               acc
@@ -160,9 +167,9 @@ defmodule XMAVLink.Util.CacheManager do
     messages = Context.new(opts).tables.messages
 
     with :ok <- require_table(messages),
-         [{_key, {received, message}}] <-
-           :ets.lookup(messages, {system_id, component_id, msg_type}) do
-      {:ok, now() - received, message}
+         [{_key, entry}] <- :ets.lookup(messages, {system_id, component_id, msg_type}),
+         {:ok, age_ms, message} <- cache_entry(entry) do
+      {:ok, age_ms, message}
     else
       {:error, :not_started} -> {:error, :not_started}
       _ -> {:error, :no_such_message}
@@ -207,13 +214,17 @@ defmodule XMAVLink.Util.CacheManager do
          param_map when is_map(param_map) <-
            :ets.foldl(
              fn
-               {{^system_id, ^component_id, param_id},
-                {_, %{__struct__: ^param_value_module, param_value: param_value}}},
-               acc ->
-                 if String.contains?(param_id, match_upcase) do
-                   Enum.into([{param_id, param_value}], acc)
-                 else
-                   acc
+               {{^system_id, ^component_id, param_id}, entry}, acc ->
+                 case cache_entry(entry) do
+                   {:ok, _age_ms, %{__struct__: ^param_value_module, param_value: param_value}} ->
+                     if String.contains?(param_id, match_upcase) do
+                       Enum.into([{param_id, param_value}], acc)
+                     else
+                       acc
+                     end
+
+                   _ ->
+                     acc
                  end
 
                _, acc ->
@@ -252,12 +263,10 @@ defmodule XMAVLink.Util.CacheManager do
     param_value_module = message_module(context.dialect, :ParamValue)
 
     with :ok <- require_table(params),
-         [
-           {_key,
-            {received, param_value_msg = %{__struct__: ^param_value_module, param_id: ^param}}}
-         ] <-
-           :ets.lookup(params, {system_id, component_id, param}) do
-      {:ok, now() - received, param_value_msg}
+         [{_key, entry}] <- :ets.lookup(params, {system_id, component_id, param}),
+         {:ok, age_ms, param_value_msg = %{__struct__: ^param_value_module, param_id: ^param}} <-
+           cache_entry(entry) do
+      {:ok, age_ms, param_value_msg}
     else
       {:error, :not_started} -> {:error, :not_started}
       _ -> {:error, :no_such_param}
@@ -338,7 +347,7 @@ defmodule XMAVLink.Util.CacheManager do
     # Replace with the new message
     :ets.insert(
       state.tables.messages,
-      {{source_system, source_component, message_type}, {now(), message}}
+      {{source_system, source_component, message_type}, CachedMessage.new(message, now())}
     )
 
     # Delegate any message-specific behaviour to handle_mav_message()
@@ -389,13 +398,12 @@ defmodule XMAVLink.Util.CacheManager do
         state.tables.systems,
         {
           {source_system_id, source_component_id},
-          # TODO System struct
-          %{
+          CachedSystem.new(%{
             mavlink_major_version: mavlink_major_version,
             mavlink_minor_version: mavlink_minor_version,
             param_count: 0,
             param_count_loaded: 0
-          }
+          })
         }
       )
 
@@ -434,7 +442,8 @@ defmodule XMAVLink.Util.CacheManager do
            true <-
              :ets.insert(
                state.tables.params,
-               {{source_system_id, source_component_id, param_id}, {now(), param_value_msg}}
+               {{source_system_id, source_component_id, param_id},
+                CachedParam.new(param_value_msg, now())}
              ) do
         # TODO Hidden parameters can become un-hidden, increasing param_count, in which case we need to spawn param_request_list again.
         :ets.insert(
@@ -496,6 +505,17 @@ defmodule XMAVLink.Util.CacheManager do
     do: param |> Atom.to_string() |> String.upcase()
 
   defp normalize_param_id(param) when is_binary(param), do: String.upcase(param)
+
+  defp cache_entry(%{received_at_ms: received_at_ms, message: message})
+       when is_integer(received_at_ms) do
+    {:ok, now() - received_at_ms, message}
+  end
+
+  defp cache_entry({received_at_ms, message}) when is_integer(received_at_ms) do
+    {:ok, now() - received_at_ms, message}
+  end
+
+  defp cache_entry(_entry), do: :error
 
   defp require_table(table) do
     case :ets.info(table) do

--- a/test/cache_manager_test.exs
+++ b/test/cache_manager_test.exs
@@ -1,6 +1,9 @@
 defmodule XMAVLink.Util.CacheManager.Test do
   use ExUnit.Case
 
+  alias XMAVLink.Util.Cache.Message, as: CachedMessage
+  alias XMAVLink.Util.Cache.Param, as: CachedParam
+  alias XMAVLink.Util.Cache.System, as: CachedSystem
   alias XMAVLink.Util.CacheManager
   alias XMAVLink.Util.Context
 
@@ -21,8 +24,22 @@ defmodule XMAVLink.Util.CacheManager.Test do
   end
 
   test "list_systems/1 returns cached system metadata" do
-    first = %{mavlink_major_version: 2, param_count: 4, param_count_loaded: 2}
-    second = %{mavlink_major_version: 1, param_count: 0, param_count_loaded: 0}
+    first =
+      CachedSystem.new(%{
+        mavlink_major_version: 2,
+        mavlink_minor_version: 3,
+        param_count: 4,
+        param_count_loaded: 2
+      })
+
+    second =
+      CachedSystem.new(%{
+        mavlink_major_version: 1,
+        mavlink_minor_version: 0,
+        param_count: 0,
+        param_count_loaded: 0
+      })
+
     :ets.insert(:systems, {{2, 1}, second})
     :ets.insert(:systems, {{1, 1}, first})
 
@@ -42,7 +59,11 @@ defmodule XMAVLink.Util.CacheManager.Test do
     }
 
     received_at = :erlang.monotonic_time(:milli_seconds) - 10
-    :ets.insert(:messages, {{1, 1, Common.Message.Heartbeat}, {received_at, heartbeat}})
+
+    :ets.insert(
+      :messages,
+      {{1, 1, Common.Message.Heartbeat}, CachedMessage.new(heartbeat, received_at)}
+    )
 
     assert {:ok, age_ms, ^heartbeat} = CacheManager.latest_message(1, 1, Common.Message.Heartbeat)
     assert age_ms >= 0
@@ -52,14 +73,16 @@ defmodule XMAVLink.Util.CacheManager.Test do
     :ets.insert(
       :params,
       {{1, 1, "SYSID_THISMAV"},
-       {0,
-        %Common.Message.ParamValue{
-          param_id: "SYSID_THISMAV",
-          param_value: 42.0,
-          param_count: 1,
-          param_index: 0,
-          param_type: :mav_param_type_real32
-        }}}
+       CachedParam.new(
+         %Common.Message.ParamValue{
+           param_id: "SYSID_THISMAV",
+           param_value: 42.0,
+           param_count: 1,
+           param_index: 0,
+           param_type: :mav_param_type_real32
+         },
+         0
+       )}
     )
 
     assert {:ok, params} = CacheManager.params({1, 1, 2}, "SYSID")
@@ -77,7 +100,7 @@ defmodule XMAVLink.Util.CacheManager.Test do
     }
 
     received_at = :erlang.monotonic_time(:milli_seconds) - 10
-    :ets.insert(:params, {{1, 1, "SYSID_THISMAV"}, {received_at, param}})
+    :ets.insert(:params, {{1, 1, "SYSID_THISMAV"}, CachedParam.new(param, received_at)})
 
     assert {:ok, age_ms, ^param} = CacheManager.get_param(1, 1, :sysid_thismav)
     assert age_ms >= 0
@@ -118,7 +141,7 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
     assert [
              {{1, 1},
-              %{
+              %CachedSystem{
                 mavlink_major_version: 2,
                 mavlink_minor_version: 3,
                 param_count: 0,
@@ -164,7 +187,7 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
     assert [
              {{1, 1},
-              %{
+              %CachedSystem{
                 mavlink_major_version: 2,
                 mavlink_minor_version: 3,
                 param_count: 0,
@@ -174,7 +197,7 @@ defmodule XMAVLink.Util.CacheManager.Test do
 
     assert {:ok, [{1, 1}]} = CacheManager.mavs(context: context)
 
-    assert {:ok, [{{1, 1}, %{mavlink_major_version: 2}}]} =
+    assert {:ok, [{{1, 1}, %CachedSystem{mavlink_major_version: 2}}]} =
              CacheManager.list_systems(context: context)
 
     assert {:ok, _age_ms, ^heartbeat} =


### PR DESCRIPTION
## Summary

Start the post-0.14 architecture cleanup by giving the utility cache explicit domain structs.

- Add `XMAVLink.Util.Cache.System`, `XMAVLink.Util.Cache.Message`, and `XMAVLink.Util.Cache.Param`.
- Store typed cache structs in the utility ETS tables for visible systems, latest messages, and parameters.
- Keep public query APIs tolerant of the previous `{timestamp, message}` tuple shape while moving writes to typed structs.
- Update cache manager tests to assert the typed cache payloads.
- Document the internal ETS payload-shape change in the changelog.

## Downstream impact

The public cache APIs remain the supported path. Direct ETS readers may observe the new typed payload structs; the changelog points users toward `XMAVLink.Util.CacheManager` query APIs instead of depending on table layout.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test test/cache_manager_test.exs` -> 12 passed
- `mise exec -- mix test --warnings-as-errors` -> 156 passed
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix docs` -> no warnings
- `mise exec -- mix dialyzer` -> passed
