### PR TITLE
Harden MAVLink XML parser validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Added MAVLink XML parser hardening for include cycles, conflicting include
+  paths, file-size limits, include-depth limits, and include-count limits.
+
 ## 0.14.1 - 2026-06-25
 
 ### Added

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -59,11 +59,11 @@ Known non-goals for 1.0 unless separately implemented:
 | Routing unchanged packets | Supported with signing caveat | Forwarding generally uses the original raw frame bytes. Unsigned MAVLink 2 frames sent over signing-enabled connections are signed for that outbound link; already signed MAVLink 2 frames are forwarded unchanged. |
 | Target inference | Supported | Generated metadata classifies broadcast, system, component, and system-component targets from `target_system` and `target_component` fields. |
 | Route reset after reboot | Supported | Routing tracks `SYSTEM_TIME.time_boot_ms` per source system/component and clears learned routes for that system when the same source reports a lower boot time. |
-| XML includes | Partial | Includes are recursive and deterministic, but missing include errors and duplicate handling are not yet aligned with `mavgen`. |
-| Enum merging | Partial | Matching enum names are merged and sorted by value. Duplicate enum entries are not rejected yet. |
-| Duplicate message ids | Unsupported validation | The parser/generator does not currently reject duplicate message ids across includes. |
+| XML includes | Supported with limits | Includes are recursive and deterministic. Missing includes, empty includes, include cycles, conflicting include paths, excessive include depth/count, and oversized XML files return explicit errors. |
+| Enum merging | Partial | Matching enum names are merged and sorted by value. Duplicate enum entries and duplicate resolved values are rejected. |
+| Duplicate message ids | Supported validation | Duplicate message ids are rejected across the combined dialect, including included XML files. |
 | XML `bitmask="true"` | Supported | Enum-level bitmask declarations are parsed and used before heuristic bitmask detection. |
-| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. Identifier validation and safer escaping are tracked separately in #49. |
+| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. The parser validates generated identifiers and escapes generated docs/descriptions before source generation. Reserved-name validation is still tracked separately. |
 | Generated Common dialect | Supported within above scope | `lib/common.ex` is regenerated from `config/common.xml` and should be treated as build output. |
 
 ## Changes Made In This Pass
@@ -106,8 +106,8 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #53: Align XML parser/generator validation with `mavgen` for missing
-  includes, duplicate message ids, duplicate enum entries, and reserved names.
+- #53: Continue aligning XML parser/generator validation with `mavgen`,
+  especially reserved-name validation.
 
 These follow-ups should be prioritized by MAVLink 2 impact first. None of the
 reviewed gaps require new MAVLink 1-only work before 1.0.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ change the generator or XML input and regenerate them rather than editing or
 formatting generated files by hand. The generator emits deterministic,
 formatter-compatible source for repeatable diffs.
 
-Treat MAVLink XML dialect files as trusted build inputs. The generator is meant
-for upstream or application-owned dialect files, not arbitrary untrusted XML.
+Treat MAVLink XML dialect files as trusted build inputs. The generator enforces
+basic include graph, file size, identifier, and duplicate-definition checks, but
+it is meant for upstream or application-owned dialect files, not arbitrary
+untrusted XML.
 
 ## Configuring the XMAVLink Application
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,8 +42,9 @@ Current trust boundaries:
   Use `utilities: [auto_param_request: false]` or pass
   `auto_param_request: false` to `XMAVLink.Util.Supervisor` when vehicle
   discovery happens on a less trusted network.
-- `mix xmavlink` treats MAVLink XML dialect files as trusted build inputs. Do
-  not run the generator on arbitrary untrusted XML.
+- `mix xmavlink` treats MAVLink XML dialect files as trusted build inputs. The
+  parser applies include graph and size limits, but you should not run the
+  generator on arbitrary untrusted XML.
 
 ## Deployment Checklist
 

--- a/lib/mavlink/parser.ex
+++ b/lib/mavlink/parser.ex
@@ -57,6 +57,11 @@ defmodule XMAVLink.Parser do
   @unit_regex ~r/\A[A-Za-z0-9_%@\/\*\^\.\-]+\z/
   @scalar_field_types ~w(char uint8_t int8_t uint16_t int16_t uint32_t int32_t uint64_t int64_t float double)
   @valid_display_values ~w(bitmask)
+  @default_limits %{
+    max_xml_file_bytes: 2_000_000,
+    max_include_depth: 32,
+    max_include_files: 128
+  }
 
   @xmerl_header "xmerl/include/xmerl.hrl"
   defrecord :xmlElement, extract(:xmlElement, from_lib: @xmerl_header)
@@ -70,77 +75,213 @@ defmodule XMAVLink.Parser do
           messages: [message_description]
         }
 
+  @type parser_limit :: pos_integer | :infinity
+  @type parse_option ::
+          {:max_xml_file_bytes, parser_limit}
+          | {:max_include_depth, parser_limit}
+          | {:max_include_files, parser_limit}
+  @type parse_options :: [parse_option]
+
   @spec parse_mavlink_xml(String.t()) ::
           mavlink_definition | {:error, String.t()}
   def parse_mavlink_xml(path) do
-    case parse_mavlink_xml(path, %{seen: MapSet.new(), definitions: []}) do
-      {:error, _message} = error ->
-        error
+    parse_mavlink_xml(path, [])
+  end
 
-      %{definitions: definitions} ->
-        definitions
-        |> reverse()
-        |> combine_definitions()
-        |> validate_definition()
+  @spec parse_mavlink_xml(String.t(), parse_options) ::
+          mavlink_definition | {:error, String.t()}
+  def parse_mavlink_xml(path, opts) when is_list(opts) do
+    with {:ok, limits} <- parse_limits(opts) do
+      path
+      |> parse_mavlink_xml_file(initial_acc(limits))
+      |> combined_definition()
     end
   end
 
-  def parse_mavlink_xml(path, paths) do
+  @doc false
+  def parse_mavlink_xml(path, paths) when is_map(paths) do
     acc =
       if Map.has_key?(paths, :seen) and Map.has_key?(paths, :definitions) do
-        paths
+        normalize_acc(paths)
       else
-        %{seen: MapSet.new(Map.keys(paths)), definitions: Map.values(paths)}
+        normalize_acc(%{
+          seen: MapSet.new(Map.keys(paths)),
+          definitions: Map.values(paths)
+        })
       end
 
     parse_mavlink_xml_file(path, acc)
   end
 
+  defp combined_definition({:error, _message} = error), do: error
+
+  defp combined_definition(%{definitions: definitions}) do
+    definitions
+    |> reverse()
+    |> combine_definitions()
+    |> validate_definition()
+  end
+
+  defp initial_acc(limits) do
+    %{
+      seen: MapSet.new(),
+      definitions: [],
+      stack: [],
+      file_count: 0,
+      limits: limits
+    }
+  end
+
+  defp normalize_acc(acc) do
+    seen =
+      acc
+      |> Map.get(:seen, MapSet.new())
+      |> MapSet.to_list()
+      |> map(&Path.expand/1)
+      |> MapSet.new()
+
+    Map.merge(acc, %{
+      seen: seen,
+      definitions: Map.get(acc, :definitions, []),
+      stack: Map.get(acc, :stack, []),
+      file_count: Map.get(acc, :file_count, 0),
+      limits: Map.get(acc, :limits, @default_limits)
+    })
+  end
+
+  defp parse_limits(opts) do
+    reduce(opts, {:ok, @default_limits}, fn
+      _option, {:error, _message} = error ->
+        error
+
+      {key, value}, {:ok, limits} when is_map_key(@default_limits, key) ->
+        if valid_limit?(value) do
+          {:ok, Map.put(limits, key, value)}
+        else
+          {:error, "Invalid MAVLink XML parser limit #{inspect(key)}: #{inspect(value)}"}
+        end
+
+      option, {:ok, _limits} ->
+        {:error, "Invalid MAVLink XML parser option #{inspect(option)}"}
+    end)
+  end
+
+  defp valid_limit?(:infinity), do: true
+  defp valid_limit?(value), do: is_integer(value) and value > 0
+
   defp parse_mavlink_xml_file(path, acc) do
     path_key = Path.expand(path)
 
-    case MapSet.member?(acc.seen, path_key) do
-      true ->
+    cond do
+      path_key in acc.stack ->
+        {:error,
+         "Cyclic MAVLink XML include detected: #{format_path_chain(acc.stack ++ [path_key])}"}
+
+      MapSet.member?(acc.seen, path_key) ->
         # Don't include a file twice
         acc
 
-      false ->
-        case scan_file(path) do
-          {defs, []} ->
-            acc = %{acc | seen: MapSet.put(acc.seen, path_key)}
+      exceeds_limit?(length(acc.stack) + 1, acc.limits.max_include_depth) ->
+        {:error,
+         "MAVLink XML include depth for '#{path_key}' exceeds max_include_depth limit of #{format_limit(acc.limits.max_include_depth)} in #{format_path_chain(acc.stack ++ [path_key])}"}
 
-            with {:ok, acc} <- parse_includes(defs, path, acc),
-                 {:ok, definition} <- parse_definition(defs) do
-              %{acc | definitions: [definition | acc.definitions]}
-            end
+      exceeds_limit?(acc.file_count + 1, acc.limits.max_include_files) ->
+        {:error,
+         "MAVLink XML include graph exceeds max_include_files limit of #{format_limit(acc.limits.max_include_files)} while parsing '#{path_key}'"}
 
-          {:error, :enoent} ->
-            {:error, "File '#{path}' does not exist"}
+      true ->
+        parse_new_mavlink_xml_file(path, path_key, acc)
+    end
+  end
 
-          {:error, message} when is_binary(message) ->
-            {:error, message}
+  defp parse_new_mavlink_xml_file(path, path_key, acc) do
+    parent_stack = acc.stack
 
-          {:error, message} ->
-            {:error, "Failed to parse MAVLink XML file '#{path}': #{inspect(message)}"}
+    acc = %{
+      acc
+      | seen: MapSet.put(acc.seen, path_key),
+        stack: parent_stack ++ [path_key],
+        file_count: acc.file_count + 1
+    }
+
+    case scan_file(path, acc.limits) do
+      {defs, []} ->
+        with {:ok, acc} <- parse_includes(defs, path_key, acc),
+             {:ok, definition} <- parse_definition(defs) do
+          %{acc | definitions: [definition | acc.definitions], stack: parent_stack}
         end
+
+      {:error, :enoent} ->
+        {:error, "File '#{path}' does not exist"}
+
+      {:error, message} when is_binary(message) ->
+        {:error, message}
+
+      {:error, message} ->
+        {:error, "Failed to parse MAVLink XML file '#{path}': #{inspect(message)}"}
     end
   end
 
   defp parse_includes(defs, path, acc) do
+    with {:ok, includes} <- include_paths(defs, path),
+         :ok <- validate_include_conflicts(includes, path) do
+      reduce(includes, {:ok, acc}, fn
+        _include, {:error, _message} = error ->
+          error
+
+        {_include, include_path}, {:ok, acc} ->
+          case parse_mavlink_xml_file(include_path, acc) do
+            {:error, _message} = error -> error
+            acc -> {:ok, acc}
+          end
+      end)
+    end
+  end
+
+  defp include_paths(defs, path) do
     :xmerl_xpath.string(~c"/mavlink/include/text()", defs)
     |> map(&extract_text/1)
-    |> reduce({:ok, acc}, fn
-      _next_include, {:error, _message} = error ->
+    |> reduce({:ok, []}, fn
+      _include, {:error, _message} = error ->
         error
 
-      next_include, {:ok, acc} ->
-        include_path = Path.expand(next_include, Path.dirname(path))
+      include, {:ok, _acc} when include in [nil, ""] ->
+        {:error, "Empty MAVLink XML include in '#{path}'"}
 
-        case parse_mavlink_xml_file(include_path, acc) do
-          {:error, _message} = error -> error
-          acc -> {:ok, acc}
-        end
+      include, {:ok, acc} ->
+        {:ok, [{include, Path.expand(include, Path.dirname(path))} | acc]}
     end)
+    |> case do
+      {:ok, includes} -> {:ok, reverse(includes)}
+      {:error, _message} = error -> error
+    end
+  end
+
+  defp validate_include_conflicts(includes, path) do
+    includes
+    |> Enum.group_by(fn {_include, include_path} -> include_path end, fn {include, _path} ->
+      include
+    end)
+    |> Enum.find(fn {_include_path, include_names} ->
+      include_names
+      |> MapSet.new()
+      |> MapSet.size()
+      |> Kernel.>(1)
+    end)
+    |> case do
+      nil ->
+        :ok
+
+      {include_path, include_names} ->
+        names =
+          include_names
+          |> Enum.uniq()
+          |> map(&inspect/1)
+          |> Enum.join(", ")
+
+        {:error,
+         "Conflicting MAVLink XML includes in '#{path}' resolve to '#{include_path}': #{names}"}
+    end
   end
 
   defp parse_definition(defs) do
@@ -173,13 +314,52 @@ defmodule XMAVLink.Parser do
     end
   end
 
-  defp scan_file(path) do
-    try do
-      :xmerl_scan.file(path)
-    catch
-      kind, reason ->
-        {:error, "Failed to parse MAVLink XML file '#{path}': #{inspect({kind, reason})}"}
+  defp scan_file(path, limits) do
+    with :ok <- validate_file_size(path, limits) do
+      try do
+        :xmerl_scan.file(path)
+      catch
+        kind, reason ->
+          {:error, "Failed to parse MAVLink XML file '#{path}': #{inspect({kind, reason})}"}
+      end
     end
+  end
+
+  defp validate_file_size(path, limits) do
+    case File.stat(path) do
+      {:ok, %{type: :regular, size: size}} ->
+        if exceeds_limit?(size, limits.max_xml_file_bytes) do
+          {:error,
+           "MAVLink XML file '#{path}' is #{size} bytes, exceeding max_xml_file_bytes limit of #{format_limit(limits.max_xml_file_bytes)}"}
+        else
+          :ok
+        end
+
+      {:ok, %{type: type}} ->
+        {:error, "MAVLink XML path '#{path}' is not a regular file: #{inspect(type)}"}
+
+      {:error, :enoent} ->
+        {:error, :enoent}
+
+      {:error, reason} ->
+        {:error, "Failed to stat MAVLink XML file '#{path}': #{inspect(reason)}"}
+    end
+  end
+
+  defp exceeds_limit?(_value, :infinity), do: false
+  defp exceeds_limit?(value, limit), do: value > limit
+
+  defp format_limit(limit) do
+    case limit do
+      :infinity -> "infinity"
+      limit -> Integer.to_string(limit)
+    end
+  end
+
+  defp format_path_chain(paths) do
+    paths
+    |> map(&Path.basename/1)
+    |> Enum.join(" -> ")
   end
 
   def combine_definitions([single_def]) do

--- a/test/mavlink_parser_test.exs
+++ b/test/mavlink_parser_test.exs
@@ -484,6 +484,142 @@ defmodule XMAVLink.Test.Parser do
     )
   end
 
+  test "XML file size limit is enforced before parsing" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <description>#{String.duplicate("x", 128)}</description>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} =
+                 parse_mavlink_xml(Path.join(dir, "root.xml"), max_xml_file_bytes: 64)
+
+        assert message =~ "max_xml_file_bytes limit of 64"
+        assert message =~ "root.xml"
+      end
+    )
+  end
+
+  test "include depth limit is enforced with include chain context" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>child.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """,
+        "child.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>grandchild.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """,
+        "grandchild.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} =
+                 parse_mavlink_xml(Path.join(dir, "root.xml"), max_include_depth: 2)
+
+        assert message =~ "max_include_depth limit of 2"
+        assert message =~ "root.xml -> child.xml -> grandchild.xml"
+      end
+    )
+  end
+
+  test "cyclic includes are rejected with include chain context" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>child.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """,
+        "child.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>root.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ "Cyclic MAVLink XML include detected"
+        assert message =~ "root.xml -> child.xml -> root.xml"
+      end
+    )
+  end
+
+  test "empty includes are rejected" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include> </include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ "Empty MAVLink XML include"
+        assert message =~ "root.xml"
+      end
+    )
+  end
+
+  test "conflicting include paths are rejected" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>included.xml</include>
+          <include>./included.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """,
+        "included.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ "Conflicting MAVLink XML includes"
+        assert message =~ ~s("included.xml")
+        assert message =~ ~s("./included.xml")
+      end
+    )
+  end
+
   test "duplicate message ids across includes are rejected" do
     with_xml(
       %{


### PR DESCRIPTION
## Summary
- Add bounded MAVLink XML parser options for file size, include depth, and include file count.
- Reject include cycles, empty include entries, and conflicting include paths before generation.
- Update parser tests, changelog, security guidance, and spec-alignment docs.

## Verification
- `mise exec -- mix format`
- `mise exec -- mix test test/mavlink_parser_test.exs`
- `mise exec -- mix test test/mavlink_task_test.exs`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix docs`
- `mise exec -- mix dialyzer`