### PR TITLE
Clarify public HexDocs API boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Clarified the public HexDocs API surface and hid internal transport delegate
+  modules from generated documentation.
+
 ## 0.14.1 - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ formatter-compatible source for repeatable diffs.
 Treat MAVLink XML dialect files as trusted build inputs. The generator is meant
 for upstream or application-owned dialect files, not arbitrary untrusted XML.
 
+## Public API Surface
+
+The supported API is the documented HexDocs surface:
+
+- Core runtime modules: `XMAVLink.Router`, `XMAVLink.Frame`,
+  `XMAVLink.Message`, `XMAVLink.Signing`, and `XMAVLink.Heartbeat`.
+- Utility modules under `XMAVLink.Util.*`, except modules hidden from HexDocs.
+- Dialect and generator support: `XMAVLink.Dialect`, `XMAVLink.Parser`,
+  `XMAVLink.Types`, `XMAVLink.Utils`, and `mix xmavlink`.
+- Generated dialect modules, including the checked-in `Common` dialect.
+
+Application, supervisor, connection worker, transport delegate, routing helper,
+and inbound parser implementation modules are internal. They may appear in
+types, logs, or stack traces, but downstream applications should use the
+documented router, utility, generated dialect, and message APIs instead of
+depending on those internals.
+
 ## Configuring the XMAVLink Application
 
 Add the `:xmavlink` OTP application with no start arguments to your `mix.exs`.

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -50,12 +50,9 @@ defmodule XMAVLink.Router do
                         Note there is no tcpin connection - tcp is rarely used for MAVLink, the exception
                         being SITL testing which requires a tcpout connection.
 
-  - connections:        A map containing the state of the connections described by connection_strings along
-                        with the local connection, which is automatically created and responsible for allowing
-                        Elixir processes to receive and send MAVLink messages. The map is keyed by the port,
-                        device or :local to allow the corresponding connection state to be easily retrieved
-                        when we receive a message. See MAVLink.*Connection for map values. Note LocalConnection
-                        contains the system/component id, subscriber list and next sequence number.
+  - connections:        A map containing internal connection state for configured
+                        transports and the local process connection. This field is
+                        owned by the router and is not a supported integration API.
   - routes:             A map from a {system id, component id} tuple to the connection key a message from that
                         system/component was last received on. Used to forward messages to that system/component.
   - system_time_boot_ms:

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -1,7 +1,5 @@
 defmodule XMAVLink.SerialConnection do
-  @moduledoc """
-  XMAVLink.Router delegate for Serial connections
-  """
+  @moduledoc false
 
   @behaviour XMAVLink.Transport
 

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -1,8 +1,5 @@
 defmodule XMAVLink.TCPOutConnection do
-  @moduledoc """
-  MAVLink.Router delegate for TCP connections
-  Typically used to connect to SITL on port 5760
-  """
+  @moduledoc false
 
   @behaviour XMAVLink.Transport
 

--- a/lib/mavlink/transport.ex
+++ b/lib/mavlink/transport.ex
@@ -1,10 +1,5 @@
 defmodule XMAVLink.Transport do
-  @moduledoc """
-  Behaviour for connection transport delegates used by router connection workers.
-
-  Transport modules own external resources such as sockets or UART handles and
-  expose pure-ish frame handling helpers to the router.
-  """
+  @moduledoc false
 
   @type tokens :: [term]
   @type connection_key :: term

--- a/lib/mavlink/types.ex
+++ b/lib/mavlink/types.ex
@@ -3,7 +3,7 @@ defmodule XMAVLink.Types do
   Core types that remain the same across dialects.
   """
 
-  @typedoc "Connection delegate modules for XMAVLink.Router"
+  @typedoc "Internal connection state structs owned by `XMAVLink.Router`"
   @type connection ::
           XMAVLink.SerialConnection
           | XMAVLink.TCPOutConnection

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -1,7 +1,5 @@
 defmodule XMAVLink.UDPInConnection do
-  @moduledoc """
-  MXAVLink.Router delegate for UDP connections
-  """
+  @moduledoc false
 
   @behaviour XMAVLink.Transport
 

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -1,7 +1,5 @@
 defmodule XMAVLink.UDPOutConnection do
-  @moduledoc """
-  XMAVLink.Router delegate for UDP connections
-  """
+  @moduledoc false
 
   @behaviour XMAVLink.Transport
 

--- a/mix.exs
+++ b/mix.exs
@@ -114,6 +114,29 @@ defmodule XMAVLink.Mixfile do
         Release: [
           "CHANGELOG.md"
         ]
+      ],
+      groups_for_modules: [
+        "Core Runtime": [
+          XMAVLink.Router,
+          XMAVLink.Frame,
+          XMAVLink.Frame.Signature,
+          XMAVLink.Message,
+          XMAVLink.Signing,
+          XMAVLink.Heartbeat
+        ],
+        Utilities: ~r/^XMAVLink\.Util\./,
+        "Dialect And Generator Support": [
+          XMAVLink.Dialect,
+          XMAVLink.Parser,
+          XMAVLink.Types,
+          XMAVLink.Utils,
+          Mix.Tasks.Xmavlink
+        ],
+        "Generated Common Dialect": [
+          Common,
+          ~r/^Common\./,
+          ~r/^XMAVLink\.Message\.Common\./
+        ]
       ]
     ]
   end


### PR DESCRIPTION
## Summary
- Hide internal transport delegate modules and the transport behaviour from HexDocs.
- Add ExDoc module groups for core runtime APIs, utilities, dialect/generator support, and the generated Common dialect.
- Document the supported public API surface in the README and update router/type docs to treat connection state as internal.

## Verification
- `mise exec -- mix format`
- `mise exec -- mix docs`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix dialyzer`