### PR TITLE
[codex] Prepare xmavlink 0.14.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.14.2 - 2026-06-25
+
 ### Added
 
 - Added MAVLink XML parser hardening for include cycles, conflicting include

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.14.1"}
+     {:xmavlink, "~> 0.14.2"}
    ]
  end
  ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.14.1",
+      version: "0.14.2",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary
- Bump package version from `0.14.1` to `0.14.2`.
- Move the current unreleased changelog entries into `0.14.2 - 2026-06-25`.
- Update the README dependency example to `~> 0.14.2`.

## Release contents
- Typed utility cache structs for systems, latest messages, and parameter values.
- MAVLink XML parser hardening for include cycles/conflicts and size/depth/count limits.
- Public HexDocs API boundary clarification and internal transport delegate docs hidden.

## Verification
- `mise exec -- mix format`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix docs`
- `mise exec -- mix dialyzer`