### PR TITLE
[codex] Add downstream smoke and docs CI

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,6 +2,7 @@
   inputs: [
     "mix.exs",
     "config/**/*.{ex,exs}",
+    "examples/**/*.{ex,exs}",
     "lib/**/*.{ex,exs}",
     "test/**/*.{ex,exs}"
   ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -181,6 +181,52 @@ jobs:
       - name: Run Dialyzer
         run: mix dialyzer
 
+  docs_and_examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: 1.20.1
+          otp-version: 29.0.2
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Cache Mix dependencies and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+            examples/downstream_smoke/deps
+            examples/downstream_smoke/_build
+          key: ${{ runner.os }}-docs-examples-1.20.1-29.0.2-${{ hashFiles('mix.lock', 'examples/downstream_smoke/mix.exs') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-examples-1.20.1-29.0.2-
+
+      - name: Install Mix tools and dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          MIX_ENV=dev mix deps.get
+
+      - name: Build docs
+        run: MIX_ENV=dev mix docs
+
+      - name: Run downstream smoke fixture
+        working-directory: examples/downstream_smoke
+        run: |
+          mix deps.get
+          mix test --warnings-as-errors
+
   publish_hex:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -189,6 +235,7 @@ jobs:
       - detect_hex_publish
       - quality
       - dialyzer
+      - docs_and_examples
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect_hex_publish.outputs.should_publish == 'true'
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ MAVLink.ex
 
 # Example output directory for generated files.
 /output
+/examples/*/_build
+/examples/*/deps
 
 # macOS kruft
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added router coverage for subscriber cleanup and independent outbound signing
   state across multiple UDP connections.
+- Added a downstream compatibility smoke fixture and CI coverage for docs and
+  example workflows.
 
 ## 0.14.2 - 2026-06-25
 

--- a/examples/downstream_smoke/mix.exs
+++ b/examples/downstream_smoke/mix.exs
@@ -1,0 +1,25 @@
+defmodule XMAVLink.DownstreamSmoke.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :xmavlink_downstream_smoke,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      deps: deps(),
+      consolidate_protocols: false
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:xmavlink, path: "../..", runtime: false}
+    ]
+  end
+end

--- a/examples/downstream_smoke/mix.lock
+++ b/examples/downstream_smoke/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "circuits_uart": {:hex, :circuits_uart, "1.6.0", "259e8126b4004648e1bba6da5827b9e473b7e09e1eb4357f0026a1d9f274fce2", [:mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "9f0bdf612706b16beb2026a9e316cc313b919c35b663c1177d374b1f7330b790"},
+  "elixir_make": {:hex, :elixir_make, "0.10.0", "16577e2583a79bb79237bbff349619ef5d80afffc07eac6e4faf0d00e2ddaf7d", [:mix], [], "hexpm", "dc1f09fb7fa68866b886abd5f0f3c83553b1a19a52359a899e92af1bb3b31982"},
+  "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},
+}

--- a/examples/downstream_smoke/test/downstream_smoke_test.exs
+++ b/examples/downstream_smoke/test/downstream_smoke_test.exs
@@ -1,0 +1,65 @@
+defmodule XMAVLink.DownstreamSmokeTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias XMAVLink.Frame
+  alias XMAVLink.Router
+
+  test "consumer app can generate a dialect and use router subscribe/send flow" do
+    repo_root = Path.expand("../../..", __DIR__)
+    xml_path = Path.join(repo_root, "test/input/test_mavlink.xml")
+    output_dir = Path.join(Mix.Project.build_path(), "generated")
+    output_path = Path.join(output_dir, "downstream_smoke_dialect.ex")
+
+    File.rm_rf!(output_dir)
+    File.mkdir_p!(output_dir)
+
+    capture_io(fn ->
+      assert :ok = Mix.Tasks.Xmavlink.run([xml_path, output_path, "DownstreamSmoke.Dialect"])
+    end)
+
+    modules =
+      output_path
+      |> Code.compile_file()
+      |> Keyword.keys()
+
+    assert DownstreamSmoke.Dialect in modules
+    assert DownstreamSmoke.Dialect.Message.Heartbeat in modules
+
+    {:ok, router} =
+      Router.start_link(
+        %{
+          name: nil,
+          system: 245,
+          component: 250,
+          dialect: DownstreamSmoke.Dialect,
+          connection_strings: []
+        },
+        []
+      )
+
+    on_exit(fn ->
+      File.rm_rf!(output_dir)
+      if Process.alive?(router), do: GenServer.stop(router)
+    end)
+
+    assert :ok =
+             Router.subscribe(router,
+               message: DownstreamSmoke.Dialect.Message.Heartbeat,
+               as_frame: true
+             )
+
+    message = struct(DownstreamSmoke.Dialect.Message.Heartbeat, type: :mav_type_generic)
+
+    assert :ok = Router.pack_and_send(router, message, 2)
+
+    assert_receive %Frame{
+                     version: 2,
+                     source_system: 245,
+                     source_component: 250,
+                     message: ^message
+                   },
+                   200
+  end
+end

--- a/examples/downstream_smoke/test/test_helper.exs
+++ b/examples/downstream_smoke/test/test_helper.exs
@@ -1,0 +1,3 @@
+Logger.configure(level: :warning)
+
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
## Summary

- Add a downstream compatibility smoke fixture under `examples/downstream_smoke` that depends on the repo as a path dependency, generates a dialect, starts a router, subscribes, and verifies a packed/sent frame.
- Add docs/example CI coverage and make Hex publishing wait for that job.
- Include example source in formatter inputs and ignore example build/dependency directories.
- Update the changelog with the new test coverage.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix docs`
- `mise exec -- mix deps.get && mise exec -- mix test --warnings-as-errors` in `examples/downstream_smoke`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix dialyzer`