### PR TITLE
[codex] Reject reserved XML identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Hardened MAVLink XML generation by rejecting reserved identifiers before
+  source generation.
+
 ### Tests
 
 - Added router coverage for subscriber cleanup and independent outbound signing

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -63,7 +63,7 @@ Known non-goals for 1.0 unless separately implemented:
 | Enum merging | Partial | Matching enum names are merged and sorted by value. Duplicate enum entries and duplicate resolved values are rejected. |
 | Duplicate message ids | Supported validation | Duplicate message ids are rejected across the combined dialect, including included XML files. |
 | XML `bitmask="true"` | Supported | Enum-level bitmask declarations are parsed and used before heuristic bitmask detection. |
-| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. The parser validates generated identifiers and escapes generated docs/descriptions before source generation. Reserved-name validation is still tracked separately. |
+| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. The parser validates generated identifiers, rejects reserved enum/message/field names, and escapes generated docs/descriptions before source generation. |
 | Generated Common dialect | Supported within above scope | `lib/common.ex` is regenerated from `config/common.xml` and should be treated as build output. |
 
 ## Changes Made In This Pass
@@ -106,8 +106,7 @@ Known non-goals for 1.0 unless separately implemented:
 
 ## Follow-Up Issues
 
-- #53: Continue aligning XML parser/generator validation with `mavgen`,
-  especially reserved-name validation.
+- #53: Continue aligning XML parser/generator validation with `mavgen`.
 
 These follow-ups should be prioritized by MAVLink 2 impact first. None of the
 reviewed gaps require new MAVLink 1-only work before 1.0.

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ formatting generated files by hand. The generator emits deterministic,
 formatter-compatible source for repeatable diffs.
 
 Treat MAVLink XML dialect files as trusted build inputs. The generator enforces
-basic include graph, file size, identifier, and duplicate-definition checks, but
-it is meant for upstream or application-owned dialect files, not arbitrary
-untrusted XML.
+basic include graph, file size, identifier, reserved-name, and
+duplicate-definition checks, but it is meant for upstream or application-owned
+dialect files, not arbitrary untrusted XML.
 
 ## Public API Surface
 

--- a/lib/mavlink/parser.ex
+++ b/lib/mavlink/parser.ex
@@ -57,6 +57,15 @@ defmodule XMAVLink.Parser do
   @unit_regex ~r/\A[A-Za-z0-9_%@\/\*\^\.\-]+\z/
   @scalar_field_types ~w(char uint8_t int8_t uint16_t int16_t uint32_t int32_t uint64_t int64_t float double)
   @valid_display_values ~w(bitmask)
+  @reserved_identifier_names MapSet.new(~w(
+    abstract after await boolean break byte case catch char class cond const
+    continue debugger default def defimpl defmodule defp defprotocol delete do
+    double else end enum export extends false final finally float fn for
+    function goto if implements import in instanceof int interface let long
+    native new nil package private protected public quote receive rescue return
+    short static super switch synchronized this throw transient true try typeof
+    unless unquote unquote_splicing var void volatile when while with yield
+  ))
   @default_limits %{
     max_xml_file_bytes: 2_000_000,
     max_include_depth: 32,
@@ -812,11 +821,20 @@ defmodule XMAVLink.Parser do
   defp required_identifier("", kind, context), do: {:error, "Missing #{kind} in #{context}"}
 
   defp required_identifier(value, kind, context) when is_binary(value) do
-    if Regex.match?(@identifier_regex, value) do
-      {:ok, value}
-    else
-      {:error, "Invalid #{kind} #{inspect(value)} in #{context}"}
+    cond do
+      not Regex.match?(@identifier_regex, value) ->
+        {:error, "Invalid #{kind} #{inspect(value)} in #{context}"}
+
+      reserved_identifier?(value) ->
+        {:error, "Reserved #{kind} #{inspect(value)} in #{context}"}
+
+      true ->
+        {:ok, value}
     end
+  end
+
+  defp reserved_identifier?(value) do
+    MapSet.member?(@reserved_identifier_names, downcase(value))
   end
 
   defp optional_identifier(nil, _kind, _context), do: {:ok, nil}

--- a/test/mavlink_parser_test.exs
+++ b/test/mavlink_parser_test.exs
@@ -761,6 +761,82 @@ defmodule XMAVLink.Test.Parser do
     )
   end
 
+  test "reserved XML identifiers are rejected before source generation" do
+    cases = [
+      {
+        "reserved message name",
+        """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <messages>
+            <message id="1" name="CLASS">
+              <field type="uint8_t" name="value">Value</field>
+            </message>
+          </messages>
+        </mavlink>
+        """,
+        ~s(Reserved message name "CLASS" in message id 1)
+      },
+      {
+        "reserved field name",
+        """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <messages>
+            <message id="1" name="TEST_MESSAGE">
+              <field type="uint8_t" name="case">Value</field>
+            </message>
+          </messages>
+        </mavlink>
+        """,
+        ~s(Reserved field name "case" in message TEST_MESSAGE)
+      },
+      {
+        "reserved enum name",
+        """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <enums>
+            <enum name="SWITCH">
+              <entry value="0" name="TEST_ENTRY" />
+            </enum>
+          </enums>
+        </mavlink>
+        """,
+        ~s(Reserved enum name "SWITCH" in enum)
+      },
+      {
+        "reserved enum entry name",
+        """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <enums>
+            <enum name="TEST_ENUM">
+              <entry value="0" name="RETURN" />
+            </enum>
+          </enums>
+        </mavlink>
+        """,
+        ~s(Reserved enum entry name "RETURN" in enum TEST_ENUM)
+      }
+    ]
+
+    for {label, xml, expected_message} <- cases do
+      with_xml(%{"root.xml" => xml}, fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml")), label
+        assert message =~ expected_message
+      end)
+    end
+  end
+
   test "invalid field display values are rejected before atom creation" do
     with_xml(
       %{


### PR DESCRIPTION
## Summary

- Reject reserved XML identifiers during parser validation before generator source emission.
- Apply the rule consistently through the existing identifier validation path for enum names, enum entries, messages, fields, and enum references.
- Document the reserved-name hardening in the README, changelog, and MAVLink spec-alignment notes.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test test/mavlink_parser_test.exs --warnings-as-errors`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix docs`
- `mise exec -- mix xref graph --label compile-connected --fail-above 0`
- `mise exec -- mix dialyzer`