### PR TITLE
[codex] Prepare 0.14.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.14.3 - 2026-06-25
+
 ### Changed
 
 - Hardened MAVLink XML generation by rejecting reserved identifiers before

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.14.2",
+      version: "0.14.3",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Bump package version from `0.14.2` to `0.14.3`.
- Move the current unreleased changelog entries into a dated `0.14.3` section.

## Release notes

- MAVLink XML generation now rejects reserved identifiers before source generation.
- This may affect custom dialects that previously parsed but generated invalid or risky Elixir source.
- Adds downstream smoke fixture and docs/example CI coverage.
- No runtime router/message API changes.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix test --warnings-as-errors`
- `mise exec -- mix docs`
- `mise exec -- mix deps.get && mise exec -- mix test --warnings-as-errors` in `examples/downstream_smoke`