### PR TITLE
[codex] harden parser and routing policies

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Check dependency lock hygiene
         run: mix deps.unlock --check-unused
 
+      - name: Audit Hex dependencies
+        run: mix hex.audit
+
       - name: Check formatting
         run: mix format --check-formatted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Hardened MAVLink XML generation by rejecting out-of-range message ids,
+  negative or oversized enum values, and message fields that reference unknown
+  enums after includes are merged.
+
+### Added
+
+- Added `accept_mavlink1: false` as an opt-in signing policy for deployments
+  that should reject MAVLink 1 inbound and outbound traffic on signing-enabled
+  connections.
+- Added `forward_unknown: :broadcast | :local_only | :drop` router policy for
+  well-shaped frames whose message ids are missing from the configured dialect.
+  The default remains `:broadcast`.
+- Added bracketed IPv6 and URI-style network connection string forms such as
+  `udpout:[::1]:14550` and `tcpout://[::1]:5760`.
+
+### Changed
+
+- Included the MAVLink 2 signing guide in Hex package files and generated
+  documentation.
+- Bounded retained stream-transport tails after valid MAVLink frames to avoid
+  holding oversized garbage buffers.
+- Deduplicated internal raw packet selection for transport forwarding.
+- Extracted router connection and worker bookkeeping into an internal router
+  registry module.
+- Deduplicated internal utility command context, retry, and table helpers.
+- Corrected internal connection and MAVLink float/double typespecs.
+- Allowed reserved Elixir words as MAVLink field names when parsing XML, matching
+  the existing generated struct-key behavior for fields such as `end`.
+- Updated coverage configuration to ignore generated Common dialect modules
+  and use a realistic baseline threshold for hand-written code.
+- Updated installation documentation for the current 0.14.3 release line.
+
+### Tests
+
+- Added a Hex dependency audit step to CI.
+- Added stream-transport coverage for oversized trailing data after a valid
+  frame.
+
 ## 0.14.3 - 2026-06-25
 
 ### Changed

--- a/MAVLINK2_SIGNING.md
+++ b/MAVLINK2_SIGNING.md
@@ -1,11 +1,11 @@
-# MAVLink 2 Signing Plan
+# MAVLink 2 Signing Guide
 
 Primary references:
 
 - MAVLink message signing: https://mavlink.io/en/guide/message_signing.html
 - MAVLink packet serialization: https://mavlink.io/en/guide/serialization.html
 
-## Current State
+## Overview
 
 XMAVLink parses the MAVLink 2 signing incompatibility flag (`0x01`) as a known
 frame-shape feature and extracts the 13-byte signing trailer into
@@ -23,13 +23,14 @@ state needed for replay protection by tracking the last accepted timestamp per
 streams more than 6,000,000 ticks behind the local signing timestamp.
 
 Routers accept a `:signing` configuration with `:secret_key`, `:link_id`,
-`:timestamp`, optional `:accept_unsigned`, and optional timestamp persistence
-callbacks. Receive paths seed each connection with that policy. Configured
-signed MAVLink 2 frames are verified before dialect unpacking, delivered to
-subscribers, forwarded through the normal routing logic, and recorded for replay
-protection. Unsigned MAVLink 2 inbound frames are rejected by default while
-signing is enabled unless `accept_unsigned: true` is set. MAVLink 1 frames
-remain accepted under a signing policy. When signing is not configured, signed
+`:timestamp`, optional `:accept_unsigned`, optional `:accept_mavlink1`, and
+optional timestamp persistence callbacks. Receive paths seed each connection
+with that policy. Configured signed MAVLink 2 frames are verified before dialect
+unpacking, delivered to subscribers, forwarded through the normal routing logic,
+and recorded for replay protection. Unsigned MAVLink 2 inbound frames are
+rejected by default while signing is enabled unless `accept_unsigned: true` is
+set. MAVLink 1 frames remain accepted under a signing policy unless
+`accept_mavlink1: false` is configured. When signing is not configured, signed
 MAVLink 2 frames still return `:signed_frame_unsupported`.
 
 Outbound routing signs unsigned MAVLink 2 frames on signing-enabled
@@ -64,7 +65,7 @@ The signature is defined as the first 48 bits of SHA-256 over the 32-byte shared
 secret key followed by the wire header including the magic byte, payload, CRC,
 link id, and timestamp.
 
-## Intended Public Policy Shape
+## Public Policy Shape
 
 Signing is currently configured per router and copied into each connection:
 
@@ -75,6 +76,10 @@ Signing is currently configured per router and copied into each connection:
   sign unsigned outbound MAVLink 2 frames on each connection.
 - `accept_unsigned: false | true`: explicit policy for unsigned frames when
   signing is enabled. The policy helper defaults to reject.
+- `accept_mavlink1: true | false`: explicit policy for MAVLink 1 frames when
+  signing is enabled. The policy helper defaults to accept for mixed-link
+  compatibility. Set false for signed-only deployments that should reject
+  MAVLink 1 inbound and outbound traffic on signing-enabled connections.
 - `timestamp_load: fun | {module, function, args}`: optional zero-arity callback
   that returns a previously saved timestamp, `{:ok, timestamp}`, or `nil` when
   no timestamp has been saved yet. Loaded timestamps are combined with the

--- a/MAVLINK_SPEC_ALIGNMENT.md
+++ b/MAVLINK_SPEC_ALIGNMENT.md
@@ -1,6 +1,6 @@
 # MAVLink Spec Alignment for 1.0
 
-Review date: 2026-05-08
+Review date: 2026-06-25
 
 Primary references:
 
@@ -53,7 +53,7 @@ Known non-goals for 1.0 unless separately implemented:
 | MAVLink 1 frame shape | Supported | Existing parser/packer handles v1 framing, checksum, and 8-bit message ids. New MAVLink 1-only expansion is not a priority for 1.0. |
 | CRC_EXTRA calculation | Supported | Field ordering is size-stable for base fields, arrays are ordered by element size, and extension fields are excluded. |
 | Field ordering | Supported | Base fields are stably sorted by native type size; extension fields remain in XML declaration order. |
-| Unknown message handling | Partial | Unknown known-shape frames are forwarded as broadcast when the message id is not present in the dialect. Unknown messages cannot expose target fields because the payload cannot be decoded. |
+| Unknown message handling | Configurable partial | Unknown known-shape frames are forwarded as broadcast by default when the message id is not present in the dialect. Routers can set `forward_unknown: :local_only` or `:drop` for stricter deployments. Unknown messages cannot expose target fields because the payload cannot be decoded. |
 | Compatible flags | Supported | MAVLink 2 compatible flags are retained and otherwise ignored. |
 | Incompatible flags | Supported | Unknown incompatible flags are discarded as required. Signing's known 13-byte trailer is consumed when present so stream boundaries stay aligned. |
 | Routing unchanged packets | Supported with signing caveat | Forwarding generally uses the original raw frame bytes. Unsigned MAVLink 2 frames sent over signing-enabled connections are signed for that outbound link; already signed MAVLink 2 frames are forwarded unchanged. |
@@ -63,10 +63,10 @@ Known non-goals for 1.0 unless separately implemented:
 | Enum merging | Partial | Matching enum names are merged and sorted by value. Duplicate enum entries and duplicate resolved values are rejected. |
 | Duplicate message ids | Supported validation | Duplicate message ids are rejected across the combined dialect, including included XML files. |
 | XML `bitmask="true"` | Supported | Enum-level bitmask declarations are parsed and used before heuristic bitmask detection. |
-| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. The parser validates generated identifiers, rejects reserved enum/message/field names, and escapes generated docs/descriptions before source generation. |
+| XML identifiers and source generation safety | Partial | XML is treated as trusted build input. The parser validates generated identifiers, rejects reserved enum and message names, rejects out-of-range message ids and enum values, validates field enum references, and escapes generated docs/descriptions before source generation. Reserved field names such as `end` are accepted because generated message structs already support them as keys. |
 | Generated Common dialect | Supported within above scope | `lib/common.ex` is regenerated from `config/common.xml` and should be treated as build output. |
 
-## Changes Made In This Pass
+## Recent Alignment Work
 
 - Generated MAVLink 2 unpackers now accept extra trailing bytes after all
   locally known fields and ignore them as future extension fields.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.14.2"}
+     {:xmavlink, "~> 0.14.3"}
    ]
  end
  ```
@@ -56,13 +56,14 @@ timestamps are tracked per connection, and unsigned MAVLink 2 inbound frames are
 rejected by default while signing is enabled unless `accept_unsigned: true` is
 set. Unsigned outbound MAVLink 2 frames sent over a signing-enabled connection
 are signed with a monotonically incremented per-connection timestamp. MAVLink 1
-inbound and outbound frames remain unsigned and accepted under a signing policy.
-Applications can configure timestamp load/save callbacks to preserve local
-signing timestamps across restarts. Inbound `SETUP_SIGNING` frames are delivered
-locally but are not forwarded between MAVLink links by generic routing. MAVLink
-2 frames with other incompatible flags are discarded. Supported configured
-transports are serial, UDP client (`udpout`), UDP server (`udpin`), and TCP
-client (`tcpout`). TCP server (`tcpin`) connections are not implemented.
+inbound and outbound frames remain unsigned and accepted under a signing policy
+unless `accept_mavlink1: false` is configured. Applications can configure
+timestamp load/save callbacks to preserve local signing timestamps across
+restarts. Inbound `SETUP_SIGNING` frames are delivered locally but are not
+forwarded between MAVLink links by generic routing. MAVLink 2 frames with other
+incompatible flags are discarded. Supported configured transports are serial,
+UDP client (`udpout`), UDP server (`udpin`), and TCP client (`tcpout`). TCP
+server (`tcpin`) connections are not implemented.
 
 MAVLink 2 is the primary 1.0 compatibility target. MAVLink 1 remains supported
 for existing frame parsing, packing, and routing behavior while that support
@@ -147,6 +148,11 @@ XMAVLink supports the following connection string formats:
 - **UDP In (server)**: `udpin:<address>:<port>` (e.g., `"udpin:0.0.0.0:14550"`)
 - **TCP Out (client)**: `tcpout:<address>:<port>` (e.g., `"tcpout:192.168.1.100:5760"`)
 
+Network connection strings also accept bracketed IPv6 literals and URI-style
+forms, for example `"udpout:[::1]:14550"` and
+`"tcpout://[::1]:5760"`. Existing hostname, IPv4, and comma-separated network
+forms remain supported.
+
 There is no `tcpin` connection string. TCP is currently supported only as an
 outbound client connection, primarily for SITL endpoints.
 
@@ -186,6 +192,19 @@ learned for routing, and delivered to local subscribers. Local messages sent
 with `XMAVLink.Router.pack_and_send/2` or `/3` can still be forwarded to learned
 remote vehicles.
 
+Frames with message ids missing from the configured dialect are treated as
+unknown but well-shaped MAVLink frames. By default, `forward_unknown:
+:broadcast` preserves forward-compatible routing behavior. Stricter deployments
+can set `forward_unknown: :local_only` to deliver unknown frames only to local
+subscribers, or `forward_unknown: :drop` to suppress them entirely:
+
+```elixir
+config :xmavlink,
+  dialect: Common,
+  connections: ["udpin:0.0.0.0:14550"],
+  forward_unknown: :local_only
+```
+
 ### DNS Hostname Support
 
 As of version 0.4.2, XMAVLink supports DNS hostnames in addition to IP addresses for network connections. This is particularly useful in:
@@ -209,7 +228,10 @@ config :xmavlink,
   ]
 ```
 
-The router will automatically resolve DNS hostnames to IP addresses at startup. If a hostname cannot be resolved, the router will raise an `ArgumentError` with details about the resolution failure.
+The router will automatically resolve DNS hostnames to IP addresses at startup.
+IPv4 is preferred when both address families resolve; IPv6 literals and
+IPv6-only names are also supported. If a hostname cannot be resolved, the router
+will raise an `ArgumentError` with details about the resolution failure.
 
 ### Heartbeat emission
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,11 +27,12 @@ Current trust boundaries:
   frames are verified before unpacking, replay timestamps are tracked per
   connection, and unsigned MAVLink 2 inbound frames are rejected by default
   while signing is enabled unless `accept_unsigned: true` is set. MAVLink 1
-  inbound frames remain accepted under a signing policy. Unsigned outbound
-  MAVLink 2 frames sent over signing-enabled connections are signed with a
-  monotonically incremented per-connection timestamp. Applications can configure
-  timestamp load/save hooks to preserve local signing timestamps across
-  restarts. Frames with other incompatible MAVLink 2 flags are discarded.
+  inbound and outbound frames remain accepted under a signing policy unless
+  `accept_mavlink1: false` is set. Unsigned outbound MAVLink 2 frames sent over
+  signing-enabled connections are signed with a monotonically incremented
+  per-connection timestamp. Applications can configure timestamp load/save hooks
+  to preserve local signing timestamps across restarts. Frames with other
+  incompatible MAVLink 2 flags are discarded.
 - `SETUP_SIGNING` frames carry key material. Inbound `SETUP_SIGNING` frames are
   delivered locally for application handling but are not forwarded from one
   MAVLink connection to another by the generic router.
@@ -52,6 +53,10 @@ Current trust boundaries:
 - Prefer MAVLink 2 signing on links where peers are not fully trusted.
 - Keep `accept_unsigned: false` unless a migration or mixed-link deployment
   explicitly requires unsigned MAVLink 2 frames on a signed connection.
+- Set `accept_mavlink1: false` on signing-enabled connections that must reject
+  all MAVLink 1 traffic.
+- Set `forward_unknown: :local_only` or `:drop` on routers that should not
+  bridge unknown dialect-extension messages between remote links.
 - Persist signing timestamps with the configured load/save callbacks when
   restart replay protection matters.
 - Treat signing keys and `SETUP_SIGNING` payloads as secrets.

--- a/lib/mavlink/connection/inbound.ex
+++ b/lib/mavlink/connection/inbound.ex
@@ -8,6 +8,7 @@ defmodule XMAVLink.Connection.Inbound do
   @mavlink_2_signature_flag 0x01
   @mavlink_2_signature_length 13
   @smallest_mavlink_message 8
+  @max_stream_buffer_size 4_096
 
   def datagram(raw, connection, connection_key, dialect, log_prefix, failure_description \\ nil) do
     case binary_to_frame_and_tail(raw) do
@@ -42,7 +43,15 @@ defmodule XMAVLink.Connection.Inbound do
         {:error, :not_a_frame, socket, struct(connection, buffer: <<>>)}
 
       {nil, rest} ->
-        {:error, :incomplete_frame, socket, struct(connection, buffer: rest)}
+        if byte_size(rest) > @max_stream_buffer_size do
+          Logger.debug(
+            "#{log_prefix}: Dropping overlong incomplete MAVLink stream buffer (#{byte_size(rest)} bytes)"
+          )
+
+          {:error, :stream_buffer_overflow, socket, struct(connection, buffer: <<>>)}
+        else
+          {:error, :incomplete_frame, socket, struct(connection, buffer: rest)}
+        end
 
       {received_frame, rest} ->
         if byte_size(rest) >= @smallest_mavlink_message do

--- a/lib/mavlink/connection/outbound.ex
+++ b/lib/mavlink/connection/outbound.ex
@@ -1,0 +1,8 @@
+defmodule XMAVLink.Connection.Outbound do
+  @moduledoc false
+
+  alias XMAVLink.Frame
+
+  def packet!(%Frame{version: 1, mavlink_1_raw: packet}) when is_binary(packet), do: packet
+  def packet!(%Frame{version: 2, mavlink_2_raw: packet}) when is_binary(packet), do: packet
+end

--- a/lib/mavlink/connection_spec.ex
+++ b/lib/mavlink/connection_spec.ex
@@ -15,7 +15,58 @@ defmodule XMAVLink.ConnectionSpec do
 
   @spec parse(String.t()) :: t
   def parse(connection_string) when is_binary(connection_string),
-    do: connection_string |> String.split([":", ","]) |> parse_tokens()
+    do: connection_string |> parse_connection_string() |> parse_tokens()
+
+  defp parse_connection_string(connection_string) do
+    cond do
+      network_uri?(connection_string) ->
+        parse_network_uri(connection_string)
+
+      bracketed_network_string?(connection_string) ->
+        parse_bracketed_network_string(connection_string)
+
+      String.starts_with?(connection_string, "serial:") ->
+        parse_serial_string(connection_string)
+
+      true ->
+        String.split(connection_string, [":", ","])
+    end
+  end
+
+  defp network_uri?(connection_string) do
+    String.match?(connection_string, ~r/\A(?:udpin|udpout|tcpout):\/\//)
+  end
+
+  defp parse_network_uri(connection_string) do
+    case URI.parse(connection_string) do
+      %URI{scheme: protocol, host: host, port: port}
+      when protocol in ["udpin", "udpout", "tcpout"] and is_binary(host) and is_integer(port) ->
+        [protocol, host, Integer.to_string(port)]
+
+      %URI{scheme: protocol} when protocol in ["udpin", "udpout", "tcpout"] ->
+        [protocol]
+
+      %URI{scheme: protocol} ->
+        [protocol || connection_string]
+    end
+  end
+
+  defp bracketed_network_string?(connection_string) do
+    String.match?(connection_string, ~r/\A(?:udpin|udpout|tcpout):\[[^\]]+\]:[^:]+\z/)
+  end
+
+  defp parse_bracketed_network_string(connection_string) do
+    [protocol, rest] = String.split(connection_string, ":[", parts: 2)
+    [address, port] = String.split(rest, "]:", parts: 2)
+    [protocol, address, port]
+  end
+
+  defp parse_serial_string(connection_string) do
+    case String.split(connection_string, ":", parts: 3) do
+      ["serial", port, baud] -> ["serial", port, baud]
+      ["serial" | rest] -> ["serial" | rest]
+    end
+  end
 
   defp parse_tokens(tokens = ["udpin" | _]),
     do: %{transport: UDPInConnection, tokens: validate_address_and_port(tokens)}

--- a/lib/mavlink/connection_worker.ex
+++ b/lib/mavlink/connection_worker.ex
@@ -3,6 +3,7 @@ defmodule XMAVLink.ConnectionWorker do
 
   use GenServer
   require Logger
+  import XMAVLink.Utils, only: [format_address: 1]
 
   defstruct [
     :router,
@@ -234,9 +235,8 @@ defmodule XMAVLink.ConnectionWorker do
 
   defp direct_connection(connection), do: connection
 
-  defp connection_description([protocol, address, port])
-       when is_tuple(address) and tuple_size(address) == 4 do
-    "#{protocol}:#{Enum.join(Tuple.to_list(address), ".")}:#{port}"
+  defp connection_description([protocol, address, port]) when is_tuple(address) do
+    "#{protocol}:#{format_address(address)}:#{port}"
   end
 
   defp connection_description(["serial", port, baud]), do: "serial:#{port}:#{baud}"

--- a/lib/mavlink/parser.ex
+++ b/lib/mavlink/parser.ex
@@ -57,6 +57,8 @@ defmodule XMAVLink.Parser do
   @unit_regex ~r/\A[A-Za-z0-9_%@\/\*\^\.\-]+\z/
   @scalar_field_types ~w(char uint8_t int8_t uint16_t int16_t uint32_t int32_t uint64_t int64_t float double)
   @valid_display_values ~w(bitmask)
+  @max_message_id 0xFF_FFFF
+  @max_enum_value 0xFFFF_FFFF_FFFF_FFFF
   @reserved_identifier_names MapSet.new(~w(
     abstract after await boolean break byte case catch char class cond const
     continue debugger default def defimpl defmodule defp defprotocol delete do
@@ -605,7 +607,7 @@ defmodule XMAVLink.Parser do
          {:ok, field_name} <-
            :xmerl_xpath.string(~c"@name", element)
            |> extract_text
-           |> required_identifier("field name", context),
+           |> required_identifier("field name", context, allow_reserved: true),
          {:ok, enum} <-
            :xmerl_xpath.string(~c"@enum", element)
            |> extract_text
@@ -699,13 +701,29 @@ defmodule XMAVLink.Parser do
   end
 
   defp validate_definition(definition) do
-    with :ok <- validate_unique_message_ids(definition.messages),
+    with :ok <- validate_message_ids(definition.messages),
+         :ok <- validate_unique_message_ids(definition.messages),
          :ok <- validate_unique_message_modules(definition.messages),
          :ok <- validate_unique_enums(definition.enums),
          :ok <- validate_enum_entries(definition.enums),
-         :ok <- validate_message_fields(definition.messages) do
+         :ok <- validate_message_fields(definition.messages),
+         :ok <- validate_field_enum_references(definition.messages, definition.enums) do
       definition
     end
+  end
+
+  defp validate_message_ids(messages) do
+    reduce(messages, :ok, fn
+      _next_message, {:error, _reason} = error ->
+        error
+
+      %{id: id}, :ok when id in 0..@max_message_id ->
+        :ok
+
+      %{id: id, name: name}, :ok ->
+        {:error,
+         "Invalid message id #{inspect(id)} for #{name}; MAVLink 2 message ids must be in 0..#{@max_message_id}"}
+    end)
   end
 
   defp validate_unique_message_ids(messages) do
@@ -766,13 +784,28 @@ defmodule XMAVLink.Parser do
   defp validate_unique_enum_entry_values(enum) do
     resolved_entries = resolve_enum_entry_values(enum.entries)
 
-    case duplicate_by(resolved_entries, & &1.value) do
+    with :ok <- validate_enum_entry_value_range(enum, resolved_entries) do
+      case duplicate_by(resolved_entries, & &1.value) do
+        nil ->
+          :ok
+
+        {value, duplicate_entries} ->
+          names = duplicate_entries |> map(&inspect(&1.name)) |> Enum.join(", ")
+          {:error, "Duplicate enum value #{value} in enum #{inspect(enum.name)} for #{names}"}
+      end
+    end
+  end
+
+  defp validate_enum_entry_value_range(enum, entries) do
+    entries
+    |> Enum.find(fn entry -> entry.value < 0 or entry.value > @max_enum_value end)
+    |> case do
       nil ->
         :ok
 
-      {value, duplicate_entries} ->
-        names = duplicate_entries |> map(&inspect(&1.name)) |> Enum.join(", ")
-        {:error, "Duplicate enum value #{value} in enum #{inspect(enum.name)} for #{names}"}
+      entry ->
+        {:error,
+         "Invalid enum value #{entry.value} for #{inspect(entry.name)} in enum #{inspect(enum.name)}; enum values must be in 0..#{@max_enum_value}"}
     end
   end
 
@@ -791,6 +824,30 @@ defmodule XMAVLink.Parser do
         end
     end)
   end
+
+  defp validate_field_enum_references(messages, enums) do
+    enum_names = MapSet.new(enums, &Atom.to_string(&1.name))
+
+    reduce(messages, :ok, fn
+      _message, {:error, _reason} = error ->
+        error
+
+      message, :ok ->
+        case Enum.find(message.fields, &unknown_enum_reference?(&1, enum_names)) do
+          nil ->
+            :ok
+
+          field ->
+            {:error,
+             "Unknown enum #{inspect(field.enum)} referenced by field #{field.name} in message #{message.name}"}
+        end
+    end)
+  end
+
+  defp unknown_enum_reference?(%{enum: ""}, _enum_names), do: false
+
+  defp unknown_enum_reference?(%{enum: enum}, enum_names),
+    do: not MapSet.member?(enum_names, enum)
 
   defp resolve_enum_entry_values(entries) do
     entries
@@ -817,15 +874,23 @@ defmodule XMAVLink.Parser do
     |> Enum.join("")
   end
 
-  defp required_identifier(nil, kind, context), do: {:error, "Missing #{kind} in #{context}"}
-  defp required_identifier("", kind, context), do: {:error, "Missing #{kind} in #{context}"}
+  defp required_identifier(value, kind, context),
+    do: required_identifier(value, kind, context, [])
 
-  defp required_identifier(value, kind, context) when is_binary(value) do
+  defp required_identifier(nil, kind, context, _opts),
+    do: {:error, "Missing #{kind} in #{context}"}
+
+  defp required_identifier("", kind, context, _opts),
+    do: {:error, "Missing #{kind} in #{context}"}
+
+  defp required_identifier(value, kind, context, opts) when is_binary(value) do
+    allow_reserved? = Keyword.get(opts, :allow_reserved, false)
+
     cond do
       not Regex.match?(@identifier_regex, value) ->
         {:error, "Invalid #{kind} #{inspect(value)} in #{context}"}
 
-      reserved_identifier?(value) ->
+      not allow_reserved? and reserved_identifier?(value) ->
         {:error, "Reserved #{kind} #{inspect(value)} in #{context}"}
 
       true ->

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -24,6 +24,7 @@ defmodule XMAVLink.Router do
   alias XMAVLink.Message
   alias XMAVLink.Router
   alias XMAVLink.Router.Config
+  alias XMAVLink.Router.ConnectionRegistry
   alias XMAVLink.Router.Routing
   alias XMAVLink.Signing
   alias XMAVLink.LocalConnection
@@ -45,6 +46,8 @@ defmodule XMAVLink.Router do
                         ```udpin:<local ip>:<local port>
                         udpout:<remote ip>:<remote port>
                         tcpout:<remote ip>:<remote port>
+                        udpout://<remote ip or host>:<remote port>
+                        tcpout://[<ipv6 address>]:<remote port>
                         serial:<device>:<baud rate>```
 
                         Note there is no tcpin connection - tcp is rarely used for MAVLink, the exception
@@ -70,6 +73,8 @@ defmodule XMAVLink.Router do
     connection_retry_ms: 1_000,
     # Whether remote inbound frames may be forwarded to other remote links
     remote_forwarding: true,
+    # How well-shaped frames from unknown message ids are routed
+    forward_unknown: :broadcast,
     # Subscription cache name for restart restoration, if any
     subscription_cache: nil,
     # Per-connection MAVLink 2 signing policy seed
@@ -90,6 +95,7 @@ defmodule XMAVLink.Router do
   @type mavlink_address :: Types.mavlink_address()
   @type mavlink_connection :: Types.connection()
   @type connection_key :: :local | binary | port | {port, Types.net_address(), Types.net_port()}
+  @type forward_unknown_policy :: :broadcast | :local_only | :drop
   @typedoc "Delivery metadata returned by `send_message/1..3`."
   @type delivery :: %{
           source_connection: connection_key(),
@@ -112,6 +118,7 @@ defmodule XMAVLink.Router do
           connection_strings: [String.t()],
           connection_retry_ms: non_neg_integer,
           remote_forwarding: boolean,
+          forward_unknown: forward_unknown_policy,
           signing: Signing.t() | nil,
           subscription_cache: router_name | nil,
           connection_supervisor: pid | nil,
@@ -152,6 +159,8 @@ defmodule XMAVLink.Router do
                         udpin:<local ip>:<local port>
                         udpout:<remote ip>:<remote port>
                         tcpout:<remote ip>:<remote port>
+                        udpout://<remote ip or host>:<remote port>
+                        tcpout://[<ipv6 address>]:<remote port>
                         serial:<device>:<baud rate>
   - connection_retry_ms:
                         Retry delay for configured connection workers after
@@ -162,6 +171,11 @@ defmodule XMAVLink.Router do
                         to other remote links. Defaults to true. Set false for
                         endpoint/GCS use cases that should receive remote
                         traffic locally without bridging it between links.
+  - forward_unknown:
+                        How frames with message ids missing from the dialect
+                        are handled. Defaults to `:broadcast`, preserving
+                        current forward-compatible routing behavior. Use
+                        `:local_only` or `:drop` for stricter deployments.
 
   - opts:               Standard GenServer options. Pass `:name` to register
                         a non-default router, or `name: nil` in the args map to
@@ -177,6 +191,7 @@ defmodule XMAVLink.Router do
             optional(:connections) => [String.t()],
             optional(:connection_retry_ms) => non_neg_integer,
             optional(:remote_forwarding) => boolean,
+            optional(:forward_unknown) => forward_unknown_policy,
             optional(:signing) => keyword() | nil
           },
           [{atom, any}]
@@ -567,6 +582,7 @@ defmodule XMAVLink.Router do
        connection_strings: args.connection_strings,
        connection_retry_ms: args.connection_retry_ms,
        remote_forwarding: args.remote_forwarding,
+       forward_unknown: args.forward_unknown,
        connection_supervisor: connection_supervisor,
        subscription_cache: subscription_cache,
        signing: args.signing,
@@ -627,13 +643,13 @@ defmodule XMAVLink.Router do
   end
 
   def handle_info({:connection_closed, worker, connection_key}, state) do
-    {:noreply, remove_worker_connection(connection_key, worker, state)}
+    {:noreply, ConnectionRegistry.remove_worker_connection(connection_key, worker, state)}
   end
 
   # Unlike UDP, TCP connections can close
   def handle_info({:tcp_closed, socket}, state) do
     reconnect_worker(state.connection_workers[socket])
-    {:noreply, remove_connection(socket, state)}
+    {:noreply, ConnectionRegistry.remove_connection(socket, state)}
   end
 
   def handle_info({:connection_message, _worker, message = {:circuits_uart, _, raw}}, state)
@@ -649,7 +665,7 @@ defmodule XMAVLink.Router do
   # Received error on serial connection
   def handle_info({:circuits_uart, port, {:error, _reason}}, state) do
     reconnect_worker(state.connection_workers[port])
-    {:noreply, remove_connection(port, state)}
+    {:noreply, ConnectionRegistry.remove_connection(port, state)}
   end
 
   # A local subscribing Elixir process or a supervised connection worker has crashed.
@@ -667,7 +683,7 @@ defmodule XMAVLink.Router do
         {:noreply,
          state
          |> struct(connection_worker_monitors: worker_monitors)
-         |> remove_connections_for_worker(worker)}
+         |> ConnectionRegistry.remove_connections_for_worker(worker)}
     end
   end
 
@@ -682,7 +698,7 @@ defmodule XMAVLink.Router do
         {:add_connection, connection_key, connection},
         state = %Router{connections: connections}
       ) do
-    connection = connection_with_signing(connection, state.signing)
+    connection = ConnectionRegistry.with_signing(connection, state.signing)
 
     {
       :noreply,
@@ -697,12 +713,12 @@ defmodule XMAVLink.Router do
         {:add_connection, connection_key, connection, worker},
         state = %Router{connections: connections}
       ) do
-    connection = connection_with_signing(connection, state.signing)
+    connection = ConnectionRegistry.with_signing(connection, state.signing)
 
     {
       :noreply,
       state
-      |> monitor_connection_worker(worker)
+      |> ConnectionRegistry.monitor_worker(worker)
       |> struct(
         connections: Map.put(connections, connection_key, connection),
         connection_workers: Map.put(state.connection_workers, connection_key, worker)
@@ -788,14 +804,6 @@ defmodule XMAVLink.Router do
   # Helper Functions #
   ####################
 
-  defp connection_with_signing(connection, signing) do
-    if Map.has_key?(connection, :signing) do
-      struct(connection, signing: signing)
-    else
-      connection
-    end
-  end
-
   # Handle user configured connections with supervised workers. If
   # successful they send us an :add_connection message with the details. The
   # local connection gets added automatically.
@@ -813,62 +821,19 @@ defmodule XMAVLink.Router do
   defp reconnect_worker(nil), do: :ok
   defp reconnect_worker(worker), do: ConnectionWorker.reconnect(worker)
 
-  defp monitor_connection_worker(state, worker) do
-    if worker in Map.values(state.connection_worker_monitors) do
-      state
-    else
-      ref = Process.monitor(worker)
-      put_in(state.connection_worker_monitors[ref], worker)
-    end
-  end
-
-  defp track_connection_worker(state, connection_key, %{worker: worker}) when is_pid(worker) do
-    state
-    |> monitor_connection_worker(worker)
-    |> struct(connection_workers: Map.put(state.connection_workers, connection_key, worker))
-  end
-
-  defp track_connection_worker(state, _connection_key, _connection), do: state
-
-  defp remove_worker_connection(connection_key, worker, state) do
-    if state.connection_workers[connection_key] == worker do
-      remove_connection(connection_key, state)
-    else
-      state
-    end
-  end
-
-  defp remove_connections_for_worker(state, worker) do
-    state.connection_workers
-    |> Enum.filter(fn {_connection_key, connection_worker} -> connection_worker == worker end)
-    |> Enum.reduce(state, fn {connection_key, _worker}, updated_state ->
-      remove_connection(connection_key, updated_state)
-    end)
-  end
-
-  defp remove_connection(connection_key, state = %Router{}) do
-    Routing.remove_connection(connection_key, state)
-  end
-
   defp update_route_info(result, state) do
     case Routing.update_route_info(result, state) do
       {:ok, source_connection_key, frame, state} ->
         {:ok, source_connection_key, frame,
-         track_connection_worker(
+         ConnectionRegistry.track_worker(
            state,
            source_connection_key,
            state.connections[source_connection_key]
          )}
 
       {:error, reason, state} ->
-        {:error, reason, track_workers_for_connections(state)}
+        {:error, reason, ConnectionRegistry.track_workers(state)}
     end
-  end
-
-  defp track_workers_for_connections(state) do
-    Enum.reduce(state.connections, state, fn {connection_key, connection}, updated_state ->
-      track_connection_worker(updated_state, connection_key, connection)
-    end)
   end
 
   defp route(result) do
@@ -882,6 +847,27 @@ defmodule XMAVLink.Router do
   defp route_with_delivery(
          {:ok, source_connection_key, frame = %Frame{message_id: @setup_signing_message_id},
           state = %Router{connections: connections}}
+       )
+       when source_connection_key != :local do
+    recipients = [:local]
+
+    {
+      forward_and_update(:local, connections.local, frame, state),
+      Routing.delivery(source_connection_key, recipients, frame, state)
+    }
+  end
+
+  defp route_with_delivery(
+         {:ok, source_connection_key, frame = %Frame{message: nil},
+          state = %Router{forward_unknown: :drop}}
+       )
+       when source_connection_key != :local do
+    {state, Routing.delivery(source_connection_key, [], frame, state)}
+  end
+
+  defp route_with_delivery(
+         {:ok, source_connection_key, frame = %Frame{message: nil},
+          state = %Router{connections: connections, forward_unknown: :local_only}}
        )
        when source_connection_key != :local do
     recipients = [:local]

--- a/lib/mavlink/router/config.ex
+++ b/lib/mavlink/router/config.ex
@@ -17,6 +17,7 @@ defmodule XMAVLink.Router.Config do
       connection_strings: Application.get_env(:xmavlink, :connections),
       connection_retry_ms: Application.get_env(:xmavlink, :connection_retry_ms, 1_000),
       remote_forwarding: Application.get_env(:xmavlink, :remote_forwarding, true),
+      forward_unknown: Application.get_env(:xmavlink, :forward_unknown, :broadcast),
       signing: Application.get_env(:xmavlink, :signing)
     })
   end
@@ -27,6 +28,7 @@ defmodule XMAVLink.Router.Config do
     connection_strings = Map.get(args, :connection_strings, Map.get(args, :connections, [])) || []
     connection_retry_ms = Map.get(args, :connection_retry_ms, 1_000)
     remote_forwarding = Map.get(args, :remote_forwarding, true)
+    forward_unknown = Map.get(args, :forward_unknown, :broadcast)
     signing = normalize_signing!(Map.get(args, :signing))
 
     if not (is_integer(connection_retry_ms) and connection_retry_ms >= 0) do
@@ -37,10 +39,15 @@ defmodule XMAVLink.Router.Config do
       raise ArgumentError, "remote_forwarding must be a boolean"
     end
 
+    if forward_unknown not in [:broadcast, :local_only, :drop] do
+      raise ArgumentError, "forward_unknown must be one of :broadcast, :local_only, or :drop"
+    end
+
     args
     |> Map.put(:connection_strings, connection_strings)
     |> Map.put(:connection_retry_ms, connection_retry_ms)
     |> Map.put(:remote_forwarding, remote_forwarding)
+    |> Map.put(:forward_unknown, forward_unknown)
     |> Map.put(:signing, signing)
   end
 

--- a/lib/mavlink/router/connection_registry.ex
+++ b/lib/mavlink/router/connection_registry.ex
@@ -1,0 +1,57 @@
+defmodule XMAVLink.Router.ConnectionRegistry do
+  @moduledoc false
+
+  alias XMAVLink.Router
+  alias XMAVLink.Router.Routing
+
+  def with_signing(connection, signing) do
+    if Map.has_key?(connection, :signing) do
+      struct(connection, signing: signing)
+    else
+      connection
+    end
+  end
+
+  def monitor_worker(state, worker) do
+    if worker in Map.values(state.connection_worker_monitors) do
+      state
+    else
+      ref = Process.monitor(worker)
+      put_in(state.connection_worker_monitors[ref], worker)
+    end
+  end
+
+  def track_worker(state, connection_key, %{worker: worker}) when is_pid(worker) do
+    state
+    |> monitor_worker(worker)
+    |> struct(connection_workers: Map.put(state.connection_workers, connection_key, worker))
+  end
+
+  def track_worker(state, _connection_key, _connection), do: state
+
+  def track_workers(state) do
+    Enum.reduce(state.connections, state, fn {connection_key, connection}, updated_state ->
+      track_worker(updated_state, connection_key, connection)
+    end)
+  end
+
+  def remove_worker_connection(connection_key, worker, state) do
+    if state.connection_workers[connection_key] == worker do
+      remove_connection(connection_key, state)
+    else
+      state
+    end
+  end
+
+  def remove_connections_for_worker(state, worker) do
+    state.connection_workers
+    |> Enum.filter(fn {_connection_key, connection_worker} -> connection_worker == worker end)
+    |> Enum.reduce(state, fn {connection_key, _worker}, updated_state ->
+      remove_connection(connection_key, updated_state)
+    end)
+  end
+
+  def remove_connection(connection_key, state = %Router{}) do
+    Routing.remove_connection(connection_key, state)
+  end
+end

--- a/lib/mavlink/serial_connection.ex
+++ b/lib/mavlink/serial_connection.ex
@@ -6,8 +6,8 @@ defmodule XMAVLink.SerialConnection do
   require Logger
 
   alias XMAVLink.Connection.Inbound
+  alias XMAVLink.Connection.Outbound
   alias XMAVLink.ConnectionWorker
-  alias XMAVLink.Frame
   alias Circuits.UART
 
   defstruct port: nil,
@@ -84,15 +84,8 @@ defmodule XMAVLink.SerialConnection do
 
   def forward(
         %XMAVLink.SerialConnection{uart: uart},
-        %Frame{version: 1, mavlink_1_raw: packet}
+        frame
       ) do
-    UART.write(uart, packet)
-  end
-
-  def forward(
-        %XMAVLink.SerialConnection{uart: uart},
-        %Frame{version: 2, mavlink_2_raw: packet}
-      ) do
-    UART.write(uart, packet)
+    UART.write(uart, Outbound.packet!(frame))
   end
 end

--- a/lib/mavlink/signing.ex
+++ b/lib/mavlink/signing.ex
@@ -22,6 +22,7 @@ defmodule XMAVLink.Signing do
             timestamp_load: nil,
             timestamp_save: nil,
             accept_unsigned: false,
+            accept_mavlink1: true,
             stream_timestamps: %{}
 
   @type timestamp :: 0..281_474_976_710_655
@@ -38,11 +39,13 @@ defmodule XMAVLink.Signing do
           timestamp_load: timestamp_load | nil,
           timestamp_save: timestamp_save | nil,
           accept_unsigned: boolean,
+          accept_mavlink1: boolean,
           stream_timestamps: %{stream_key() => timestamp}
         }
 
   @type new_error ::
           :invalid_accept_unsigned
+          | :invalid_accept_mavlink1
           | :invalid_options
           | :invalid_link_id
           | :invalid_secret_key
@@ -63,6 +66,7 @@ defmodule XMAVLink.Signing do
           | :timestamp_save_failed
           | :unsigned_frame
           | :unsigned_frame_rejected
+          | :mavlink_1_rejected
 
   @type sign_error ::
           :already_signed
@@ -72,6 +76,7 @@ defmodule XMAVLink.Signing do
           | :invalid_mavlink_2_frame
           | :invalid_secret_key
           | :invalid_timestamp
+          | :mavlink_1_rejected
           | :mavlink_1_not_signable
           | :missing_crc_extra
           | :missing_mavlink_2_raw
@@ -100,7 +105,15 @@ defmodule XMAVLink.Signing do
          {:ok, timestamp} <-
            initial_timestamp(Keyword.get_lazy(opts, :timestamp, &now_timestamp/0), timestamp_load),
          {:ok, accept_unsigned} <-
-           validate_accept_unsigned(Keyword.get(opts, :accept_unsigned, false)) do
+           validate_boolean_option(
+             Keyword.get(opts, :accept_unsigned, false),
+             :invalid_accept_unsigned
+           ),
+         {:ok, accept_mavlink1} <-
+           validate_boolean_option(
+             Keyword.get(opts, :accept_mavlink1, true),
+             :invalid_accept_mavlink1
+           ) do
       {:ok,
        %Signing{
          secret_key: secret_key,
@@ -108,7 +121,8 @@ defmodule XMAVLink.Signing do
          timestamp: timestamp,
          timestamp_load: timestamp_load,
          timestamp_save: timestamp_save,
-         accept_unsigned: accept_unsigned
+         accept_unsigned: accept_unsigned,
+         accept_mavlink1: accept_mavlink1
        }}
     end
   end
@@ -125,8 +139,11 @@ defmodule XMAVLink.Signing do
 
   def validate_inbound(frame = %Frame{}, signing = %Signing{}) do
     cond do
-      frame.version == 1 ->
+      frame.version == 1 and signing.accept_mavlink1 ->
         {:ok, frame, signing}
+
+      frame.version == 1 ->
+        {:error, :mavlink_1_rejected, signing}
 
       Frame.signed?(frame) ->
         validate_signed_inbound(frame, signing)
@@ -143,8 +160,13 @@ defmodule XMAVLink.Signing do
           {:ok, Frame.t(), t | nil} | {:error, sign_error, t | nil}
   def sign_outbound(frame = %Frame{}, nil), do: {:ok, frame, nil}
 
-  def sign_outbound(frame = %Frame{version: 1}, signing = %Signing{}),
-    do: {:ok, frame, signing}
+  def sign_outbound(frame = %Frame{version: 1}, signing = %Signing{}) do
+    if signing.accept_mavlink1 do
+      {:ok, frame, signing}
+    else
+      {:error, :mavlink_1_rejected, signing}
+    end
+  end
 
   def sign_outbound(
         frame = %Frame{version: 2, signature: %{timestamp: timestamp}},
@@ -363,10 +385,8 @@ defmodule XMAVLink.Signing do
 
   defp validate_timestamp(_timestamp), do: {:error, :invalid_timestamp}
 
-  defp validate_accept_unsigned(accept_unsigned) when is_boolean(accept_unsigned),
-    do: {:ok, accept_unsigned}
-
-  defp validate_accept_unsigned(_accept_unsigned), do: {:error, :invalid_accept_unsigned}
+  defp validate_boolean_option(value, _error) when is_boolean(value), do: {:ok, value}
+  defp validate_boolean_option(_value, error), do: {:error, error}
 
   defp validate_timestamp_load(nil), do: {:ok, nil}
 

--- a/lib/mavlink/tcp_out_connection.ex
+++ b/lib/mavlink/tcp_out_connection.ex
@@ -4,14 +4,16 @@ defmodule XMAVLink.TCPOutConnection do
   @behaviour XMAVLink.Transport
 
   require Logger
+  import XMAVLink.Utils, only: [format_address: 1]
+
   alias XMAVLink.Connection.Inbound
+  alias XMAVLink.Connection.Outbound
   alias XMAVLink.ConnectionWorker
-  alias XMAVLink.Frame
 
   defstruct socket: nil, address: nil, port: nil, buffer: <<>>, worker: nil, signing: nil
 
   @type t :: %XMAVLink.TCPOutConnection{
-          socket: pid,
+          socket: port,
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
           buffer: binary,
@@ -35,9 +37,9 @@ defmodule XMAVLink.TCPOutConnection do
   end
 
   def open(["tcpout", address, port], controlling_process) do
-    case :gen_tcp.connect(address, port, [:binary, active: true]) do
+    case :gen_tcp.connect(address, port, [:binary, active: true] ++ family_options(address)) do
       {:ok, socket} ->
-        :ok = Logger.debug("Opened tcpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
+        :ok = Logger.debug("Opened tcpout:#{format_address(address)}:#{port}")
 
         :ok = :gen_tcp.controlling_process(socket, controlling_process)
 
@@ -55,6 +57,9 @@ defmodule XMAVLink.TCPOutConnection do
     end
   end
 
+  defp family_options(address) when is_tuple(address) and tuple_size(address) == 8, do: [:inet6]
+  defp family_options(_address), do: []
+
   def close(%XMAVLink.TCPOutConnection{socket: socket}) do
     :gen_tcp.close(socket)
   end
@@ -69,15 +74,8 @@ defmodule XMAVLink.TCPOutConnection do
 
   def forward(
         %XMAVLink.TCPOutConnection{socket: socket},
-        %Frame{version: 1, mavlink_1_raw: packet}
+        frame
       ) do
-    :gen_tcp.send(socket, packet)
-  end
-
-  def forward(
-        %XMAVLink.TCPOutConnection{socket: socket},
-        %Frame{version: 2, mavlink_2_raw: packet}
-      ) do
-    :gen_tcp.send(socket, packet)
+    :gen_tcp.send(socket, Outbound.packet!(frame))
   end
 end

--- a/lib/mavlink/types.ex
+++ b/lib/mavlink/types.ex
@@ -4,11 +4,7 @@ defmodule XMAVLink.Types do
   """
 
   @typedoc "Internal connection state structs owned by `XMAVLink.Router`"
-  @type connection ::
-          XMAVLink.SerialConnection
-          | XMAVLink.TCPOutConnection
-          | XMAVLink.UDPInConnection
-          | XMAVLink.UDPOutConnection
+  @type connection :: struct()
 
   @typedoc "A system/component id tuple"
   @type mavlink_address :: {0..255, 0..255}
@@ -19,8 +15,8 @@ defmodule XMAVLink.Types do
   @typedoc "MAVLink message sequence number"
   @type sequence_number :: 0..255
 
-  @typedoc "A 4-tuple network address"
-  @type net_address :: {0..255, 0..255, 0..255, 0..255}
+  @typedoc "An IPv4 or IPv6 network address tuple"
+  @type net_address :: :inet.ip_address()
 
   @typedoc "A non-reserved network port"
   @type net_port :: 1024..65535
@@ -69,8 +65,8 @@ defmodule XMAVLink.Types do
   @typedoc "64-bit unsigned integer"
   @type uint64_t :: 0..18_446_744_073_709_551_615
 
-  @typedoc "64-bit signed float"
-  @type double :: Float64
+  @typedoc "64-bit MAVLink double represented as an Elixir float"
+  @type double :: float()
 
   @typedoc "1 -> not an array 2..255 -> an array"
   @type field_ordinality :: 1..255

--- a/lib/mavlink/udp_in_connection.ex
+++ b/lib/mavlink/udp_in_connection.ex
@@ -4,10 +4,11 @@ defmodule XMAVLink.UDPInConnection do
   @behaviour XMAVLink.Transport
 
   require Logger
+  import XMAVLink.Utils, only: [format_address: 1]
 
   alias XMAVLink.Connection.Inbound
+  alias XMAVLink.Connection.Outbound
   alias XMAVLink.ConnectionWorker
-  alias XMAVLink.Frame
 
   defstruct address: nil,
             port: nil,
@@ -18,7 +19,7 @@ defmodule XMAVLink.UDPInConnection do
   @type t :: %XMAVLink.UDPInConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
-          socket: pid,
+          socket: port,
           worker: pid | nil,
           signing: XMAVLink.Signing.t() | nil
         }
@@ -41,7 +42,7 @@ defmodule XMAVLink.UDPInConnection do
       connection_key,
       dialect,
       "UDPInConnection.handle_info",
-      "from #{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port}"
+      "from #{format_address(source_addr)}:#{source_port}"
     )
   end
 
@@ -71,9 +72,9 @@ defmodule XMAVLink.UDPInConnection do
     # Do not add to connections, we don't want to forward to ourselves
     # Router.update_route_info() will add connections for other parties that
     # connect to this socket
-    case :gen_udp.open(port, [:binary, ip: address, active: true]) do
+    case :gen_udp.open(port, [:binary, ip: address, active: true] ++ family_options(address)) do
       {:ok, socket} ->
-        :ok = Logger.info("Opened udpin:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
+        :ok = Logger.info("Opened udpin:#{format_address(address)}:#{port}")
         :ok = :gen_udp.controlling_process(socket, controlling_process)
 
         {:ok, nil,
@@ -89,6 +90,9 @@ defmodule XMAVLink.UDPInConnection do
         {:error, other}
     end
   end
+
+  defp family_options(address) when is_tuple(address) and tuple_size(address) == 8, do: [:inet6]
+  defp family_options(_address), do: []
 
   def close(%XMAVLink.UDPInConnection{socket: socket}) do
     :gen_udp.close(socket)
@@ -110,19 +114,8 @@ defmodule XMAVLink.UDPInConnection do
           address: address,
           port: port
         },
-        %Frame{version: 1, mavlink_1_raw: packet}
+        frame
       ) do
-    :gen_udp.send(socket, address, port, packet)
-  end
-
-  def forward(
-        %XMAVLink.UDPInConnection{
-          socket: socket,
-          address: address,
-          port: port
-        },
-        %Frame{version: 2, mavlink_2_raw: packet}
-      ) do
-    :gen_udp.send(socket, address, port, packet)
+    :gen_udp.send(socket, address, port, Outbound.packet!(frame))
   end
 end

--- a/lib/mavlink/udp_out_connection.ex
+++ b/lib/mavlink/udp_out_connection.ex
@@ -4,9 +4,11 @@ defmodule XMAVLink.UDPOutConnection do
   @behaviour XMAVLink.Transport
 
   require Logger
+  import XMAVLink.Utils, only: [format_address: 1]
+
   alias XMAVLink.Connection.Inbound
+  alias XMAVLink.Connection.Outbound
   alias XMAVLink.ConnectionWorker
-  alias XMAVLink.Frame
 
   defstruct address: nil,
             port: nil,
@@ -17,7 +19,7 @@ defmodule XMAVLink.UDPOutConnection do
   @type t :: %XMAVLink.UDPOutConnection{
           address: XMAVLink.Types.net_address(),
           port: XMAVLink.Types.net_port(),
-          socket: pid,
+          socket: port,
           worker: pid | nil,
           signing: XMAVLink.Signing.t() | nil
         }
@@ -38,14 +40,14 @@ defmodule XMAVLink.UDPOutConnection do
       socket,
       dialect,
       "UDPOutConnection.handle_info",
-      "from #{Enum.join(Tuple.to_list(source_addr), ".")}:#{source_port}"
+      "from #{format_address(source_addr)}:#{source_port}"
     )
   end
 
   def open(["udpout", address, port], controlling_process) do
-    case :gen_udp.open(0, [:binary, active: true]) do
+    case :gen_udp.open(0, [:binary, active: true] ++ family_options(address)) do
       {:ok, socket} ->
-        :ok = Logger.info("Opened udpout:#{Enum.join(Tuple.to_list(address), ".")}:#{port}")
+        :ok = Logger.info("Opened udpout:#{format_address(address)}:#{port}")
 
         :ok = :gen_udp.controlling_process(socket, controlling_process)
 
@@ -62,6 +64,9 @@ defmodule XMAVLink.UDPOutConnection do
         {:error, other}
     end
   end
+
+  defp family_options(address) when is_tuple(address) and tuple_size(address) == 8, do: [:inet6]
+  defp family_options(_address), do: []
 
   def close(%XMAVLink.UDPOutConnection{socket: socket}) do
     :gen_udp.close(socket)
@@ -83,19 +88,8 @@ defmodule XMAVLink.UDPOutConnection do
           address: address,
           port: port
         },
-        %Frame{version: 1, mavlink_1_raw: packet}
+        frame
       ) do
-    :gen_udp.send(socket, address, port, packet)
-  end
-
-  def forward(
-        %XMAVLink.UDPOutConnection{
-          socket: socket,
-          address: address,
-          port: port
-        },
-        %Frame{version: 2, mavlink_2_raw: packet}
-      ) do
-    :gen_udp.send(socket, address, port, packet)
+    :gen_udp.send(socket, address, port, Outbound.packet!(frame))
   end
 end

--- a/lib/mavlink/utils.ex
+++ b/lib/mavlink/utils.ex
@@ -133,9 +133,23 @@ defmodule XMAVLink.Utils do
       {:ok, ip_tuple} ->
         {:ok, ip_tuple}
 
-      {:error, reason} ->
-        {:error, reason}
+      {:error, ipv4_reason} ->
+        case :inet.getaddr(charlist_address, :inet6) do
+          {:ok, ip_tuple} -> {:ok, ip_tuple}
+          {:error, _ipv6_reason} -> {:error, ipv4_reason}
+        end
     end
+  end
+
+  def format_address(address) when is_tuple(address) and tuple_size(address) == 4 do
+    address |> Tuple.to_list() |> Enum.join(".")
+  end
+
+  def format_address(address) when is_tuple(address) and tuple_size(address) == 8 do
+    address
+    |> Tuple.to_list()
+    |> Enum.map(&Integer.to_string(&1, 16))
+    |> Enum.join(":")
   end
 
   @doc "Parse an ip address string into a tuple"

--- a/lib/mavlink_util/arm.ex
+++ b/lib/mavlink_util/arm.ex
@@ -13,7 +13,7 @@ defmodule XMAVLink.Util.Arm do
 
   require Logger
   alias XMAVLink.Util.CacheManager
-  alias XMAVLink.Util.Context
+  alias XMAVLink.Util.Command
   import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def arm(opts \\ []) when is_list(opts) do
@@ -23,8 +23,8 @@ defmodule XMAVLink.Util.Arm do
   end
 
   def arm(system_id, component_id, mavlink_version, opts \\ []) do
-    opts = command_opts(opts, @arm_retry_interval, @arm_retries)
-    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+    opts = Command.opts(opts, @arm_retry_interval, @arm_retries)
+    heartbeat_module = Command.message_module(opts.dialect, :Heartbeat)
 
     with {:ok, _, %{__struct__: ^heartbeat_module, system_status: system_status}}
          when system_status in [
@@ -49,7 +49,7 @@ defmodule XMAVLink.Util.Arm do
     else
       {:ok, _, %{__struct__: ^heartbeat_module, system_status: invalid_system_status}} ->
         Logger.warning(
-          "Cannot arm vehicle #{system_id}.#{component_id}: #{describe(opts.dialect, invalid_system_status)}"
+          "Cannot arm vehicle #{system_id}.#{component_id}: #{Command.describe(opts.dialect, invalid_system_status)}"
         )
 
         {:error, :cannot_arm_invalid_vehicle_status}
@@ -70,8 +70,8 @@ defmodule XMAVLink.Util.Arm do
   end
 
   def disarm(system_id, component_id, mavlink_version, opts \\ []) do
-    opts = command_opts(opts, @arm_retry_interval, @arm_retries)
-    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+    opts = Command.opts(opts, @arm_retry_interval, @arm_retries)
+    heartbeat_module = Command.message_module(opts.dialect, :Heartbeat)
 
     with :ok <-
            XMAVLink.Router.subscribe(opts.router,
@@ -89,7 +89,7 @@ defmodule XMAVLink.Util.Arm do
   defp do_arm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
 
   defp do_arm(system_id, component_id, mavlink_version, opts, attempts) do
-    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+    heartbeat_module = Command.message_module(opts.dialect, :Heartbeat)
 
     with :ok <-
            XMAVLink.Router.pack_and_send(
@@ -103,11 +103,17 @@ defmodule XMAVLink.Util.Arm do
             Logger.info("Armed vehicle #{system_id}.#{component_id}")
             :ok
           else
-            do_arm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+            do_arm(
+              system_id,
+              component_id,
+              mavlink_version,
+              opts,
+              Command.next_attempts(attempts)
+            )
           end
       after
         opts.retry_interval_ms ->
-          do_arm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+          do_arm(system_id, component_id, mavlink_version, opts, Command.next_attempts(attempts))
       end
     end
   end
@@ -115,7 +121,7 @@ defmodule XMAVLink.Util.Arm do
   defp do_disarm(_system_id, _component_id, _mavlink_version, _opts, 0), do: {:error, :timeout}
 
   defp do_disarm(system_id, component_id, mavlink_version, opts, attempts) do
-    heartbeat_module = message_module(opts.dialect, :Heartbeat)
+    heartbeat_module = Command.message_module(opts.dialect, :Heartbeat)
 
     with :ok <-
            XMAVLink.Router.pack_and_send(
@@ -129,37 +135,29 @@ defmodule XMAVLink.Util.Arm do
             Logger.info("Disarmed vehicle #{system_id}.#{component_id}")
             :ok
           else
-            do_disarm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+            do_disarm(
+              system_id,
+              component_id,
+              mavlink_version,
+              opts,
+              Command.next_attempts(attempts)
+            )
           end
       after
         opts.retry_interval_ms ->
-          do_disarm(system_id, component_id, mavlink_version, opts, next_attempts(attempts))
+          do_disarm(
+            system_id,
+            component_id,
+            mavlink_version,
+            opts,
+            Command.next_attempts(attempts)
+          )
       end
     end
   end
 
-  defp command_opts(opts, retry_interval_ms, retries) do
-    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
-    retries = Keyword.get(opts, :retries, retries)
-
-    %{
-      context: context,
-      router: context.router,
-      dialect: context.dialect,
-      table_prefix: context.table_prefix,
-      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, retry_interval_ms),
-      attempts: attempts(retries)
-    }
-  end
-
-  defp attempts(:infinity), do: :infinity
-  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
-
-  defp next_attempts(:infinity), do: :infinity
-  defp next_attempts(attempts), do: attempts - 1
-
   defp arm_command(system_id, component_id, arm, dialect) do
-    struct(message_module(dialect, :CommandLong), %{
+    struct(Command.message_module(dialect, :CommandLong), %{
       command: :mav_cmd_component_arm_disarm,
       confirmation: 1,
       param1: arm,
@@ -172,15 +170,5 @@ defmodule XMAVLink.Util.Arm do
       target_component: component_id,
       target_system: system_id
     })
-  end
-
-  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
-
-  defp describe(dialect, value) do
-    if function_exported?(dialect, :describe, 1) do
-      apply(dialect, :describe, [value])
-    else
-      inspect(value)
-    end
   end
 end

--- a/lib/mavlink_util/command.ex
+++ b/lib/mavlink_util/command.ex
@@ -1,0 +1,46 @@
+defmodule XMAVLink.Util.Command do
+  @moduledoc false
+
+  alias XMAVLink.Util.CacheManager
+  alias XMAVLink.Util.Context
+
+  def opts(source_opts, retry_interval_ms, retries) do
+    context =
+      source_opts |> Keyword.put(:router, CacheManager.router(source_opts)) |> Context.new()
+
+    retries = Keyword.get(source_opts, :retries, retries)
+
+    %{
+      context: context,
+      router: context.router,
+      dialect: context.dialect,
+      table_prefix: context.table_prefix,
+      retry_interval_ms: Keyword.get(source_opts, :retry_interval_ms, retry_interval_ms),
+      attempts: attempts(retries),
+      source_opts: source_opts
+    }
+  end
+
+  def attempts(:infinity), do: :infinity
+  def attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
+
+  def next_attempts(:infinity), do: :infinity
+  def next_attempts(attempts), do: attempts - 1
+
+  def require_table(table) do
+    case :ets.info(table) do
+      :undefined -> {:error, :not_started}
+      _ -> :ok
+    end
+  end
+
+  def message_module(dialect, name), do: Module.concat([dialect, Message, name])
+
+  def describe(dialect, value) do
+    if function_exported?(dialect, :describe, 1) do
+      apply(dialect, :describe, [value])
+    else
+      inspect(value)
+    end
+  end
+end

--- a/lib/mavlink_util/param_request.ex
+++ b/lib/mavlink_util/param_request.ex
@@ -12,8 +12,7 @@ defmodule XMAVLink.Util.ParamRequest do
   @param_retries 10
 
   require Logger
-  alias XMAVLink.Util.CacheManager
-  alias XMAVLink.Util.Context
+  alias XMAVLink.Util.Command
   import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def param_request_list(opts \\ []) when is_list(opts) do
@@ -26,13 +25,13 @@ defmodule XMAVLink.Util.ParamRequest do
   def param_request_list(system_id, component_id, mavlink_version, _opts_or_last \\ [])
 
   def param_request_list(system_id, component_id, mavlink_version, opts) when is_list(opts) do
-    opts = command_opts(opts)
+    opts = Command.opts(opts, @param_retry_interval, @param_retries)
     do_param_request_list(system_id, component_id, mavlink_version, 0, opts)
   end
 
   def param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded)
       when is_integer(last_param_count_loaded) do
-    opts = command_opts([])
+    opts = Command.opts([], @param_retry_interval, @param_retries)
     do_param_request_list(system_id, component_id, mavlink_version, last_param_count_loaded, opts)
   end
 
@@ -45,7 +44,7 @@ defmodule XMAVLink.Util.ParamRequest do
        ) do
     systems = opts.context.tables.systems
 
-    with :ok <- require_table(systems),
+    with :ok <- Command.require_table(systems),
          [{_, %{param_count: param_count, param_count_loaded: param_count_loaded}}] <-
            :ets.lookup(systems, {system_id, component_id}),
          retry <- param_count_loaded == last_param_count_loaded,
@@ -70,11 +69,12 @@ defmodule XMAVLink.Util.ParamRequest do
                  maybe_send_param_request(retry, system_id, component_id, mavlink_version, opts) do
             opts =
               if retry do
-                %{opts | attempts: next_attempts(opts.attempts)}
+                %{opts | attempts: Command.next_attempts(opts.attempts)}
               else
                 %{
                   opts
-                  | attempts: attempts(Keyword.get(opts.source_opts, :retries, @param_retries))
+                  | attempts:
+                      Command.attempts(Keyword.get(opts.source_opts, :retries, @param_retries))
                 }
               end
 
@@ -101,41 +101,11 @@ defmodule XMAVLink.Util.ParamRequest do
   defp maybe_send_param_request(true, system_id, component_id, mavlink_version, opts) do
     XMAVLink.Router.pack_and_send(
       opts.router,
-      struct(message_module(opts.dialect, :ParamRequestList), %{
+      struct(Command.message_module(opts.dialect, :ParamRequestList), %{
         target_system: system_id,
         target_component: component_id
       }),
       mavlink_version
     )
   end
-
-  defp command_opts(opts) do
-    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
-    retries = Keyword.get(opts, :retries, @param_retries)
-
-    %{
-      context: context,
-      router: context.router,
-      dialect: context.dialect,
-      table_prefix: context.table_prefix,
-      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
-      attempts: attempts(retries),
-      source_opts: opts
-    }
-  end
-
-  defp attempts(:infinity), do: :infinity
-  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
-
-  defp next_attempts(:infinity), do: :infinity
-  defp next_attempts(attempts), do: attempts - 1
-
-  defp require_table(table) do
-    case :ets.info(table) do
-      :undefined -> {:error, :not_started}
-      _ -> :ok
-    end
-  end
-
-  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 end

--- a/lib/mavlink_util/param_set.ex
+++ b/lib/mavlink_util/param_set.ex
@@ -12,8 +12,7 @@ defmodule XMAVLink.Util.ParamSet do
   @param_retries 5
 
   require Logger
-  alias XMAVLink.Util.CacheManager
-  alias XMAVLink.Util.Context
+  alias XMAVLink.Util.Command
   import XMAVLink.Util.FocusManager, only: [focus: 1]
 
   def param_set(param, new_value, opts \\ []) when is_list(opts) do
@@ -24,11 +23,11 @@ defmodule XMAVLink.Util.ParamSet do
 
   def param_set(system_id, component_id, mavlink_version, param, new_value, opts \\ []) do
     param = normalize_param_id(param)
-    opts = command_opts(opts)
+    opts = Command.opts(opts, @param_retry_interval, @param_retries)
     params = opts.context.tables.params
-    param_value_module = message_module(opts.dialect, :ParamValue)
+    param_value_module = Command.message_module(opts.dialect, :ParamValue)
 
-    with :ok <- require_table(params),
+    with :ok <- Command.require_table(params),
          [
            {{^system_id, ^component_id, ^param},
             {_time, %{__struct__: ^param_value_module, param_type: param_type}}}
@@ -62,12 +61,12 @@ defmodule XMAVLink.Util.ParamSet do
        do: {:error, :timeout}
 
   defp do_param_set(system_id, component_id, mavlink_version, param, new_value, param_type, opts) do
-    param_value_module = message_module(opts.dialect, :ParamValue)
+    param_value_module = Command.message_module(opts.dialect, :ParamValue)
 
     with :ok <-
            XMAVLink.Router.pack_and_send(
              opts.router,
-             struct(message_module(opts.dialect, :ParamSet), %{
+             struct(Command.message_module(opts.dialect, :ParamSet), %{
                target_system: system_id,
                target_component: component_id,
                param_id: param,
@@ -92,7 +91,7 @@ defmodule XMAVLink.Util.ParamSet do
             param,
             new_value,
             param_type,
-            %{opts | attempts: next_attempts(opts.attempts)}
+            %{opts | attempts: Command.next_attempts(opts.attempts)}
           )
       end
     end
@@ -102,33 +101,4 @@ defmodule XMAVLink.Util.ParamSet do
     do: param |> Atom.to_string() |> String.upcase()
 
   defp normalize_param_id(param) when is_binary(param), do: String.upcase(param)
-
-  defp command_opts(opts) do
-    context = opts |> Keyword.put(:router, CacheManager.router(opts)) |> Context.new()
-    retries = Keyword.get(opts, :retries, @param_retries)
-
-    %{
-      context: context,
-      router: context.router,
-      dialect: context.dialect,
-      table_prefix: context.table_prefix,
-      retry_interval_ms: Keyword.get(opts, :retry_interval_ms, @param_retry_interval),
-      attempts: attempts(retries)
-    }
-  end
-
-  defp attempts(:infinity), do: :infinity
-  defp attempts(retries) when is_integer(retries) and retries >= 0, do: retries + 1
-
-  defp next_attempts(:infinity), do: :infinity
-  defp next_attempts(attempts), do: attempts - 1
-
-  defp require_table(table) do
-    case :ets.info(table) do
-      :undefined -> {:error, :not_started}
-      _ -> :ok
-    end
-  end
-
-  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
 end

--- a/lib/mavlink_util/sitl.ex
+++ b/lib/mavlink_util/sitl.ex
@@ -13,6 +13,7 @@ defmodule XMAVLink.Util.SITL do
   import XMAVLink.Utils, only: [resolve_address: 1]
 
   alias XMAVLink.Util.CacheManager
+  alias XMAVLink.Util.Command
   alias XMAVLink.Util.Context
   import XMAVLink.Util.FocusManager, only: [focus: 1]
 
@@ -190,5 +191,5 @@ defmodule XMAVLink.Util.SITL do
   defp resolve_destination_address(address) when is_binary(address), do: resolve_address(address)
   defp resolve_destination_address(_address), do: {:error, :invalid_destination_address}
 
-  defp message_module(dialect, name), do: Module.concat([dialect, Message, name])
+  defp message_module(dialect, name), do: Command.message_module(dialect, name)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,14 @@ defmodule XMAVLink.Mixfile do
       aliases: aliases(),
       deps: deps(),
       dialyzer: [plt_add_apps: [:mix, :xmerl]],
+      test_coverage: [
+        summary: [threshold: 70],
+        ignore_modules: [
+          Common,
+          ~r/^Common\./,
+          ~r/^XMAVLink\.Message\.Common\./
+        ]
+      ],
       source_url: "https://github.com/fancydrones/xmavlink",
       consolidate_protocols: Mix.env() != :test
     ]
@@ -50,6 +58,8 @@ defmodule XMAVLink.Mixfile do
         # Keep router behavior by default. Set false for endpoint/GCS use cases
         # that should receive remote traffic without bridging remote links.
         remote_forwarding: true,
+        # Keep forward-compatible unknown-message routing by default.
+        forward_unknown: :broadcast,
         connections: []
       ],
       mod: {XMAVLink.Application, []},
@@ -86,7 +96,8 @@ defmodule XMAVLink.Mixfile do
         "MIGRATING_0_14.md",
         "LICENSE",
         "SECURITY.md",
-        "MAVLINK_SPEC_ALIGNMENT.md"
+        "MAVLINK_SPEC_ALIGNMENT.md",
+        "MAVLINK2_SIGNING.md"
       ],
       exclude_patterns: [".DS_Store"],
       licenses: ["MIT"],
@@ -103,13 +114,15 @@ defmodule XMAVLink.Mixfile do
         "MIGRATING_0_14.md",
         "CHANGELOG.md",
         "SECURITY.md",
-        "MAVLINK_SPEC_ALIGNMENT.md"
+        "MAVLINK_SPEC_ALIGNMENT.md",
+        "MAVLINK2_SIGNING.md"
       ],
       groups_for_extras: [
         Guides: [
           "MIGRATING_0_14.md",
           "SECURITY.md",
-          "MAVLINK_SPEC_ALIGNMENT.md"
+          "MAVLINK_SPEC_ALIGNMENT.md",
+          "MAVLINK2_SIGNING.md"
         ],
         Release: [
           "CHANGELOG.md"

--- a/test/input/test_mavlink_include.xml
+++ b/test/input/test_mavlink_include.xml
@@ -10,6 +10,12 @@
         <description>Generic autopilot, full support for everything</description>
       </entry>
     </enum>
+    <enum name="MAV_TYPE">
+      <description>MAVLINK component type reported in HEARTBEAT message.</description>
+      <entry value="0" name="MAV_TYPE_GENERIC">
+        <description>Generic micro air vehicle.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/test/mavlink_connection_inbound_test.exs
+++ b/test/mavlink_connection_inbound_test.exs
@@ -1,0 +1,60 @@
+defmodule XMAVLink.Test.ConnectionInbound do
+  use ExUnit.Case, async: true
+
+  alias XMAVLink.Connection.Inbound
+  alias XMAVLink.Frame
+  alias XMAVLink.SerialConnection
+
+  test "stream preserves oversized coalesced frame tails after a valid frame" do
+    first_frame = unsigned_heartbeat_frame(1)
+    second_frame = unsigned_heartbeat_frame(2)
+    tail = :binary.copy(second_frame.mavlink_2_raw, 300)
+    raw = first_frame.mavlink_2_raw <> tail
+    connection = %SerialConnection{port: "ttyS0", buffer: <<>>}
+
+    assert {:ok, "ttyS0", updated_connection, %Frame{message: %Common.Message.Heartbeat{}}} =
+             Inbound.stream(raw, connection, <<>>, "ttyS0", Common, "test")
+
+    assert updated_connection.buffer == tail
+    assert_receive {:circuits_uart, "ttyS0", <<>>}, 20
+
+    assert {:ok, "ttyS0", next_connection, %Frame{sequence_number: 2}} =
+             Inbound.stream(
+               <<>>,
+               updated_connection,
+               updated_connection.buffer,
+               "ttyS0",
+               Common,
+               "test"
+             )
+
+    assert byte_size(next_connection.buffer) ==
+             byte_size(tail) - byte_size(second_frame.mavlink_2_raw)
+  end
+
+  defp unsigned_heartbeat_frame(sequence_number) do
+    {:ok, message_id, {:ok, crc_extra, _expected_length, _target}, payload} =
+      XMAVLink.Message.pack(sample_heartbeat(), 2)
+
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: sequence_number,
+      source_system: 1,
+      source_component: 1,
+      message_id: message_id,
+      payload: payload,
+      crc_extra: crc_extra
+    })
+  end
+
+  defp sample_heartbeat do
+    %Common.Message.Heartbeat{
+      type: :mav_type_gcs,
+      autopilot: :mav_autopilot_invalid,
+      base_mode: MapSet.new(),
+      custom_mode: 0,
+      system_status: :mav_state_active,
+      mavlink_version: 3
+    }
+  end
+end

--- a/test/mavlink_parser_test.exs
+++ b/test/mavlink_parser_test.exs
@@ -389,6 +389,19 @@ defmodule XMAVLink.Test.Parser do
                    }
                  ],
                  name: :mav_autopilot
+               },
+               %{
+                 bitmask: false,
+                 description: "MAVLINK component type reported in HEARTBEAT message.",
+                 entries: [
+                   %{
+                     description: "Generic micro air vehicle.",
+                     name: :mav_type_generic,
+                     params: [],
+                     value: 0
+                   }
+                 ],
+                 name: :mav_type
                }
              ],
              messages: [
@@ -686,6 +699,70 @@ defmodule XMAVLink.Test.Parser do
     )
   end
 
+  test "out-of-range message ids are rejected" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <messages>
+            <message id="16777216" name="TOO_HIGH">
+              <field type="uint8_t" name="value">Value</field>
+            </message>
+          </messages>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ "Invalid message id 16777216"
+        assert message =~ "TOO_HIGH"
+        assert message =~ "0..16777215"
+      end
+    )
+  end
+
+  test "fields referencing unknown enums are rejected after includes are merged" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>included.xml</include>
+          <version>3</version>
+          <dialect>0</dialect>
+          <messages>
+            <message id="1" name="TEST_MESSAGE">
+              <field type="uint8_t" name="known" enum="INCLUDED_ENUM">Known enum</field>
+              <field type="uint8_t" name="missing" enum="MISSING_ENUM">Missing enum</field>
+            </message>
+          </messages>
+        </mavlink>
+        """,
+        "included.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <enums>
+            <enum name="INCLUDED_ENUM">
+              <entry value="0" name="INCLUDED_ZERO" />
+            </enum>
+          </enums>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ ~s(Unknown enum "missing_enum")
+        assert message =~ "field missing"
+        assert message =~ "TEST_MESSAGE"
+      end
+    )
+  end
+
   test "duplicate enum entries are rejected" do
     with_xml(
       %{
@@ -706,6 +783,31 @@ defmodule XMAVLink.Test.Parser do
       fn dir ->
         assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
         assert message =~ "Duplicate enum entry :test_entry"
+        assert message =~ ":test_enum"
+      end
+    )
+  end
+
+  test "negative enum values are rejected" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <enums>
+            <enum name="TEST_ENUM">
+              <entry value="-1" name="TEST_NEGATIVE" />
+            </enum>
+          </enums>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert {:error, message} = parse_mavlink_xml(Path.join(dir, "root.xml"))
+        assert message =~ "Invalid enum value -1"
+        assert message =~ ":test_negative"
         assert message =~ ":test_enum"
       end
     )
@@ -780,22 +882,6 @@ defmodule XMAVLink.Test.Parser do
         ~s(Reserved message name "CLASS" in message id 1)
       },
       {
-        "reserved field name",
-        """
-        <?xml version="1.0"?>
-        <mavlink>
-          <version>3</version>
-          <dialect>0</dialect>
-          <messages>
-            <message id="1" name="TEST_MESSAGE">
-              <field type="uint8_t" name="case">Value</field>
-            </message>
-          </messages>
-        </mavlink>
-        """,
-        ~s(Reserved field name "case" in message TEST_MESSAGE)
-      },
-      {
         "reserved enum name",
         """
         <?xml version="1.0"?>
@@ -835,6 +921,29 @@ defmodule XMAVLink.Test.Parser do
         assert message =~ expected_message
       end)
     end
+  end
+
+  test "reserved field names are accepted as struct keys" do
+    with_xml(
+      %{
+        "root.xml" => """
+        <?xml version="1.0"?>
+        <mavlink>
+          <version>3</version>
+          <dialect>0</dialect>
+          <messages>
+            <message id="1" name="TEST_MESSAGE">
+              <field type="uint16_t" name="end">End index</field>
+            </message>
+          </messages>
+        </mavlink>
+        """
+      },
+      fn dir ->
+        assert %{messages: [%{fields: [%{name: "end"}]}]} =
+                 parse_mavlink_xml(Path.join(dir, "root.xml"))
+      end
+    )
   end
 
   test "invalid field display values are rejected before atom creation" do

--- a/test/mavlink_router_test.exs
+++ b/test/mavlink_router_test.exs
@@ -1,8 +1,12 @@
 defmodule XMAVLink.Test.Router do
   use ExUnit.Case
 
+  alias XMAVLink.ConnectionSpec
   alias XMAVLink.Frame
   alias XMAVLink.Router
+  alias XMAVLink.TCPOutConnection
+  alias XMAVLink.UDPInConnection
+  alias XMAVLink.UDPOutConnection
 
   @secret_key :binary.copy(<<42>>, 32)
   @link_id 9
@@ -84,6 +88,30 @@ defmodule XMAVLink.Test.Router do
       assert_receive :tcp_peer_accepted, 1_000
 
       GenServer.stop(pid)
+    end
+
+    test "parses bracketed IPv6 network connection strings" do
+      assert %{
+               transport: UDPOutConnection,
+               tokens: ["udpout", {0, 0, 0, 0, 0, 0, 0, 1}, 14_550]
+             } = ConnectionSpec.parse("udpout:[::1]:14550")
+
+      assert %{
+               transport: UDPInConnection,
+               tokens: ["udpin", {0, 0, 0, 0, 0, 0, 0, 0}, 14_550]
+             } = ConnectionSpec.parse("udpin:[::]:14550")
+    end
+
+    test "parses URI-style network connection strings" do
+      assert %{
+               transport: UDPOutConnection,
+               tokens: ["udpout", {127, 0, 0, 1}, 14_550]
+             } = ConnectionSpec.parse("udpout://127.0.0.1:14550")
+
+      assert %{
+               transport: TCPOutConnection,
+               tokens: ["tcpout", {0, 0, 0, 0, 0, 0, 0, 1}, 5_760]
+             } = ConnectionSpec.parse("tcpout://[::1]:5760")
     end
 
     test "rejects invalid hostname" do
@@ -174,6 +202,21 @@ defmodule XMAVLink.Test.Router do
             dialect: APM.Dialect,
             connection_strings: [],
             remote_forwarding: :nope
+          },
+          []
+        )
+      end
+    end
+
+    test "rejects invalid unknown-message forwarding config" do
+      assert_raise ArgumentError, ~r/forward_unknown/, fn ->
+        Router.start_link(
+          %{
+            system: 1,
+            component: 1,
+            dialect: APM.Dialect,
+            connection_strings: [],
+            forward_unknown: :somewhere
           },
           []
         )
@@ -641,6 +684,99 @@ defmodule XMAVLink.Test.Router do
       refute_receive {:udp, ^target_peer_socket, _, _, _}, 50
 
       Router.unsubscribe(router_pid)
+    end
+  end
+
+  describe "unknown message forwarding policy" do
+    test "local_only delivers unknown frames locally without forwarding to remote links" do
+      {:ok, router_socket} = :gen_udp.open(0, [:binary, active: false])
+      {:ok, target_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, target_peer_port} = :inet.port(target_peer_socket)
+      address = {127, 0, 0, 1}
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            forward_unknown: :local_only
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(router_socket)
+        :gen_udp.close(target_peer_socket)
+        stop_router(router_pid)
+      end)
+
+      assert :ok = Router.subscribe(router_pid, message: :unknown, as_frame: true)
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, target_peer_port,
+         unsigned_heartbeat_frame(5, 1).mavlink_2_raw}
+      )
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, 14_551, unknown_frame(6, 1).mavlink_2_raw}
+      )
+
+      assert_receive %Frame{
+                       message_id: 999_999,
+                       source_system: 6,
+                       source_component: 1,
+                       message: %{__struct__: XMAVLink.UnknownMessage}
+                     },
+                     200
+
+      refute_receive {:udp, ^target_peer_socket, _, _, _}, 50
+    end
+
+    test "drop suppresses unknown frames locally and remotely" do
+      {:ok, router_socket} = :gen_udp.open(0, [:binary, active: false])
+      {:ok, target_peer_socket} = :gen_udp.open(0, [:binary, active: true])
+      {:ok, target_peer_port} = :inet.port(target_peer_socket)
+      address = {127, 0, 0, 1}
+
+      {:ok, router_pid} =
+        Router.start_link(
+          %{
+            name: nil,
+            system: 1,
+            component: 1,
+            dialect: Common,
+            connection_strings: [],
+            forward_unknown: :drop
+          },
+          []
+        )
+
+      on_exit(fn ->
+        :gen_udp.close(router_socket)
+        :gen_udp.close(target_peer_socket)
+        stop_router(router_pid)
+      end)
+
+      assert :ok = Router.subscribe(router_pid, message: :unknown, as_frame: true)
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, target_peer_port,
+         unsigned_heartbeat_frame(5, 1).mavlink_2_raw}
+      )
+
+      send(
+        router_pid,
+        {:udp, router_socket, address, 14_551, unknown_frame(6, 1).mavlink_2_raw}
+      )
+
+      refute_receive %Frame{message: %{__struct__: XMAVLink.UnknownMessage}}, 50
+      refute_receive {:udp, ^target_peer_socket, _, _, _}, 50
     end
   end
 
@@ -1678,6 +1814,18 @@ defmodule XMAVLink.Test.Router do
       message_id: message_id,
       payload: payload,
       crc_extra: crc_extra
+    })
+  end
+
+  defp unknown_frame(source_system, source_component) do
+    Frame.pack_frame(%Frame{
+      version: 2,
+      sequence_number: 7,
+      source_system: source_system,
+      source_component: source_component,
+      message_id: 999_999,
+      payload: <<1, 2, 3>>,
+      crc_extra: 0
     })
   end
 

--- a/test/mavlink_signing_test.exs
+++ b/test/mavlink_signing_test.exs
@@ -27,6 +27,7 @@ defmodule XMAVLink.Test.Signing do
                 timestamp_load: nil,
                 timestamp_save: nil,
                 accept_unsigned: true,
+                accept_mavlink1: true,
                 stream_timestamps: %{}
               }} =
                Signing.new(
@@ -91,6 +92,13 @@ defmodule XMAVLink.Test.Signing do
                  secret_key: @secret_key,
                  link_id: @link_id,
                  accept_unsigned: :sometimes
+               )
+
+      assert {:error, :invalid_accept_mavlink1} =
+               Signing.new(
+                 secret_key: @secret_key,
+                 link_id: @link_id,
+                 accept_mavlink1: :sometimes
                )
 
       assert {:error, :invalid_timestamp_load} =
@@ -231,6 +239,24 @@ defmodule XMAVLink.Test.Signing do
       assert {:ok, ^frame, ^signing} = Signing.validate_inbound(frame, signing)
     end
 
+    test "rejects MAVLink 1 frames when signing policy disables MAVLink 1 acceptance" do
+      frame =
+        Frame.pack_frame(%Frame{
+          version: 1,
+          sequence_number: 7,
+          source_system: 1,
+          source_component: 1,
+          message_id: 24,
+          payload: <<1, 2, 3>>,
+          crc_extra: 0
+        })
+
+      signing = signing(accept_mavlink1: false)
+
+      assert {:error, :mavlink_1_rejected, ^signing} =
+               Signing.validate_inbound(frame, signing)
+    end
+
     test "disabled policy keeps unsigned frames accepted and signed frames unsupported" do
       unsigned_frame = unsigned_frame()
       signed_frame = signed_frame(@valid_timestamp)
@@ -288,6 +314,24 @@ defmodule XMAVLink.Test.Signing do
       signing = signing()
 
       assert {:ok, ^mavlink_1_frame, ^signing} = Signing.sign_outbound(mavlink_1_frame, signing)
+    end
+
+    test "rejects outbound MAVLink 1 frames when signing policy disables MAVLink 1 acceptance" do
+      mavlink_1_frame =
+        Frame.pack_frame(%Frame{
+          version: 1,
+          sequence_number: 7,
+          source_system: 1,
+          source_component: 1,
+          message_id: 24,
+          payload: <<1, 2, 3>>,
+          crc_extra: 0
+        })
+
+      signing = signing(accept_mavlink1: false)
+
+      assert {:error, :mavlink_1_rejected, ^signing} =
+               Signing.sign_outbound(mavlink_1_frame, signing)
     end
 
     test "leaves already signed frames unchanged and catches up local timestamp" do


### PR DESCRIPTION
## Summary

- Harden MAVLink XML parsing with earlier validation for out-of-range message ids, invalid enum values, and unknown field enum references after includes are merged.
- Add opt-in runtime policy controls for signed-only MAVLink 1 rejection and unknown-message forwarding behavior.
- Preserve existing defaults for mixed-link compatibility while documenting stricter deployment options.
- Add IPv6 and URI-style network connection strings without removing existing connection string forms.
- Refactor duplicated transport forwarding, router connection bookkeeping, and utility command helpers into internal modules.
- Update README, security/signing/spec docs, changelog, CI Hex audit, and coverage configuration.

## User Impact

This includes one documented breaking generator behavior: custom invalid MAVLink XML that previously reached generation may now fail earlier with clearer parser errors. Runtime security/routing behavior remains opt-in by default.

## Validation

- `mix test --warnings-as-errors` -> 176 passed
- `mix test --cover` -> 76.75%
- `MIX_ENV=dev mix docs`
- `mix hex.audit`
- `mix xref graph --label compile-connected --fail-above 0`
- `mix format --check-formatted`
- `mix deps.unlock --check-unused`
- `MIX_ENV=dev mix compile --warnings-as-errors`
- `mix xmavlink config/common.xml /private/tmp/xmavlink_common_generated.ex CommonGenerated`