### PR TITLE
[codex] prepare 0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.15.0 - 2026-06-25
+
 ### Breaking Changes
 
 - Hardened MAVLink XML generation by rejecting out-of-range message ids,
@@ -34,7 +36,7 @@
   the existing generated struct-key behavior for fields such as `end`.
 - Updated coverage configuration to ignore generated Common dialect modules
   and use a realistic baseline threshold for hand-written code.
-- Updated installation documentation for the current 0.14.3 release line.
+- Updated installation documentation for the current 0.15.0 release line.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `xmavlink` to your list of dependencies in `mix.exs`:
   ```elixir
  def deps do
    [
-     {:xmavlink, "~> 0.14.3"}
+     {:xmavlink, "~> 0.15.0"}
    ]
  end
  ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XMAVLink.Mixfile do
   def project do
     [
       app: :xmavlink,
-      version: "0.14.3",
+      version: "0.15.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
## Summary

- Bump package version from `0.14.3` to `0.15.0`.
- Move the accumulated unreleased notes into `## 0.15.0 - 2026-06-25`.
- Update the README install snippet to `~> 0.15.0`.

## Why

PR #86 introduced a documented breaking generator behavior for stricter MAVLink XML validation, so the release should be a minor `0.x` bump rather than a patch release.

## Validation

- `mix format --check-formatted`
- `MIX_ENV=dev mix compile --warnings-as-errors`
- `mix test --warnings-as-errors` -> 176 passed
- `MIX_ENV=dev mix docs`